### PR TITLE
change app label for logical backup pod

### DIFF
--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -307,8 +307,7 @@ class K8s:
             time.sleep(self.RETRY_TIMEOUT_SEC)
 
     def get_logical_backup_job(self, namespace='default'):
-        return self.api.batch_v1_beta1.list_namespaced_cron_job(
-            namespace, label_selector="application=spilo-logical-backup")
+        return self.api.batch_v1_beta1.list_namespaced_cron_job(namespace, label_selector="application=spilo")
 
     def wait_for_logical_backup_job(self, expected_num_of_jobs):
         while (len(self.get_logical_backup_job().items) != expected_num_of_jobs):

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -307,7 +307,8 @@ class K8s:
             time.sleep(self.RETRY_TIMEOUT_SEC)
 
     def get_logical_backup_job(self, namespace='default'):
-        return self.api.batch_v1_beta1.list_namespaced_cron_job(namespace, label_selector="application=spilo")
+        return self.api.batch_v1_beta1.list_namespaced_cron_job(
+            namespace, label_selector="application=spilo-logical-backup")
 
     def wait_for_logical_backup_job(self, expected_num_of_jobs):
         while (len(self.get_logical_backup_job().items) != expected_num_of_jobs):

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1465,7 +1465,7 @@ func (c *Cluster) generateLogicalBackupJob() (*batchv1beta1.CronJob, error) {
 	// re-use the method that generates DB pod templates
 	if podTemplate, err = generatePodTemplate(
 		c.Namespace,
-		c.labelsSet(true),
+		labels,
 		logicalBackupContainer,
 		[]v1.Container{},
 		[]v1.Container{},


### PR DESCRIPTION
Label Logical Backup Pod with `application=spilo-logical-backup` to avoid interference with AntiAffitiny from StatefulSet.

Fixes #593