### PR TITLE
specify ReadOnlyRootFilesystem: false for pod security policies

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -360,6 +360,8 @@ func generateSpiloContainer(
 	volumeMounts []v1.VolumeMount,
 	privilegedMode bool,
 ) *v1.Container {
+	falseBool := false
+
 	return &v1.Container{
 		Name:            name,
 		Image:           *dockerImage,
@@ -383,6 +385,7 @@ func generateSpiloContainer(
 		Env:          envVars,
 		SecurityContext: &v1.SecurityContext{
 			Privileged: &privilegedMode,
+			ReadOnlyRootFilesystem: &falseBool,
 		},
 	}
 }


### PR DESCRIPTION
spilo depends on ReadOnlyRootFilesystem: false, but the operator does
not explicitly specify it. And a default pod security policy may change
the default to ReadOnlyRootFilesystem: true.

Explicitly specify ReadOnlyRootFilesystem: false so kubernetes can pick
a less restrictive policy the operator has access to.