### PR TITLE
set default name also for RoleBinding and roleRef

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -230,6 +230,8 @@ func (c *Controller) initRoleBinding() {
 	default:
 		c.PodServiceAccountRoleBinding = obj.(*rbacv1beta1.RoleBinding)
 		c.PodServiceAccountRoleBinding.Namespace = ""
+		c.PodServiceAccountRoleBinding.ObjectMeta.Name = c.PodServiceAccount.Name
+		c.PodServiceAccountRoleBinding.RoleRef.Name = c.PodServiceAccount.Name
 		c.PodServiceAccountRoleBinding.Subjects[0].Name = c.PodServiceAccount.Name
 		c.logger.Info("successfully parsed")
 


### PR DESCRIPTION
Fixes issue #528.

I wonder if the name could already be set in the init JSON literal.