### PR TITLE
Handle IPv6 k8s pods in Patroni URLs

### DIFF
--- a/pkg/util/patroni/patroni.go
+++ b/pkg/util/patroni/patroni.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -49,18 +50,14 @@ func apiURL(masterPod *v1.Pod) (string, error) {
 	if ip == nil {
 		return "", fmt.Errorf("%s is not a valid IP", masterPod.Status.PodIP)
 	}
-	var ipString string
-	// If IPv6, add braces
+	// Sanity check PodIP
 	if ip.To4() == nil {
 		if ip.To16() == nil {
 			// Shouldn't ever get here, but library states it's possible.
 			return "", fmt.Errorf("%s is not a valid IPv4/IPv6 address", ip.String())
 		}
-		ipString = fmt.Sprintf("[%s]", ip.String())
-	} else {
-		ipString = ip.String()
 	}
-	return fmt.Sprintf("http://%s:%d", ipString, apiPort), nil
+	return fmt.Sprintf("http://%s", net.JoinHostPort(ip.String(), strconv.Itoa(apiPort))), nil
 }
 
 func (p *Patroni) httpPostOrPatch(method string, url string, body *bytes.Buffer) (err error) {

--- a/pkg/util/patroni/patroni.go
+++ b/pkg/util/patroni/patroni.go
@@ -54,7 +54,7 @@ func apiURL(masterPod *v1.Pod) (string, error) {
 	if ip.To4() == nil {
 		if ip.To16() == nil {
 			// Shouldn't ever get here, but library states it's possible.
-			return "", fmt.Errorf("%s is not a valid IPv4/IPv6 address", ip.String())
+			return "", fmt.Errorf("%s is not a valid IPv4/IPv6 address", masterPod.Status.PodIP)
 		}
 	}
 	return fmt.Sprintf("http://%s", net.JoinHostPort(ip.String(), strconv.Itoa(apiPort))), nil

--- a/pkg/util/patroni/patroni_test.go
+++ b/pkg/util/patroni/patroni_test.go
@@ -1,0 +1,74 @@
+package patroni
+
+import (
+	"errors"
+	"fmt"
+	"k8s.io/api/core/v1"
+	"testing"
+)
+
+func newMockPod(ip string) *v1.Pod {
+	return &v1.Pod{
+		Status: v1.PodStatus{
+			PodIP: ip,
+		},
+	}
+}
+
+func TestApiURL(t *testing.T) {
+	var testTable = []struct {
+		podIP            string
+		expectedResponse string
+		expectedError    error
+	}{
+		{
+			"127.0.0.1",
+			fmt.Sprintf("http://127.0.0.1:%d", apiPort),
+			nil,
+		},
+		{
+			"0000:0000:0000:0000:0000:0000:0000:0001",
+			fmt.Sprintf("http://[::1]:%d", apiPort),
+			nil,
+		},
+		{
+			"::1",
+			fmt.Sprintf("http://[::1]:%d", apiPort),
+			nil,
+		},
+		{
+			"",
+			"",
+			errors.New(" is not a valid IP"),
+		},
+		{
+			"foobar",
+			"",
+			errors.New("foobar is not a valid IP"),
+		},
+		{
+			"127.0.1",
+			"",
+			errors.New("127.0.1 is not a valid IP"),
+		},
+		{
+			":::",
+			"",
+			errors.New("::: is not a valid IP"),
+		},
+	}
+	for _, test := range testTable {
+		resp, err := apiURL(newMockPod(test.podIP))
+		if resp != test.expectedResponse {
+			t.Errorf("expected response %v does not match the actual %v", test.expectedResponse, resp)
+		}
+		if err != test.expectedError {
+			if err == nil || test.expectedError == nil {
+				t.Errorf("expected error '%v' does not match the actual error '%v'", test.expectedError, err)
+			}
+			if err != nil && test.expectedError != nil && err.Error() != test.expectedError.Error() {
+				t.Errorf("expected error '%v' does not match the actual error '%v'", test.expectedError, err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Encapsulate IPv6 addresses in brackets.

Fixes `could not patch postgres parameters with a pod namespace/pod-0: could not make request: Patch http://ffff:ffff::1009:8008/config: invalid URL port \"ffff:1009:8008\`

Changing patroni configs now works properly.
```
time="2019-09-19T07:36:06Z" level=debug msg="calling Patroni API on a pod namespace/pod-0 to set the following Postgres options: map[max_connections:2000]" cluster-name=namespace/pod pkg=cluster
time="2019-09-19T07:36:06Z" level=debug msg="making PATCH http request: http://[ffff:ffff::1009]:8008/config" cluster-name=namespace/pod pkg=cluster
time="2019-09-19T07:36:06Z" level=debug msg="performing rolling update" cluster-name=namespace/pod pkg=cluster
```