### PR TITLE
enable GO111MODULE also on go test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ deps:
 
 test:
 	hack/verify-codegen.sh
-	@go test ./pkg/...
+	GO111MODULE=on go test ./...
 
 e2e: docker # build operator image to be tested
 	cd e2e; make tools test clean

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -32,7 +32,7 @@ pipeline:
         - desc: 'Run unit tests'
           cmd: |
             export PATH=$PATH:$HOME/go/bin
-            go test ./pkg/...
+            make test
         - desc: 'Run e2e tests'
           cmd: |
             make e2e

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -32,7 +32,7 @@ pipeline:
         - desc: 'Run unit tests'
           cmd: |
             export PATH=$PATH:$HOME/go/bin
-            make test
+            go test ./...
         - desc: 'Run e2e tests'
           cmd: |
             make e2e


### PR DESCRIPTION
to make sure test succeed when called from another project where operator is a dependency