### PR TITLE
Fix parameter expansion when performing logical backup.

### DIFF
--- a/docker/logical-backup/dump.sh
+++ b/docker/logical-backup/dump.sh
@@ -70,7 +70,7 @@ declare -a search_strategy=(
 function get_config_resource() {
     curl "${K8S_API_URL}/apis/apps/v1/namespaces/default/deployments/postgres-operator" \
         --cacert $CERT   \
-        -H "Authorization: Bearer ${TOKEN}" | jq '.spec.template.spec.containers[0].env[] | select(.name == "$1") | .value'
+        -H "Authorization: Bearer ${TOKEN}" | jq '.spec.template.spec.containers[0].env[] | select(.name == "'"$1"'") | .value'
 }
 
 function get_cluster_name_label {


### PR DESCRIPTION
This pull request is a minor fix for the function  `get_config_resource` in `dump.sh`. 
Previously paramater expansion was not being performed and the string litteral value `"$1"` was used in the select statement.