### PR TITLE
feat: use controller namespace for logical backup API calls

### DIFF
--- a/docker/logical-backup/dump.sh
+++ b/docker/logical-backup/dump.sh
@@ -68,7 +68,7 @@ declare -a search_strategy=(
 )
 
 function get_config_resource() {
-    curl "${K8S_API_URL}/apis/apps/v1/namespaces/default/deployments/postgres-operator" \
+    curl "${K8S_API_URL}/apis/apps/v1/namespaces/${CONTROLLER_NAMESPACE}/deployments/postgres-operator" \
         --cacert $CERT   \
         -H "Authorization: Bearer ${TOKEN}" | jq '.spec.template.spec.containers[0].env[] | select(.name == "$1") | .value'
 }
@@ -79,13 +79,13 @@ function get_cluster_name_label {
 
     config=$(get_config_resource "CONFIG_MAP_NAME")
     if [ -n "$config" ]; then
-        clustername=$(curl "${K8S_API_URL}/api/v1/namespaces/default/configmaps/${config}" \
+        clustername=$(curl "${K8S_API_URL}/api/v1/namespaces/${CONTROLLER_NAMESPACE}/configmaps/${config}" \
                             --cacert $CERT   \
                             -H "Authorization: Bearer ${TOKEN}" | jq '.data.cluster_name_label')
     else
         config=$(get_config_resource "POSTGRES_OPERATOR_CONFIGURATION_OBJECT")
         if [ -n "$config" ]; then
-            clustername=$(curl "${K8S_API_URL}/apis/acid.zalan.do/v1/namespaces/default/operatorconfigurations/${config}" \
+            clustername=$(curl "${K8S_API_URL}/apis/acid.zalan.do/v1/namespaces/${CONTROLLER_NAMESPACE}/operatorconfigurations/${config}" \
                                 --cacert $CERT   \
                                 -H "Authorization: Bearer ${TOKEN}" | jq '.configuration.kubernetes.cluster_name_label')
         fi

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -43,6 +43,7 @@ var (
 type Config struct {
 	OpConfig                     config.Config
 	RestConfig                   *rest.Config
+	ControllerConfig             *spec.ControllerConfig
 	InfrastructureRoles          map[string]spec.PgUser // inherited from the controller
 	PodServiceAccount            *v1.ServiceAccount
 	PodServiceAccountRoleBinding *rbacv1beta1.RoleBinding

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -43,7 +43,7 @@ var (
 type Config struct {
 	OpConfig                     config.Config
 	RestConfig                   *rest.Config
-	ControllerConfig             *spec.ControllerConfig
+	ControllerNamespace          string
 	InfrastructureRoles          map[string]spec.PgUser // inherited from the controller
 	PodServiceAccount            *v1.ServiceAccount
 	PodServiceAccountRoleBinding *rbacv1beta1.RoleBinding

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1566,6 +1566,11 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 				},
 			},
 		},
+		// Controller namespace to use for k8s API calls
+		{
+			Name: "CONTROLLER_NAMESPACE",
+			Value: c.ControllerConfig.Namespace,
+		},
 		// Bucket env vars
 		{
 			Name:  "LOGICAL_BACKUP_S3_BUCKET",

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1569,7 +1569,7 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 		// Controller namespace to use for k8s API calls
 		{
 			Name: "CONTROLLER_NAMESPACE",
-			Value: c.ControllerConfig.Namespace,
+			Value: c.ControllerNamespace,
 		},
 		// Bucket env vars
 		{

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -25,11 +25,11 @@ func (c *Controller) makeClusterConfig() cluster.Config {
 	}
 
 	return cluster.Config{
-		ControllerConfig:    c.config,
 		RestConfig:          c.config.RestConfig,
 		OpConfig:            config.Copy(c.opConfig),
 		InfrastructureRoles: infrastructureRoles,
 		PodServiceAccount:   c.PodServiceAccount,
+		ControllerNamespace: c.config.Namespace,
 	}
 }
 

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -25,6 +25,7 @@ func (c *Controller) makeClusterConfig() cluster.Config {
 	}
 
 	return cluster.Config{
+		ControllerConfig:    c.config,
 		RestConfig:          c.config.RestConfig,
 		OpConfig:            config.Copy(c.opConfig),
 		InfrastructureRoles: infrastructureRoles,


### PR DESCRIPTION
Currently, the controller must be deployed in the default namespace in order for logical backups to
work. Logical backups should work regardless of the namespace the controller is deployed in.