### PR TITLE
Fixing spelling mistake in delete PVC function name

### DIFF
--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -329,7 +329,7 @@ func (c *Cluster) deleteStatefulSet() error {
 		return fmt.Errorf("could not delete pods: %v", err)
 	}
 
-	if err := c.deletePersistenVolumeClaims(); err != nil {
+	if err := c.deletePersistentVolumeClaims(); err != nil {
 		return fmt.Errorf("could not delete PersistentVolumeClaims: %v", err)
 	}
 

--- a/pkg/cluster/volumes.go
+++ b/pkg/cluster/volumes.go
@@ -30,7 +30,7 @@ func (c *Cluster) listPersistentVolumeClaims() ([]v1.PersistentVolumeClaim, erro
 	return pvcs.Items, nil
 }
 
-func (c *Cluster) deletePersistenVolumeClaims() error {
+func (c *Cluster) deletePersistentVolumeClaims() error {
 	c.logger.Debugln("deleting PVCs")
 	pvcs, err := c.listPersistentVolumeClaims()
 	if err != nil {


### PR DESCRIPTION
Super minor change, just corrects a very minor spelling mistake in the function name.

Let me know if there is anything else required for this.