### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
 language: go
 
 go:
-  - "1.10.x"
+  - "1.12.x"
 
 before_install:
   - go get github.com/Masterminds/glide

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -11,7 +11,7 @@ pipeline:
             apt-get update
         - desc: 'Install required build software'
           cmd: |
-            apt-get install -y make git apt-transport-https ca-certificates curl
+            apt-get install -y make git apt-transport-https ca-certificates curl build-essential
         - desc: 'Install go'
           cmd: |
             cd /tmp

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -15,7 +15,7 @@ pipeline:
         - desc: 'Install go'
           cmd: |
             cd /tmp
-            wget -q https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz -O go.tar.gz
+            wget -q https://storage.googleapis.com/golang/go1.12.linux-amd64.tar.gz -O go.tar.gz
             tar -xf go.tar.gz
             mv go /usr/local
             ln -s /usr/local/go/bin/go /usr/bin/go


### PR DESCRIPTION
1. update the golang to version 1.12. The `staticcheck` tool we use in `make tools` [supports only 2 last versions of golang](https://github.com/dominikh/go-tools/issues/442#issuecomment-482561255), and that currently breakes the build

To update your local golang installation you [can use this script](https://gist.github.com/nikhita/432436d570b89cab172dcf2894465753#gistcomment-2767808)

2. install `gcc` (in `build-essential`) due to internal build requirements