### PR TITLE
postgres-operator deployment template: run operator as non-root, and with readonly filesystem

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,4 +6,9 @@ RUN apk --no-cache add ca-certificates
 
 COPY build/* /
 
+RUN addgroup -g 1000 pgo
+RUN adduser -D -u 1000 -G pgo -g 'Postgres operator' pgo
+
+USER 1000:1000
+
 ENTRYPOINT ["/postgres-operator"]

--- a/manifests/postgres-operator.yaml
+++ b/manifests/postgres-operator.yaml
@@ -21,6 +21,10 @@ spec:
           limits:
             cpu: 2000m
             memory: 500Mi
+        securityContext:
+          runAsUser: 1000
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
         env:
         # provided additional ENV vars can overwrite individual config map entries  
         - name: CONFIG_MAP_NAME


### PR DESCRIPTION
postgres-operator deployment template: 

Support running operator as non-root, and with readonly filesystem

[edit add description to content too]