### PR TITLE
additional printer columns for CRDs

### DIFF
--- a/charts/postgres-operator/templates/customrresourcedefinition.yaml
+++ b/charts/postgres-operator/templates/customrresourcedefinition.yaml
@@ -27,9 +27,9 @@ spec:
     type: string
     description: PostgreSQL version
     JSONPath: .spec.postgresql.version
-  - name: Instances
+  - name: Pods
     type: integer
-    description: Number of instances per Postgres cluster
+    description: Number of Pods per Postgres cluster
     JSONPath: .spec.numberOfInstances
   - name: Volume
     type: string

--- a/charts/postgres-operator/templates/customrresourcedefinition.yaml
+++ b/charts/postgres-operator/templates/customrresourcedefinition.yaml
@@ -18,6 +18,26 @@ spec:
     singular: postgresql
     shortNames:
     - pg
+  additionalPrinterColumns:
+  - name: Team
+    type: string
+    description: Team responsible for Postgres CLuster
+    JSONPath: .spec.teamId
+  - name: Status
+    type: string
+    description: Current status of Postgres cluster
+    JSONPath: .status.PostgresClusterStatus
+  - name: Instances
+    type: integer
+    description: Number of instances per Postgres cluster
+    JSONPath: .spec.numberOfInstances
+  - name: Volume
+    type: string
+    description: Size of the bound volume
+    JSONPath: .spec.volume.size
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
   scope: Namespaced
   subresources:
     status: {}
@@ -42,7 +62,27 @@ spec:
     plural: operatorconfigurations
     singular: operatorconfiguration
     shortNames:
-    - pgc
+    - opconfig
+  additionalPrinterColumns:
+  - name: Image
+    type: string
+    description: Spilo image to be used for Pods
+    JSONPath: .configuration.docker_image
+  - name: Cluster-Label
+    type: string
+    description: Label for K8s resources created by operator
+    JSONPath: .configuration.kubernetes.cluster_name_label
+  - name: Service-Account
+    type: string
+    description: Name of service account to be used
+    JSONPath: .configuration.kubernetes.pod_service_account_name
+  - name: Min-Instances
+    type: integer
+    description: Minimum number of instances per Postgres cluster
+    JSONPath: .configuration.min_instances
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
   scope: Namespaced
   subresources:
     status: {}

--- a/charts/postgres-operator/templates/customrresourcedefinition.yaml
+++ b/charts/postgres-operator/templates/customrresourcedefinition.yaml
@@ -23,10 +23,10 @@ spec:
     type: string
     description: Team responsible for Postgres CLuster
     JSONPath: .spec.teamId
-  - name: Status
+  - name: Version
     type: string
-    description: Current status of Postgres cluster
-    JSONPath: .status.PostgresClusterStatus
+    description: PostgreSQL version
+    JSONPath: .spec.postgresql.version
   - name: Instances
     type: integer
     description: Number of instances per Postgres cluster
@@ -35,9 +35,21 @@ spec:
     type: string
     description: Size of the bound volume
     JSONPath: .spec.volume.size
+  - name: CPU-Request
+    type: string
+    description: Requested CPU for Postgres containers
+    JSONPath: .spec.resources.requests.cpu
+  - name: Memory-Request
+    type: string
+    description: Requested memory for Postgres containers
+    JSONPath: .spec.resources.requests.memory
   - name: Age
     type: date
     JSONPath: .metadata.creationTimestamp
+  - name: Status
+    type: string
+    description: Current sync status of postgresql resource
+    JSONPath: .status.PostgresClusterStatus
   scope: Namespaced
   subresources:
     status: {}

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -34,9 +34,9 @@ var PostgresCRDResourceColumns = []apiextv1beta1.CustomResourceColumnDefinition{
 		JSONPath:    ".spec.postgresql.version",
 	},
 	apiextv1beta1.CustomResourceColumnDefinition{
-		Name:        "Instances",
+		Name:        "Pods",
 		Type:        "integer",
-		Description: "Number of instances per Postgres cluster",
+		Description: "Number of Pods per Postgres cluster",
 		JSONPath:    ".spec.numberOfInstances",
 	},
 	apiextv1beta1.CustomResourceColumnDefinition{

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -28,10 +28,10 @@ var PostgresCRDResourceColumns = []apiextv1beta1.CustomResourceColumnDefinition{
 		JSONPath:    ".spec.teamId",
 	},
 	apiextv1beta1.CustomResourceColumnDefinition{
-		Name:        "Status",
+		Name:        "Version",
 		Type:        "string",
-		Description: "Current status of Postgres cluster",
-		JSONPath:    ".status.PostgresClusterStatus",
+		Description: "PostgreSQL version",
+		JSONPath:    ".spec.postgresql.version",
 	},
 	apiextv1beta1.CustomResourceColumnDefinition{
 		Name:        "Instances",
@@ -46,9 +46,27 @@ var PostgresCRDResourceColumns = []apiextv1beta1.CustomResourceColumnDefinition{
 		JSONPath:    ".spec.volume.size",
 	},
 	apiextv1beta1.CustomResourceColumnDefinition{
+		Name:        "CPU-Request",
+		Type:        "string",
+		Description: "Requested CPU for Postgres containers",
+		JSONPath:    ".spec.resources.requests.cpu",
+	},
+	apiextv1beta1.CustomResourceColumnDefinition{
+		Name:        "Memory-Request",
+		Type:        "string",
+		Description: "Requested memory for Postgres containers",
+		JSONPath:    ".spec.resources.requests.memory",
+	},
+	apiextv1beta1.CustomResourceColumnDefinition{
 		Name:     "Age",
 		Type:     "date",
 		JSONPath: ".metadata.creationTimestamp",
+	},
+	apiextv1beta1.CustomResourceColumnDefinition{
+		Name:        "Status",
+		Type:        "string",
+		Description: "Current sync status of postgresql resource",
+		JSONPath:    ".status.PostgresClusterStatus",
 	},
 }
 

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -19,7 +19,73 @@ const (
 	OperatorConfigCRDResourceShort  = "opconfig"
 )
 
-func buildCRD(name, kind, plural, short string) *apiextv1beta1.CustomResourceDefinition {
+// PostgresCRDResourceColumns definition of AdditionalPrinterColumns for postgresql CRD
+var PostgresCRDResourceColumns = []apiextv1beta1.CustomResourceColumnDefinition{
+	apiextv1beta1.CustomResourceColumnDefinition{
+		Name:        "Team",
+		Type:        "string",
+		Description: "Team responsible for Postgres cluster",
+		JSONPath:    ".spec.teamId",
+	},
+	apiextv1beta1.CustomResourceColumnDefinition{
+		Name:        "Status",
+		Type:        "string",
+		Description: "Current status of Postgres cluster",
+		JSONPath:    ".status.PostgresClusterStatus",
+	},
+	apiextv1beta1.CustomResourceColumnDefinition{
+		Name:        "Instances",
+		Type:        "integer",
+		Description: "Number of instances per Postgres cluster",
+		JSONPath:    ".spec.numberOfInstances",
+	},
+	apiextv1beta1.CustomResourceColumnDefinition{
+		Name:        "Volume",
+		Type:        "string",
+		Description: "Size of the bound volume",
+		JSONPath:    ".spec.volume.size",
+	},
+	apiextv1beta1.CustomResourceColumnDefinition{
+		Name:     "Age",
+		Type:     "date",
+		JSONPath: ".metadata.creationTimestamp",
+	},
+}
+
+// OperatorConfigCRDResourceColumns definition of AdditionalPrinterColumns for OperatorConfiguration CRD
+var OperatorConfigCRDResourceColumns = []apiextv1beta1.CustomResourceColumnDefinition{
+	apiextv1beta1.CustomResourceColumnDefinition{
+		Name:        "Image",
+		Type:        "string",
+		Description: "Spilo image to be used for Pods",
+		JSONPath:    ".configuration.docker_image",
+	},
+	apiextv1beta1.CustomResourceColumnDefinition{
+		Name:        "Cluster-Label",
+		Type:        "string",
+		Description: "Label for K8s resources created by operator",
+		JSONPath:    ".configuration.kubernetes.cluster_name_label",
+	},
+	apiextv1beta1.CustomResourceColumnDefinition{
+		Name:        "Service-Account",
+		Type:        "string",
+		Description: "Name of service account to be used",
+		JSONPath:    ".configuration.kubernetes.pod_service_account_name",
+	},
+	apiextv1beta1.CustomResourceColumnDefinition{
+		Name:        "Min-Instances",
+		Type:        "integer",
+		Description: "Minimum number of instances per Postgres cluster",
+		JSONPath:    ".configuration.min_instances",
+	},
+	apiextv1beta1.CustomResourceColumnDefinition{
+		Name:     "Age",
+		Type:     "date",
+		JSONPath: ".metadata.creationTimestamp",
+	},
+}
+
+func buildCRD(name, kind, plural, short string, columns []apiextv1beta1.CustomResourceColumnDefinition) *apiextv1beta1.CustomResourceDefinition {
 	return &apiextv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -36,6 +102,7 @@ func buildCRD(name, kind, plural, short string) *apiextv1beta1.CustomResourceDef
 			Subresources: &apiextv1beta1.CustomResourceSubresources{
 				Status: &apiextv1beta1.CustomResourceSubresourceStatus{},
 			},
+			AdditionalPrinterColumns: columns,
 		},
 	}
 }
@@ -45,7 +112,8 @@ func PostgresCRD() *apiextv1beta1.CustomResourceDefinition {
 	return buildCRD(PostgresCRDResouceName,
 		PostgresCRDResourceKind,
 		PostgresCRDResourcePlural,
-		PostgresCRDResourceShort)
+		PostgresCRDResourceShort,
+		PostgresCRDResourceColumns)
 }
 
 // ConfigurationCRD returns CustomResourceDefinition built from OperatorConfigCRDResource
@@ -53,5 +121,6 @@ func ConfigurationCRD() *apiextv1beta1.CustomResourceDefinition {
 	return buildCRD(OperatorConfigCRDResourceName,
 		OperatorConfigCRDResouceKind,
 		OperatorConfigCRDResourcePlural,
-		OperatorConfigCRDResourceShort)
+		OperatorConfigCRDResourceShort,
+		OperatorConfigCRDResourceColumns)
 }


### PR DESCRIPTION
Show some more infos when listing `postgresql` or `OperatorConfiguration` resources. We can discuss in this PR which columns to print.

```
kubectl get pg                                         
NAME                TEAM   VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE   STATUS
acid-test-cluster   ACID   10        2      1Gi      10m           100Mi            6s    Creating

kubectl get opconfig
NAME                                        IMAGE                                               CLUSTER-LABEL   SERVICE-ACCOUNT   MIN-INSTANCES   AGE
postgresql-operator-default-configuration   registry.opensource.zalan.do/acid/spilo-11:1.5-p9   cluster-name    operator          -1              2s
```

Closes #635