### PR TITLE
Remove service accounts cache

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -58,7 +58,6 @@ type Controller struct {
 
 	PodServiceAccount            *v1.ServiceAccount
 	PodServiceAccountRoleBinding *rbacv1beta1.RoleBinding
-	namespacesWithDefinedRBAC    sync.Map
 }
 
 // NewController creates a new controller

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -493,17 +493,16 @@ func (c *Controller) postgresqlDelete(obj interface{}) {
 }
 
 /*
-  Ensures the pod service account and role bindings exists in a namespace before a PG cluster is created there so that a user does not have to deploy these credentials manually.
-  StatefulSets require the service account to create pods; Patroni requires relevant RBAC bindings to access endpoints.
+  Ensures the pod service account and role bindings exists in a namespace
+  before a PG cluster is created there so that a user does not have to deploy
+  these credentials manually.  StatefulSets require the service account to
+  create pods; Patroni requires relevant RBAC bindings to access endpoints.
 
   The operator does not sync accounts/role bindings after creation.
 */
 func (c *Controller) submitRBACCredentials(event ClusterEvent) error {
 
 	namespace := event.NewSpec.GetNamespace()
-	if _, ok := c.namespacesWithDefinedRBAC.Load(namespace); ok {
-		return nil
-	}
 
 	if err := c.createPodServiceAccount(namespace); err != nil {
 		return fmt.Errorf("could not create pod service account %v : %v", c.opConfig.PodServiceAccountName, err)
@@ -512,7 +511,6 @@ func (c *Controller) submitRBACCredentials(event ClusterEvent) error {
 	if err := c.createRoleBindings(namespace); err != nil {
 		return fmt.Errorf("could not create role binding %v : %v", c.PodServiceAccountRoleBinding.Name, err)
 	}
-	c.namespacesWithDefinedRBAC.Store(namespace, true)
 	return nil
 }
 


### PR DESCRIPTION
For optimization purposes operator was creating a cache map to remember
if service accounts and role binding was deployed to a namespace. This
could lead to a problem, when a namespace was deleted, since this
cache was not synchronized. For the sake of correctness remove the
cache, and check every time if required service account and rbac is
present. In the normal case this introduces an overhead of two API calls
per an event (one to get a service accounts, one to get a role binding),
which should not be a problem, unless proven otherwise.