### PR TITLE
database.go: remove hardcoded .svc.cluster.local dns suffix

### DIFF
--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -23,6 +23,7 @@ config:
   workers: "4"
   docker_image: registry.opensource.zalan.do/acid/spilo-cdp-11:1.5-p70
   secret_name_template: '{username}.{cluster}.credentials'
+  cluster_domain: cluster.local
   super_username: postgres
   enable_teams_api: "false"
   spilo_privileged: "false"

--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -103,6 +103,12 @@ In this definition, the operator overwrites the account's name to match
 `pod_service_account_name` and the `default` namespace to match the target
 namespace. The operator performs **no** further syncing of this account.
 
+## Non-default cluster domain
+
+If your cluster uses a different dns domain than `cluster.local`, this needs
+to be set in the operator ConfigMap. This is used by the operator to connect
+to the clusters after creation.
+
 ## Role-based access control for the operator
 
 The `manifests/operator-service-account-rbac.yaml` defines cluster roles and

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -157,6 +157,11 @@ configuration they are grouped under the `kubernetes` key.
   allowed. The default is
   `{username}.{cluster}.credentials.{tprkind}.{tprgroup}`.
 
+* **cluster_domain**
+  defines the default dns domain for the kubernetes cluster the operator is
+  running in. The default is `cluster.local`. Used by the operator to connect
+  to the postgres clusters after creation.
+
 * **oauth_token_secret_name**
   a name of the secret containing the `OAuth2` token to pass to the teams API.
   The default is `postgresql-operator`.

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -13,6 +13,7 @@ data:
   docker_image: registry.opensource.zalan.do/acid/spilo-cdp-11:1.5-p70
   pod_service_account_name: "zalando-postgres-operator"
   secret_name_template: '{username}.{cluster}.credentials'
+  cluster_domain: cluster.local
   super_username: postgres
   enable_teams_api: "false"
   spilo_privileged: "false"

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -21,6 +21,7 @@ configuration:
     pod_terminate_grace_period: 5m
     pdb_name_format: "postgres-{cluster}-pdb"
     secret_name_template: "{username}.{cluster}.credentials.{tprkind}.{tprgroup}"
+    cluster_domain: cluster.local
     oauth_token_secret_name: postgresql-operator
     pod_role_label: spilo-role
     spilo_privileged: false

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -49,6 +49,7 @@ type KubernetesMetaConfiguration struct {
 	WatchedNamespace                       string                `json:"watched_namespace,omitempty"`
 	PDBNameFormat                          config.StringTemplate `json:"pdb_name_format,omitempty"`
 	SecretNameTemplate                     config.StringTemplate `json:"secret_name_template,omitempty"`
+	ClusterDomain                          string                `json:"cluster_domain"`
 	OAuthTokenSecretName                   spec.NamespacedName   `json:"oauth_token_secret_name,omitempty"`
 	InfrastructureRolesSecretName          spec.NamespacedName   `json:"infrastructure_roles_secret_name,omitempty"`
 	PodRoleLabel                           string                `json:"pod_role_label,omitempty"`

--- a/pkg/cluster/database.go
+++ b/pkg/cluster/database.go
@@ -34,7 +34,7 @@ func (c *Cluster) pgConnectionString() string {
 	password := c.systemUsers[constants.SuperuserKeyName].Password
 
 	return fmt.Sprintf("host='%s' dbname=postgres sslmode=require user='%s' password='%s' connect_timeout='%d'",
-		fmt.Sprintf("%s.%s", c.Name, c.Namespace),
+		fmt.Sprintf("%s.%s.svc.%s", c.Name, c.Namespace, c.OpConfig.ClusterDomain),
 		c.systemUsers[constants.SuperuserKeyName].Name,
 		strings.Replace(password, "$", "\\$", -1),
 		constants.PostgresConnectTimeout/time.Second)

--- a/pkg/cluster/database.go
+++ b/pkg/cluster/database.go
@@ -34,7 +34,7 @@ func (c *Cluster) pgConnectionString() string {
 	password := c.systemUsers[constants.SuperuserKeyName].Password
 
 	return fmt.Sprintf("host='%s' dbname=postgres sslmode=require user='%s' password='%s' connect_timeout='%d'",
-		fmt.Sprintf("%s.%s.svc.cluster.local", c.Name, c.Namespace),
+		fmt.Sprintf("%s.%s", c.Name, c.Namespace),
 		c.systemUsers[constants.SuperuserKeyName].Name,
 		strings.Replace(password, "$", "\\$", -1),
 		constants.PostgresConnectTimeout/time.Second)

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -42,6 +42,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.PodEnvironmentConfigMap = fromCRD.Kubernetes.PodEnvironmentConfigMap
 	result.PodTerminateGracePeriod = time.Duration(fromCRD.Kubernetes.PodTerminateGracePeriod)
 	result.SpiloPrivileged = fromCRD.Kubernetes.SpiloPrivileged
+	result.ClusterDomain = fromCRD.Kubernetes.ClusterDomain
 	result.WatchedNamespace = fromCRD.Kubernetes.WatchedNamespace
 	result.PDBNameFormat = fromCRD.Kubernetes.PDBNameFormat
 	result.SecretNameTemplate = fromCRD.Kubernetes.SecretNameTemplate

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -26,6 +26,7 @@ type Resources struct {
 	PodDeletionWaitTimeout  time.Duration     `name:"pod_deletion_wait_timeout" default:"10m"`
 	PodTerminateGracePeriod time.Duration     `name:"pod_terminate_grace_period" default:"5m"`
 	PodPriorityClassName    string            `name:"pod_priority_class_name"`
+	ClusterDomain           string            `name:"cluster_domain" default:"cluster.local"`
 	SpiloPrivileged         bool              `name:"spilo_privileged" default:"false"`
 	ClusterLabels           map[string]string `name:"cluster_labels" default:"application:spilo"`
 	InheritedLabels         []string          `name:"inherited_labels" default:""`


### PR DESCRIPTION
Use the pod's configured dns search path, for clusters
where .svc.cluster.local is not correct.