### PR TITLE
fix relative links to manifest files

### DIFF
--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -4,9 +4,9 @@ Individual Postgres clusters are described by the Kubernetes *cluster manifest*
 that has the structure defined by the `postgresql` CRD (custom resource
 definition). The following section describes the structure of the manifest and
 the purpose of individual keys. You can take a look at the examples of the
-[minimal](../manifests/minimal-postgres-manifest.yaml)
+[minimal](../../manifests/minimal-postgres-manifest.yaml)
 and the
-[complete](../manifests/complete-postgres-manifest.yaml)
+[complete](../../manifests/complete-postgres-manifest.yaml)
 cluster manifests.
 
 When Kubernetes resources, such as memory, CPU or volumes, are configured,


### PR DESCRIPTION
[minimal](../manifests/minimal-postgres-manifest.yaml)
and the
[complete](../manifests/complete-postgres-manifest.yaml)
Links don't work as the manifests directory is higher in the structure.