### PR TITLE
Fix clone timestamp key in example manifest

### DIFF
--- a/manifests/complete-postgres-manifest.yaml
+++ b/manifests/complete-postgres-manifest.yaml
@@ -49,7 +49,7 @@ spec:
   # with an empty/absent timestamp, clone from an existing alive cluster using pg_basebackup
   # clone:
   #  cluster: "acid-batman"
-  #  endTimestamp: "2017-12-19T12:40:33+01:00" # timezone required (offset relative to UTC, see RFC 3339 section 5.6)
+  #  timestamp: "2017-12-19T12:40:33+01:00" # timezone required (offset relative to UTC, see RFC 3339 section 5.6)
   maintenanceWindows:
   - 01:00-06:00 #UTC
   - Sat:00:00-04:00


### PR DESCRIPTION
It was set to `endTimestamp`, but it should be `timestamp`.