### PR TITLE
Set statefulset update and management policy explicitly

### DIFF
--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -226,6 +226,11 @@ configuration they are grouped under the `kubernetes` key.
   [topology key](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#interlude-built-in-node-labels)
   for pod anti affinity. The default is `kubernetes.io/hostname`.
 
+* **pod_management_policy**
+  specify the
+  [pod management policy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies)
+  of stateful sets of PG clusters. The default is `ordered_ready`, the second possible value is `parallel`.
+
 ## Kubernetes resource requests
 
 This group allows you to configure resource requests for the Postgres pods.

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -44,6 +44,7 @@ data:
   pod_terminate_grace_period: 5m
   pod_deletion_wait_timeout: 10m
   pod_label_wait_timeout: 10m
+  pod_management_policy: "ordered_ready"
   ready_wait_interval: 3s
   ready_wait_timeout: 30s
   #  master_pod_move_timeout: 10m

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -858,6 +858,11 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*v1beta1.State
 
 	numberOfInstances := c.getNumberOfInstances(spec)
 
+	// the operator has domain-specific logic on how to do rolling updates of PG clusters
+	// so we do not use default rolling updates implemented by stateful sets
+	// that leaves "OnDelete" update strategy as the only option
+	updateStrategy := v1beta1.StatefulSetUpdateStrategy{Type: v1beta1.OnDeleteStatefulSetStrategyType}
+
 	statefulSet := &v1beta1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        c.statefulSetName(),
@@ -871,6 +876,7 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*v1beta1.State
 			ServiceName:          c.serviceName(Master),
 			Template:             *podTemplate,
 			VolumeClaimTemplates: []v1.PersistentVolumeClaim{*volumeClaimTemplate},
+			UpdateStrategy:       updateStrategy,
 		},
 	}
 

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -860,8 +860,17 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*v1beta1.State
 
 	// the operator has domain-specific logic on how to do rolling updates of PG clusters
 	// so we do not use default rolling updates implemented by stateful sets
-	// that leaves "OnDelete" update strategy as the only option
+	// that leaves the legacy "OnDelete" update strategy as the only option
 	updateStrategy := v1beta1.StatefulSetUpdateStrategy{Type: v1beta1.OnDeleteStatefulSetStrategyType}
+
+	var podManagementPolicy v1beta1.PodManagementPolicyType
+	if c.OpConfig.PodManagementPolicy == "ordered_ready" {
+		podManagementPolicy = v1beta1.OrderedReadyPodManagement
+	} else if c.OpConfig.PodManagementPolicy == "parallel" {
+		podManagementPolicy = v1beta1.ParallelPodManagement
+	} else {
+		return nil, fmt.Errorf("could not set the pod management policy to the unknown value: %v", c.OpConfig.PodManagementPolicy)
+	}
 
 	statefulSet := &v1beta1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -877,6 +886,7 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*v1beta1.State
 			Template:             *podTemplate,
 			VolumeClaimTemplates: []v1.PersistentVolumeClaim{*volumeClaimTemplate},
 			UpdateStrategy:       updateStrategy,
+			PodManagementPolicy:  podManagementPolicy,
 		},
 	}
 

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -184,7 +184,7 @@ func (c *Controller) moveMasterPodsOffNode(node *v1.Node) {
 	)
 
 	if err != nil {
-		c.logger.Warning("failed to move master pods from the node %q: timeout of %v minutes expired", node.Name, c.opConfig.MasterPodMoveTimeout)
+		c.logger.Warningf("failed to move master pods from the node %q: timeout of %v minutes expired", node.Name, c.opConfig.MasterPodMoveTimeout)
 	}
 
 }

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -109,6 +109,7 @@ type Config struct {
 	ClusterHistoryEntries    int               `name:"cluster_history_entries" default:"1000"`
 	TeamAPIRoleConfiguration map[string]string `name:"team_api_role_configuration" default:"log_statement:all"`
 	PodTerminateGracePeriod  time.Duration     `name:"pod_terminate_grace_period" default:"5m"`
+	PodManagementPolicy      string            `name:"pod_management_policy" default:"ordered_ready"`
 	ProtectedRoles           []string          `name:"protected_role_names" default:"admin"`
 	PostgresSuperuserTeams   []string          `name:"postgres_superuser_teams" default:""`
 	SetMemoryRequestToLimit  bool              `name:"set_memory_request_to_limit" defaults:"false"`


### PR DESCRIPTION
1. implement #514 We use `ordered_ready` as the  default policy because it was used before and actually comes form the default Kubernetes stateful sets options' 
2. fix an error in logging master pod migration attempts  