### PR TITLE
fix errors when changing service type

### DIFF
--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -380,8 +380,6 @@ func (c *Cluster) updateService(role PostgresRole, newService *v1.Service) error
 			return fmt.Errorf("could not delete service %q: %v", serviceName, err)
 		}
 
-		// make sure we clear the stored service status if the subsequent create fails.
-		c.Services[role] = nil
 		// wait until the service is truly deleted
 		c.logger.Debugf("waiting for service to be deleted")
 
@@ -395,7 +393,8 @@ func (c *Cluster) updateService(role PostgresRole, newService *v1.Service) error
 			return fmt.Errorf("could not delete service %q: %v", serviceName, err)
 		}
 
-		// make sure we clear the stored endpoint status if the subsequent create fails.
+		// make sure we clear the stored service and endpoint status if the subsequent create fails.
+		c.Services[role] = nil
 		c.Endpoints[role] = nil
 		if role == Master {
 			// create the new endpoint using the addresses obtained from the previous one

--- a/pkg/util/constants/kubernetes.go
+++ b/pkg/util/constants/kubernetes.go
@@ -4,11 +4,11 @@ import "time"
 
 // General kubernetes-related constants
 const (
-	PostgresContainerName       = "postgres"
-	PostgresContainerIdx        = 0
-	K8sAPIPath                  = "/apis"
-	StatefulsetDeletionInterval = 1 * time.Second
-	StatefulsetDeletionTimeout  = 30 * time.Second
+	PostgresContainerName    = "postgres"
+	PostgresContainerIdx     = 0
+	K8sAPIPath               = "/apis"
+	ResourceDeletionInterval = 1 * time.Second
+	ResourceDeletionTimeout  = 30 * time.Second
 
 	QueueResyncPeriodPod  = 5 * time.Minute
 	QueueResyncPeriodTPR  = 5 * time.Minute

--- a/pkg/util/constants/kubernetes.go
+++ b/pkg/util/constants/kubernetes.go
@@ -4,11 +4,9 @@ import "time"
 
 // General kubernetes-related constants
 const (
-	PostgresContainerName    = "postgres"
-	PostgresContainerIdx     = 0
-	K8sAPIPath               = "/apis"
-	ResourceDeletionInterval = 1 * time.Second
-	ResourceDeletionTimeout  = 30 * time.Second
+	PostgresContainerName = "postgres"
+	PostgresContainerIdx  = 0
+	K8sAPIPath            = "/apis"
 
 	QueueResyncPeriodPod  = 5 * time.Minute
 	QueueResyncPeriodTPR  = 5 * time.Minute


### PR DESCRIPTION
when service type is changed, operator deletes the current service and tries to create a new one immediately, which fails as deletion doesn't happen that fast. This PR reuses the same retry/wait logic from StatefulSet deletion. 

After this part of `updateService`, creation order of endpoint and service is also reversed to avoid connection problems while syncing roles in the next step

fixes #713

