### PR TITLE
rbac: add user-facing clusterroles

### DIFF
--- a/docs/user.md
+++ b/docs/user.md
@@ -41,6 +41,15 @@ $ kubectl create -f manifests/minimal-postgres-manifest.yaml
 $ kubectl get pods -w --show-labels
 ```
 
+## Give K8S users access to create/list postgresqls
+
+```bash
+$ kubectl create -f manifests/user-facing-clusterroles.yaml
+```
+
+Creates zalando-postgres-operator:users:view, :edit and :admin clusterroles that are
+aggregated into the default roles.
+
 ## Connect to PostgreSQL
 
 With a `port-forward` on one of the database pods (e.g. the master) you can

--- a/manifests/user-facing-clusterroles.yaml
+++ b/manifests/user-facing-clusterroles.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: zalando-postgres-operator:users:edit
+rules:
+- apiGroups:
+  - acid.zalan.do
+  resources:
+  - postgresqls
+  - postgresqls/status
+  verbs:
+  - "*"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: zalando-postgres-operator:users:view
+rules:
+- apiGroups:
+  - acid.zalan.do
+  resources:
+  - postgresqls
+  - postgresqls/status
+  verbs:
+  - get
+  - list
+  - watch
+

--- a/manifests/user-facing-clusterroles.yaml
+++ b/manifests/user-facing-clusterroles.yaml
@@ -25,7 +25,6 @@ rules:
   - acid.zalan.do
   resources:
   - postgresqls
-  - postgresqls/status
   verbs:
   - create
   - update

--- a/manifests/user-facing-clusterroles.yaml
+++ b/manifests/user-facing-clusterroles.yaml
@@ -3,6 +3,21 @@ kind: ClusterRole
 metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: zalando-postgres-operator:users:admin
+rules:
+- apiGroups:
+  - acid.zalan.do
+  resources:
+  - postgresqls
+  - postgresqls/status
+  verbs:
+  - "*"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: zalando-postgres-operator:users:edit
 rules:
@@ -12,7 +27,10 @@ rules:
   - postgresqls
   - postgresqls/status
   verbs:
-  - "*"
+  - create
+  - update
+  - patch
+  - delete
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Fixes #584. Adds user facing clusterroles so kubectl get postgresql and kubectl create postgresql works for view and edit/admin default rolebindings.