### PR TITLE
Support subPath in generated container

### DIFF
--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -269,6 +269,9 @@ properties of the persistent storage that stores postgres data.
   documentation](https://kubernetes.io/docs/concepts/storage/storage-classes/)
   for the details on storage classes. Optional.
 
+* **subPath**
+  Subpath to use when mounting volume into Spilo container
+
 ### Sidecar definitions
 
 Those parameters are defined under the `sidecars` key. They consist of a list

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -82,6 +82,7 @@ type MaintenanceWindow struct {
 type Volume struct {
 	Size         string `json:"size"`
 	StorageClass string `json:"storageClass"`
+	SubPath      string `json:"subPath,omitempty"`
 }
 
 // PostgresqlParam describes PostgreSQL version and pairs of configuration parameter name - values.

--- a/pkg/apis/acid.zalan.do/v1/util_test.go
+++ b/pkg/apis/acid.zalan.do/v1/util_test.go
@@ -181,7 +181,8 @@ var unmarshalCluster = []struct {
 	    "teamId": "ACID",
 	    "volume": {
 	      "size": "5Gi",
-	      "storageClass": "SSD"
+	      "storageClass": "SSD",
+	      "subPath": "subdir"
 	    },
 	    "numberOfInstances": 2,
 	    "users": {
@@ -263,6 +264,7 @@ var unmarshalCluster = []struct {
 				Volume: Volume{
 					Size:         "5Gi",
 					StorageClass: "SSD",
+					SubPath:      "subdir",
 				},
 				Patroni: Patroni{
 					InitDB: map[string]string{
@@ -311,7 +313,7 @@ var unmarshalCluster = []struct {
 			},
 			Error: "",
 		},
-		marshal: []byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"9.6","parameters":{"log_statement":"all","max_connections":"10","shared_buffers":"32MB"}},"volume":{"size":"5Gi","storageClass":"SSD"},"patroni":{"initdb":{"data-checksums":"true","encoding":"UTF8","locale":"en_US.UTF-8"},"pg_hba":["hostssl all all 0.0.0.0/0 md5","host    all all 0.0.0.0/0 md5"],"ttl":30,"loop_wait":10,"retry_timeout":10,"maximum_lag_on_failover":33554432,"slots":{"permanent_logical_1":{"database":"foo","plugin":"pgoutput","type":"logical"}}},"resources":{"requests":{"cpu":"10m","memory":"50Mi"},"limits":{"cpu":"300m","memory":"3000Mi"}},"teamId":"ACID","allowedSourceRanges":["127.0.0.1/32"],"numberOfInstances":2,"users":{"zalando":["superuser","createdb"]},"maintenanceWindows":["Mon:01:00-06:00","Sat:00:00-04:00","05:00-05:15"],"clone":{"cluster":"acid-batman"}},"status":{"PostgresClusterStatus":""}}`),
+		marshal: []byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"9.6","parameters":{"log_statement":"all","max_connections":"10","shared_buffers":"32MB"}},"volume":{"size":"5Gi","storageClass":"SSD", "subPath": "subdir"},"patroni":{"initdb":{"data-checksums":"true","encoding":"UTF8","locale":"en_US.UTF-8"},"pg_hba":["hostssl all all 0.0.0.0/0 md5","host    all all 0.0.0.0/0 md5"],"ttl":30,"loop_wait":10,"retry_timeout":10,"maximum_lag_on_failover":33554432,"slots":{"permanent_logical_1":{"database":"foo","plugin":"pgoutput","type":"logical"}}},"resources":{"requests":{"cpu":"10m","memory":"50Mi"},"limits":{"cpu":"300m","memory":"3000Mi"}},"teamId":"ACID","allowedSourceRanges":["127.0.0.1/32"],"numberOfInstances":2,"users":{"zalando":["superuser","createdb"]},"maintenanceWindows":["Mon:01:00-06:00","Sat:00:00-04:00","05:00-05:15"],"clone":{"cluster":"acid-batman"}},"status":{"PostgresClusterStatus":""}}`),
 		err:     nil},
 	// example with teamId set in input
 	{

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -342,11 +342,12 @@ func isBootstrapOnlyParameter(param string) bool {
 		param == "track_commit_timestamp"
 }
 
-func generateVolumeMounts() []v1.VolumeMount {
+func generateVolumeMounts(volume acidv1.Volume) []v1.VolumeMount {
 	return []v1.VolumeMount{
 		{
 			Name:      constants.DataVolumeName,
 			MountPath: constants.PostgresDataMount, //TODO: fetch from manifest
+			SubPath:   volume.SubPath,
 		},
 	}
 }
@@ -797,7 +798,7 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*v1beta1.State
 	// pickup the docker image for the spilo container
 	effectiveDockerImage := util.Coalesce(spec.DockerImage, c.OpConfig.DockerImage)
 
-	volumeMounts := generateVolumeMounts()
+	volumeMounts := generateVolumeMounts(spec.Volume)
 
 	// generate the spilo container
 	c.logger.Debugf("Generating Spilo container, environment variables: %v", spiloEnvVars)


### PR DESCRIPTION
This is something which is useful together https://github.com/zalando-incubator/postgres-operator/pull/445 or sidecars when they get support of arbitrary volume mounts.

These containers might want to use volume for their own need, but it should not interfere with Spilo/Patroni container, so safest way is to use subPath in Patroni container.

This change is completely transparent for Patroni, paths in container remain the same and nothing changes from it's point of view.