### PR TITLE
Make sure we never modify informer cached manifest.

### DIFF
--- a/pkg/controller/postgresql_test.go
+++ b/pkg/controller/postgresql_test.go
@@ -23,14 +23,14 @@ func TestMergeDeprecatedPostgreSQLSpecParameters(t *testing.T) {
 		{
 			"Check that old parameters propagate values to the new ones",
 			&spec.PostgresSpec{UseLoadBalancer: &True, ReplicaLoadBalancer: &True},
-			&spec.PostgresSpec{UseLoadBalancer: &True, ReplicaLoadBalancer: &True,
+			&spec.PostgresSpec{UseLoadBalancer: nil, ReplicaLoadBalancer: nil,
 				EnableMasterLoadBalancer: &True, EnableReplicaLoadBalancer: &True},
 			"New parameters should be set from the values of old ones",
 		},
 		{
 			"Check that new parameters are not set when both old and new ones are present",
-			&spec.PostgresSpec{UseLoadBalancer: &True, EnableReplicaLoadBalancer: &True},
-			&spec.PostgresSpec{UseLoadBalancer: &True, EnableReplicaLoadBalancer: &True},
+			&spec.PostgresSpec{UseLoadBalancer: &True, EnableMasterLoadBalancer: &False},
+			&spec.PostgresSpec{UseLoadBalancer: nil, EnableMasterLoadBalancer: &False},
 			"New parameters should remain unchanged when both old and new are present",
 		},
 	}


### PR DESCRIPTION
987b434 introduced a new function that modifies the cluster spec in
memory before the cluster processes it. Unfortunately, the instance
being modified appeared to be the one stored internally in the
PostgresInformer, resulting in those modifications to be propagated with
futher cluster events and producing update loops in some occasions.

This commit makes sure we copy the spec before putting it into the
clusterEventQueues.