### PR TITLE
Limit go test to pkg folder

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -40,7 +40,7 @@ pipeline:
           cmd: |
             export PATH=$PATH:$HOME/go/bin
             cd $OPERATOR_TOP_DIR/postgres-operator
-            go test ./...
+            go test ./pkg/...
         - desc: 'Run e2e tests'
           cmd: |
             cd $OPERATOR_TOP_DIR/postgres-operator


### PR DESCRIPTION
The kubectl-pg dependencies are currently not downloaded which leads to an error when calling `go test ./...`. As unit tests only live in the `pkg` directory at the moment we can also call `go test ./pkg/...`.

Adding `GO111MODULE=on` would also solve this problem, but we can leave it to PR #544 .