### PR TITLE
change name of current status field of CRD

### DIFF
--- a/pkg/apis/acid.zalan.do/v1/marshal.go
+++ b/pkg/apis/acid.zalan.do/v1/marshal.go
@@ -81,7 +81,7 @@ func (p *Postgresql) UnmarshalJSON(data []byte) error {
 		}
 
 		tmp.Error = err.Error()
-		tmp.Status = ClusterStatusInvalid
+		tmp.PostgresClusterStatus = ClusterStatusInvalid
 
 		*p = Postgresql(tmp)
 
@@ -91,10 +91,10 @@ func (p *Postgresql) UnmarshalJSON(data []byte) error {
 
 	if clusterName, err := extractClusterName(tmp2.ObjectMeta.Name, tmp2.Spec.TeamID); err != nil {
 		tmp2.Error = err.Error()
-		tmp2.Status = ClusterStatusInvalid
+		tmp2.PostgresClusterStatus = ClusterStatusInvalid
 	} else if err := validateCloneClusterDescription(&tmp2.Spec.Clone); err != nil {
 		tmp2.Error = err.Error()
-		tmp2.Status = ClusterStatusInvalid
+		tmp2.PostgresClusterStatus = ClusterStatusInvalid
 	} else {
 		tmp2.Spec.ClusterName = clusterName
 	}

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -15,9 +15,9 @@ type Postgresql struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   PostgresSpec   `json:"spec"`
-	Status PostgresStatus `json:"status,omitempty"`
-	Error  string         `json:"-"`
+	Spec                  PostgresSpec   `json:"spec"`
+	PostgresClusterStatus PostgresStatus `json:"status,omitempty"`
+	Error                 string         `json:"-"`
 }
 
 // PostgresSpec defines the specification for the PostgreSQL TPR.

--- a/pkg/apis/acid.zalan.do/v1/util.go
+++ b/pkg/apis/acid.zalan.do/v1/util.go
@@ -85,12 +85,12 @@ func validateCloneClusterDescription(clone *CloneDescription) error {
 }
 
 // Success of the current Status
-func (status PostgresStatus) Success() bool {
-	return status != ClusterStatusAddFailed &&
-		status != ClusterStatusUpdateFailed &&
-		status != ClusterStatusSyncFailed
+func (postgresClusterStatus PostgresStatus) Success() bool {
+	return postgresClusterStatus != ClusterStatusAddFailed &&
+		postgresClusterStatus != ClusterStatusUpdateFailed &&
+		postgresClusterStatus != ClusterStatusSyncFailed
 }
 
-func (status PostgresStatus) String() string {
-	return string(status)
+func (postgresClusterStatus PostgresStatus) String() string {
+	return string(postgresClusterStatus)
 }

--- a/pkg/apis/acid.zalan.do/v1/util_test.go
+++ b/pkg/apis/acid.zalan.do/v1/util_test.go
@@ -128,7 +128,7 @@ var unmarshalCluster = []struct {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "acid-testcluster1",
 		},
-		Status: ClusterStatusInvalid,
+		PostgresClusterStatus: ClusterStatusInvalid,
 		// This error message can vary between Go versions, so compute it for the current version.
 		Error: json.Unmarshal([]byte(`{"teamId": 0}`), &PostgresSpec{}).Error(),
 	},
@@ -284,9 +284,9 @@ var unmarshalCluster = []struct {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "teapot-testcluster1",
 			},
-			Spec:   PostgresSpec{TeamID: "acid"},
-			Status: ClusterStatusInvalid,
-			Error:  errors.New("name must match {TEAM}-{NAME} format").Error(),
+			Spec:                  PostgresSpec{TeamID: "acid"},
+			PostgresClusterStatus: ClusterStatusInvalid,
+			Error:                 errors.New("name must match {TEAM}-{NAME} format").Error(),
 		},
 		[]byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"teapot-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0,"slots":null},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null,"clone":{}},"status":"Invalid"}`), nil},
 	{
@@ -350,8 +350,8 @@ var postgresqlList = []struct {
 					AllowedSourceRanges: []string{"185.85.220.0/22"},
 					NumberOfInstances:   1,
 				},
-				Status: ClusterStatusRunning,
-				Error:  "",
+				PostgresClusterStatus: ClusterStatusRunning,
+				Error:                 "",
 			}},
 		},
 		nil},

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -27,9 +27,9 @@ func (c *Cluster) Sync(newSpec *acidv1.Postgresql) error {
 	defer func() {
 		if err != nil {
 			c.logger.Warningf("error while syncing cluster state: %v", err)
-			c.setStatus(acidv1.ClusterStatusSyncFailed)
-		} else if c.Status != acidv1.ClusterStatusRunning {
-			c.setStatus(acidv1.ClusterStatusRunning)
+			c.setPostgresClusterStatus(acidv1.ClusterStatusSyncFailed)
+		} else if c.PostgresClusterStatus != acidv1.ClusterStatusRunning {
+			c.setPostgresClusterStatus(acidv1.ClusterStatusRunning)
 		}
 	}()
 

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -63,9 +63,9 @@ type ClusterStatus struct {
 	StatefulSet         *v1beta1.StatefulSet
 	PodDisruptionBudget *policybeta1.PodDisruptionBudget
 
-	CurrentProcess Process
-	Worker         uint32
-	Status         acidv1.PostgresStatus
-	Spec           acidv1.PostgresSpec
-	Error          error
+	CurrentProcess        Process
+	Worker                uint32
+	PostgresClusterStatus acidv1.PostgresStatus
+	Spec                  acidv1.PostgresSpec
+	Error                 error
 }

--- a/pkg/controller/logs_and_api.go
+++ b/pkg/controller/logs_and_api.go
@@ -29,7 +29,7 @@ func (c *Controller) ClusterStatus(team, namespace, cluster string) (*cluster.Cl
 		return nil, fmt.Errorf("could not find cluster")
 	}
 
-	status := cl.GetStatus()
+	status := cl.GetPostgresClusterStatus()
 	status.Worker = c.clusterWorkerID(clusterName)
 
 	return status, nil

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -89,7 +89,7 @@ func (c *Controller) queueEvents(list *acidv1.PostgresqlList, event EventType) {
 		activeClustersCnt++
 		// check if that cluster needs repair
 		if event == EventRepair {
-			if pg.Status.Success() {
+			if pg.PostgresClusterStatus.Success() {
 				continue
 			} else {
 				clustersToRepair++


### PR DESCRIPTION
There's a plan to implement the `status` subresource for the Postgres CRD somewhen in the future #408.
It's up to decide what to do with the current status behavior, as it used for syncing. When keeping both, the name of the latter has to change. This PR does that: `PostgresClusterStatus`.

One immediate benefit could be, that other K8S frameworks (e.g. OperatorHub) do not misinterpret our custom status object as a K8s subresource. See [here](https://github.com/operator-framework/community-operators/pull/210)