### PR TITLE
charts: Add pods/exec permission

### DIFF
--- a/charts/postgres-operator/templates/clusterrole.yaml
+++ b/charts/postgres-operator/templates/clusterrole.yaml
@@ -90,6 +90,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create

--- a/manifests/operator-service-account-rbac.yaml
+++ b/manifests/operator-service-account-rbac.yaml
@@ -91,6 +91,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create


### PR DESCRIPTION
Without this it fails with: `could not sync persistent volumes: could not sync volumes: could not resize the filesystem on pod \"testns/testdb-0\": could not get device and type for the postgres filesystem: could not execute: pods \"testdb-0\" is forbidden: User \"system:serviceaccount:postgres-operator:postgres-operator\" cannot create resource \"pods/exec\" in API group \"\" in the namespace \"testns\"`
