### PR TITLE
Avoid orphaned objects on delete

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -164,11 +164,13 @@ func (c *Cluster) setStatus(status string) {
 	}
 
 	// we cannot do a full scale update here without fetching the previous manifest (as the resourceVersion may differ),
-	// however, we could do patch without it. In the future, once /status subresource is there (starting Kubernets 1.11)
+	// however, we could do patch without it. In the future, once /status subresource is there (starting Kubernetes 1.11)
 	// we should take advantage of it.
 	newspec, err := c.KubeClient.AcidV1ClientSet.AcidV1().Postgresqls(c.clusterNamespace()).Patch(c.Name, types.MergePatchType, patch, "status")
 	if err != nil {
 		c.logger.Errorf("could not update status: %v", err)
+		// return as newspec is empty, see PR654
+		return
 	}
 	// update the spec, maintaining the new resourceVersion.
 	c.setSpec(newspec)

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -365,7 +365,7 @@ func (c *Cluster) waitStatefulsetPodsReady() error {
 	c.setProcessName("waiting for the pods of the statefulset")
 	// TODO: wait for the first Pod only
 	if err := c.waitStatefulsetReady(); err != nil {
-		return fmt.Errorf("statuful set error: %v", err)
+		return fmt.Errorf("stateful set error: %v", err)
 	}
 
 	// TODO: wait only for master

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -258,14 +258,6 @@ func (c *Controller) processEvent(event ClusterEvent) {
 		}
 		lg.Infoln("deletion of the cluster started")
 
-		// HACK if a delete happens too soon, cl fields are empty
-		// thus, pods, logical backup jobs and headless service will not get deleted
-		// see issues 551, 218
-		if cl.Name == "" {
-			cl.Name = clusterName.Name
-			cl.Namespace = clusterName.Namespace
-		}
-
 		teamName := strings.ToLower(cl.Spec.TeamID)
 
 		c.curWorkerCluster.Store(event.WorkerID, cl)

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -258,6 +258,14 @@ func (c *Controller) processEvent(event ClusterEvent) {
 		}
 		lg.Infoln("deletion of the cluster started")
 
+		// HACK if a delete happens too soon, cl fields are empty
+		// thus, pods, logical backup jobs and headless service will not get deleted
+		// see issues 551, 218
+		if cl.Name == "" {
+			cl.Name = clusterName.Name
+			cl.Namespace = clusterName.Namespace
+		}
+
 		teamName := strings.ToLower(cl.Spec.TeamID)
 
 		c.curWorkerCluster.Store(event.WorkerID, cl)

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -82,7 +82,7 @@ func ResourceNotFound(err error) bool {
 	return apierrors.IsNotFound(err)
 }
 
-// NewFromConfig create Kubernets Interface using REST config
+// NewFromConfig create Kubernetes Interface using REST config
 func NewFromConfig(cfg *rest.Config) (KubernetesClient, error) {
 	kubeClient := KubernetesClient{}
 


### PR DESCRIPTION
If a cluster is deleted immediately after creation, fields of the `cluster` struct are empty when processing the DELETE event. The same might happen when a cluster doesn't get into the `Running` state at all.

fixes #551 