### PR TITLE
Allow disabling of CRD creation

### DIFF
--- a/charts/postgres-operator/templates/customrresourcedefinition.yaml
+++ b/charts/postgres-operator/templates/customrresourcedefinition.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.crd.create }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -47,3 +48,4 @@ spec:
   subresources:
     status: {}
   version: v1
+{{ end }}

--- a/charts/postgres-operator/values-crd.yaml
+++ b/charts/postgres-operator/values-crd.yaml
@@ -238,6 +238,10 @@ rbac:
   # Specifies whether RBAC resources should be created
   create: true
 
+crd:
+  # Specifies whether custom resource definitions should be created
+  create: true
+
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -219,6 +219,10 @@ rbac:
   # Specifies whether RBAC resources should be created
   create: true
 
+crd:
+  # Specifies whether custom resource definitions should be created
+  create: true
+
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true


### PR DESCRIPTION
Signed-off-by: Stefan Frye <frye@deitmer-it.de>

In certain scenarios (e.g., automated testing) it is helpful to be able to switch off CRD creation by the Helm chart. As CRDs are not automatically deleted on `helm delete`, we prefer to manage them separately.