### PR TITLE
Add binries_path_template option.

### DIFF
--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -26,6 +26,7 @@ config:
   super_username: postgres
   enable_teams_api: "false"
   spilo_privileged: "false"
+  binaries_path_template: "/usr/lib/postgresql/%s/bin"
   # set_memory_request_to_limit: "true"
   # postgres_superuser_teams: "postgres_superusers"
   # enable_team_superuser: "false"

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -175,6 +175,12 @@ explanation of `ttl` and `loop_wait` parameters.
 * **slots**
   permanent replication slots that Patroni preserves after failover by re-creating them on the new primary immediately after doing a promote. Slots could be reconfigured with the help of `patronictl edit-config`. It is the responsibility of a user to avoid clashes in names between replication slots automatically created by Patroni for cluster members and permanent replication slots. Optional.
 
+* **binaries_path_template**
+  template to use for generating the PostgreSQL binaries path. Patroni
+  uses this template in conjunction with the specified PostgreSQL
+  version to generate the bin_dir location used by patroni. The
+  default is "/usr/lib/postgresql/%s/bin".
+
 ## Postgres container resources
 
 Those parameters define [CPU and memory requests and

--- a/manifests/complete-postgres-manifest.yaml
+++ b/manifests/complete-postgres-manifest.yaml
@@ -52,6 +52,7 @@ spec:
         type: logical
         database: foo
         plugin: pgoutput
+    binaries_path_template: "/usr/lib/postgresql/%s/bin"
     ttl: 30
     loop_wait: &loop_wait 10
     retry_timeout: 10

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -16,6 +16,7 @@ data:
   super_username: postgres
   enable_teams_api: "false"
   spilo_privileged: "false"
+  binaries_path_template: "/usr/lib/postgresql/%s/bin"
   # custom_service_annotations:
   #   "keyx:valuez,keya:valuea"
   # set_memory_request_to_limit: "true"

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -24,6 +24,7 @@ configuration:
     oauth_token_secret_name: postgresql-operator
     pod_role_label: spilo-role
     spilo_privileged: false
+    binaries_path_template: "/usr/lib/postgresql/%s/bin"
     cluster_labels:
         application: spilo
     # inherited_labels:

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -46,6 +46,7 @@ type KubernetesMetaConfiguration struct {
 	PodServiceAccountRoleBindingDefinition string                `json:"pod_service_account_role_binding_definition,omitempty"`
 	PodTerminateGracePeriod                Duration              `json:"pod_terminate_grace_period,omitempty"`
 	SpiloPrivileged                        bool                  `json:"spilo_privileged,omitemty"`
+	PgBinariesLocationTemplate             string                `json:"binaries_path_template,omitempty"`
 	WatchedNamespace                       string                `json:"watched_namespace,omitempty"`
 	PDBNameFormat                          config.StringTemplate `json:"pdb_name_format,omitempty"`
 	SecretNameTemplate                     config.StringTemplate `json:"secret_name_template,omitempty"`

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -100,13 +100,14 @@ type Resources struct {
 
 // Patroni contains Patroni-specific configuration
 type Patroni struct {
-	InitDB               map[string]string            `json:"initdb"`
-	PgHba                []string                     `json:"pg_hba"`
-	TTL                  uint32                       `json:"ttl"`
-	LoopWait             uint32                       `json:"loop_wait"`
-	RetryTimeout         uint32                       `json:"retry_timeout"`
-	MaximumLagOnFailover float32                      `json:"maximum_lag_on_failover"` // float32 because https://github.com/kubernetes/kubernetes/issues/30213
-	Slots                map[string]map[string]string `json:"slots"`
+	InitDB                     map[string]string            `json:"initdb"`
+	PgHba                      []string                     `json:"pg_hba"`
+	TTL                        uint32                       `json:"ttl"`
+	LoopWait                   uint32                       `json:"loop_wait"`
+	RetryTimeout               uint32                       `json:"retry_timeout"`
+	MaximumLagOnFailover       float32                      `json:"maximum_lag_on_failover"` // float32 because https://github.com/kubernetes/kubernetes/issues/30213
+	Slots                      map[string]map[string]string `json:"slots"`
+	PgBinariesLocationTemplate string                       `json:"binaries_path_template"`
 }
 
 // CloneDescription describes which cluster the new should clone and up to which point in time

--- a/pkg/apis/acid.zalan.do/v1/util_test.go
+++ b/pkg/apis/acid.zalan.do/v1/util_test.go
@@ -148,7 +148,7 @@ var unmarshalCluster = []struct {
 			// This error message can vary between Go versions, so compute it for the current version.
 			Error: json.Unmarshal([]byte(`{"teamId": 0}`), &PostgresSpec{}).Error(),
 		},
-		marshal: []byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0,"slots":null},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"","allowedSourceRanges":null,"numberOfInstances":0,"users":null,"clone":{}},"status":"Invalid"}`),
+		marshal: []byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0,"slots":null,"binaries_path_template":""},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"","allowedSourceRanges":null,"numberOfInstances":0,"users":null,"clone":{}},"status":"Invalid"}`),
 		err:     nil},
 	// example with /status subresource
 	{
@@ -311,7 +311,7 @@ var unmarshalCluster = []struct {
 			},
 			Error: "",
 		},
-		marshal: []byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"9.6","parameters":{"log_statement":"all","max_connections":"10","shared_buffers":"32MB"}},"volume":{"size":"5Gi","storageClass":"SSD"},"patroni":{"initdb":{"data-checksums":"true","encoding":"UTF8","locale":"en_US.UTF-8"},"pg_hba":["hostssl all all 0.0.0.0/0 md5","host    all all 0.0.0.0/0 md5"],"ttl":30,"loop_wait":10,"retry_timeout":10,"maximum_lag_on_failover":33554432,"slots":{"permanent_logical_1":{"database":"foo","plugin":"pgoutput","type":"logical"}}},"resources":{"requests":{"cpu":"10m","memory":"50Mi"},"limits":{"cpu":"300m","memory":"3000Mi"}},"teamId":"ACID","allowedSourceRanges":["127.0.0.1/32"],"numberOfInstances":2,"users":{"zalando":["superuser","createdb"]},"maintenanceWindows":["Mon:01:00-06:00","Sat:00:00-04:00","05:00-05:15"],"clone":{"cluster":"acid-batman"}},"status":{"PostgresClusterStatus":""}}`),
+		marshal: []byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"9.6","parameters":{"log_statement":"all","max_connections":"10","shared_buffers":"32MB"}},"volume":{"size":"5Gi","storageClass":"SSD"},"patroni":{"initdb":{"data-checksums":"true","encoding":"UTF8","locale":"en_US.UTF-8"},"pg_hba":["hostssl all all 0.0.0.0/0 md5","host    all all 0.0.0.0/0 md5"],"ttl":30,"loop_wait":10,"retry_timeout":10,"maximum_lag_on_failover":33554432,"slots":{"permanent_logical_1":{"database":"foo","plugin":"pgoutput","type":"logical"}}},"binaries_path_template":"","resources":{"requests":{"cpu":"10m","memory":"50Mi"},"limits":{"cpu":"300m","memory":"3000Mi"}},"teamId":"ACID","allowedSourceRanges":["127.0.0.1/32"],"numberOfInstances":2,"users":{"zalando":["superuser","createdb"]},"maintenanceWindows":["Mon:01:00-06:00","Sat:00:00-04:00","05:00-05:15"],"clone":{"cluster":"acid-batman"}},"status":{"PostgresClusterStatus":""}}`),
 		err:     nil},
 	// example with teamId set in input
 	{
@@ -328,7 +328,7 @@ var unmarshalCluster = []struct {
 			Status: PostgresStatus{PostgresClusterStatus: ClusterStatusInvalid},
 			Error:  errors.New("name must match {TEAM}-{NAME} format").Error(),
 		},
-		marshal: []byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"teapot-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0,"slots":null},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null,"clone":{}},"status":{"PostgresClusterStatus":"Invalid"}}`),
+		marshal: []byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"teapot-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0,"slots":null,"binaries_path_template":""},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null,"clone":{}},"status":{"PostgresClusterStatus":"Invalid"}}`),
 		err:     nil},
 	// clone example
 	{
@@ -350,7 +350,7 @@ var unmarshalCluster = []struct {
 			},
 			Error: "",
 		},
-		marshal: []byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0,"slots":null},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null,"clone":{"cluster":"team-batman"}},"status":{"PostgresClusterStatus":""}}`),
+		marshal: []byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0,"slots":null,"binaries_path_template":""},"resources":{"requests":{"cpu":"","memory":""},"limits":{"cpu":"","memory":""}},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null,"clone":{"cluster":"team-batman"}},"status":{"PostgresClusterStatus":""}}`),
 		err:     nil},
 	// erroneous examples
 	{

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -222,7 +222,13 @@ PatroniInitDBParams:
 	}
 
 	config.PgLocalConfiguration = make(map[string]interface{})
-	config.PgLocalConfiguration[patroniPGBinariesParameterName] = fmt.Sprintf(pgBinariesLocationTemplate, pg.PgVersion)
+	logger.Infof("binaries: %s", patroni.PgBinariesLocationTemplate)
+	if patroni.PgBinariesLocationTemplate != "" {
+		config.PgLocalConfiguration[patroniPGBinariesParameterName] = fmt.Sprintf(patroni.PgBinariesLocationTemplate, pg.PgVersion)
+	} else {
+		config.PgLocalConfiguration[patroniPGBinariesParameterName] = fmt.Sprintf(pgBinariesLocationTemplate, pg.PgVersion)
+	}
+
 	if len(pg.Parameters) > 0 {
 		local, bootstrap := getLocalAndBoostrapPostgreSQLParameters(pg.Parameters)
 

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -42,6 +42,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.PodEnvironmentConfigMap = fromCRD.Kubernetes.PodEnvironmentConfigMap
 	result.PodTerminateGracePeriod = time.Duration(fromCRD.Kubernetes.PodTerminateGracePeriod)
 	result.SpiloPrivileged = fromCRD.Kubernetes.SpiloPrivileged
+	result.PgBinariesLocationTemplate = fromCRD.Kubernetes.PgBinariesLocationTemplate
 	result.WatchedNamespace = fromCRD.Kubernetes.WatchedNamespace
 	result.PDBNameFormat = fromCRD.Kubernetes.PDBNameFormat
 	result.SecretNameTemplate = fromCRD.Kubernetes.SecretNameTemplate

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -20,27 +20,28 @@ type CRD struct {
 
 // Resources describes kubernetes resource specific configuration parameters
 type Resources struct {
-	ResourceCheckInterval   time.Duration     `name:"resource_check_interval" default:"3s"`
-	ResourceCheckTimeout    time.Duration     `name:"resource_check_timeout" default:"10m"`
-	PodLabelWaitTimeout     time.Duration     `name:"pod_label_wait_timeout" default:"10m"`
-	PodDeletionWaitTimeout  time.Duration     `name:"pod_deletion_wait_timeout" default:"10m"`
-	PodTerminateGracePeriod time.Duration     `name:"pod_terminate_grace_period" default:"5m"`
-	PodPriorityClassName    string            `name:"pod_priority_class_name"`
-	SpiloPrivileged         bool              `name:"spilo_privileged" default:"false"`
-	ClusterLabels           map[string]string `name:"cluster_labels" default:"application:spilo"`
-	InheritedLabels         []string          `name:"inherited_labels" default:""`
-	ClusterNameLabel        string            `name:"cluster_name_label" default:"cluster-name"`
-	PodRoleLabel            string            `name:"pod_role_label" default:"spilo-role"`
-	PodToleration           map[string]string `name:"toleration" default:""`
-	DefaultCPURequest       string            `name:"default_cpu_request" default:"100m"`
-	DefaultMemoryRequest    string            `name:"default_memory_request" default:"100Mi"`
-	DefaultCPULimit         string            `name:"default_cpu_limit" default:"3"`
-	DefaultMemoryLimit      string            `name:"default_memory_limit" default:"1Gi"`
-	PodEnvironmentConfigMap string            `name:"pod_environment_configmap" default:""`
-	NodeReadinessLabel      map[string]string `name:"node_readiness_label" default:""`
-	MaxInstances            int32             `name:"max_instances" default:"-1"`
-	MinInstances            int32             `name:"min_instances" default:"-1"`
-	ShmVolume               bool              `name:"enable_shm_volume" default:"true"`
+	ResourceCheckInterval      time.Duration     `name:"resource_check_interval" default:"3s"`
+	ResourceCheckTimeout       time.Duration     `name:"resource_check_timeout" default:"10m"`
+	PodLabelWaitTimeout        time.Duration     `name:"pod_label_wait_timeout" default:"10m"`
+	PodDeletionWaitTimeout     time.Duration     `name:"pod_deletion_wait_timeout" default:"10m"`
+	PodTerminateGracePeriod    time.Duration     `name:"pod_terminate_grace_period" default:"5m"`
+	PodPriorityClassName       string            `name:"pod_priority_class_name"`
+	SpiloPrivileged            bool              `name:"spilo_privileged" default:"false"`
+	PgBinariesLocationTemplate string            `name:"binaries_path_template" default:""`
+	ClusterLabels              map[string]string `name:"cluster_labels" default:"application:spilo"`
+	InheritedLabels            []string          `name:"inherited_labels" default:""`
+	ClusterNameLabel           string            `name:"cluster_name_label" default:"cluster-name"`
+	PodRoleLabel               string            `name:"pod_role_label" default:"spilo-role"`
+	PodToleration              map[string]string `name:"toleration" default:""`
+	DefaultCPURequest          string            `name:"default_cpu_request" default:"100m"`
+	DefaultMemoryRequest       string            `name:"default_memory_request" default:"100Mi"`
+	DefaultCPULimit            string            `name:"default_cpu_limit" default:"3"`
+	DefaultMemoryLimit         string            `name:"default_memory_limit" default:"1Gi"`
+	PodEnvironmentConfigMap    string            `name:"pod_environment_configmap" default:""`
+	NodeReadinessLabel         map[string]string `name:"node_readiness_label" default:""`
+	MaxInstances               int32             `name:"max_instances" default:"-1"`
+	MinInstances               int32             `name:"min_instances" default:"-1"`
+	ShmVolume                  bool              `name:"enable_shm_volume" default:"true"`
 }
 
 // Auth describes authentication specific configuration parameters


### PR DESCRIPTION
The operator expects that PostgreSQL binaries are located at
/usr/lib/postgresql/<pgVersion>/bin. While this is true for Debian and
Ubuntu based images, it doesn't work for images that uses another binary
location. One example is CentOS where binaries are located at
/usr/pgsql-<pgVersion>/bin.

This commit adds a configuration option to make the bin_path template
parameter configurable. If "binaries_path_location" is set it will be
used to generate the bin_path option. If binaries_path_location is
omitted it will still use the build-in default
/usr/lib/postgresql/<pgVersion>/bin.