### PR TITLE
Move CRD definitions into a formal API to allow access from other controllers

### DIFF
--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1,0 +1,54 @@
+package v1
+
+import (
+	"github.com/zalando-incubator/postgres-operator/pkg/apis/acid.zalan.do"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	PostgresCRDResourceKind   = "postgresql"
+	PostgresCRDResourcePlural = "postgresqls"
+	PostgresCRDResouceName    = PostgresCRDResourcePlural + "." + acidzalando.GroupName
+	PostgresCRDResourceShort  = "pg"
+
+	OperatorConfigCRDResouceKind    = "OperatorConfiguration"
+	OperatorConfigCRDResourcePlural = "operatorconfigurations"
+	OperatorConfigCRDResourceName   = OperatorConfigCRDResourcePlural + "." + acidzalando.GroupName
+	OperatorConfigCRDResourceShort  = "opconfig"
+)
+
+func buildCRD(name, kind, plural, short string) *apiextv1beta1.CustomResourceDefinition {
+	return &apiextv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: apiextv1beta1.CustomResourceDefinitionSpec{
+			Group:   SchemeGroupVersion.Group,
+			Version: SchemeGroupVersion.Version,
+			Names: apiextv1beta1.CustomResourceDefinitionNames{
+				Plural:     plural,
+				ShortNames: []string{short},
+				Kind:       kind,
+			},
+			Scope: apiextv1beta1.NamespaceScoped,
+			Subresources: &apiextv1beta1.CustomResourceSubresources{
+				Status: &apiextv1beta1.CustomResourceSubresourceStatus{},
+			},
+		},
+	}
+}
+
+func PostgresCRD() *apiextv1beta1.CustomResourceDefinition {
+	return buildCRD(PostgresCRDResouceName,
+		PostgresCRDResourceKind,
+		PostgresCRDResourcePlural,
+		PostgresCRDResourceShort)
+}
+
+func ConfigurationCRD() *apiextv1beta1.CustomResourceDefinition {
+	return buildCRD(OperatorConfigCRDResourceName,
+		OperatorConfigCRDResouceKind,
+		OperatorConfigCRDResourcePlural,
+		OperatorConfigCRDResourceShort)
+}

--- a/pkg/apis/acid.zalan.do/v1/register.go
+++ b/pkg/apis/acid.zalan.do/v1/register.go
@@ -9,16 +9,6 @@ import (
 )
 
 const (
-	PostgresCRDResourceKind   = "postgresql"
-	PostgresCRDResourcePlural = "postgresqls"
-	PostgresCRDResouceName    = PostgresCRDResourcePlural + "." + acidzalando.GroupName
-	PostgresCRDResourceShort  = "pg"
-
-	OperatorConfigCRDResouceKind    = "OperatorConfiguration"
-	OperatorConfigCRDResourcePlural = "operatorconfigurations"
-	OperatorConfigCRDResourceName   = OperatorConfigCRDResourcePlural + "." + acidzalando.GroupName
-	OperatorConfigCRDResourceShort  = "opconfig"
-
 	APIVersion = "v1"
 )
 

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -47,27 +47,7 @@ func (c *Controller) clusterWorkerID(clusterName spec.NamespacedName) uint32 {
 	return c.clusterWorkers[clusterName]
 }
 
-func (c *Controller) createOperatorCRD(name, kind, plural, short string) error {
-	subResourceStatus := apiextv1beta1.CustomResourceSubresourceStatus{}
-	crd := &apiextv1beta1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: apiextv1beta1.CustomResourceDefinitionSpec{
-			Group:   acidv1.SchemeGroupVersion.Group,
-			Version: acidv1.SchemeGroupVersion.Version,
-			Names: apiextv1beta1.CustomResourceDefinitionNames{
-				Plural:     plural,
-				ShortNames: []string{short},
-				Kind:       kind,
-			},
-			Scope: apiextv1beta1.NamespaceScoped,
-			Subresources: &apiextv1beta1.CustomResourceSubresources{
-				Status: &subResourceStatus,
-			},
-		},
-	}
-
+func (c *Controller) createOperatorCRD(crd *apiextv1beta1.CustomResourceDefinition) error {
 	if _, err := c.KubeClient.CustomResourceDefinitions().Create(crd); err != nil {
 		if !k8sutil.ResourceAlreadyExists(err) {
 			return fmt.Errorf("could not create customResourceDefinition: %v", err)
@@ -101,17 +81,11 @@ func (c *Controller) createOperatorCRD(name, kind, plural, short string) error {
 }
 
 func (c *Controller) createPostgresCRD() error {
-	return c.createOperatorCRD(acidv1.PostgresCRDResouceName,
-		acidv1.PostgresCRDResourceKind,
-		acidv1.PostgresCRDResourcePlural,
-		acidv1.PostgresCRDResourceShort)
+	return c.createOperatorCRD(acidv1.PostgresCRD())
 }
 
 func (c *Controller) createConfigurationCRD() error {
-	return c.createOperatorCRD(acidv1.OperatorConfigCRDResourceName,
-		acidv1.OperatorConfigCRDResouceKind,
-		acidv1.OperatorConfigCRDResourcePlural,
-		acidv1.OperatorConfigCRDResourceShort)
+	return c.createOperatorCRD(acidv1.ConfigurationCRD())
 }
 
 func readDecodedRole(s string) (*spec.PgUser, error) {


### PR DESCRIPTION
This helps when building other operators on top of this, so I can do stuff like:

```go
t := &envtest.Environment{
    // ...
    CRDs: []*apiextv1beta1.CustomResourceDefinition{postgresv1.PostgresCRD()},
}
```

when testing my own operator code.