### PR TITLE
inject cluster name label into logical backup pod

### DIFF
--- a/docker/logical-backup/dump.sh
+++ b/docker/logical-backup/dump.sh
@@ -16,7 +16,6 @@ DUMP_SIZE_COEFF=5
 TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
 K8S_API_URL=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT
 CERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-CLUSTER_NAME_LABEL=cluster-name
 
 function estimate_size {
     "$PG_BIN"/psql -tqAc "${ALL_DB_SIZE_QUERY}"
@@ -61,40 +60,10 @@ function get_current_pod {
 }
 
 declare -a search_strategy=(
-    get_cluster_name_label
     list_all_replica_pods_current_node
     list_all_replica_pods_any_node
     get_master_pod
 )
-
-function get_config_resource() {
-    curl "${K8S_API_URL}/apis/apps/v1/namespaces/default/deployments/postgres-operator" \
-        --cacert $CERT   \
-        -H "Authorization: Bearer ${TOKEN}" | jq '.spec.template.spec.containers[0].env[] | select(.name == "$1") | .value'
-}
-
-function get_cluster_name_label {
-    local config
-    local clustername
-
-    config=$(get_config_resource "CONFIG_MAP_NAME")
-    if [ -n "$config" ]; then
-        clustername=$(curl "${K8S_API_URL}/api/v1/namespaces/default/configmaps/${config}" \
-                            --cacert $CERT   \
-                            -H "Authorization: Bearer ${TOKEN}" | jq '.data.cluster_name_label')
-    else
-        config=$(get_config_resource "POSTGRES_OPERATOR_CONFIGURATION_OBJECT")
-        if [ -n "$config" ]; then
-            clustername=$(curl "${K8S_API_URL}/apis/acid.zalan.do/v1/namespaces/default/operatorconfigurations/${config}" \
-                                --cacert $CERT   \
-                                -H "Authorization: Bearer ${TOKEN}" | jq '.configuration.kubernetes.cluster_name_label')
-        fi
-    fi
-
-    if [ -n "$clustername" ]; then
-        CLUSTER_NAME_LABEL=${clustername}
-    fi;
-}
 
 function list_all_replica_pods_current_node {
     get_pods "labelSelector=${CLUSTER_NAME_LABEL}%3D${SCOPE},spilo-role%3Dreplica&fieldSelector=spec.nodeName%3D${CURRENT_NODENAME}" | head -n 1

--- a/docker/logical-backup/dump.sh
+++ b/docker/logical-backup/dump.sh
@@ -14,7 +14,7 @@ PG_BIN=$PG_DIR/$PG_VERSION/bin
 DUMP_SIZE_COEFF=5
 
 TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-K8S_API_URL=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT
+K8S_API_URL=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/api/v1
 CERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 
 function estimate_size {
@@ -48,14 +48,14 @@ function aws_upload {
 function get_pods {
     declare -r SELECTOR="$1"
 
-    curl "${K8S_API_URL}/api/v1/namespaces/${POD_NAMESPACE}/pods?$SELECTOR"        \
-        --cacert $CERT                          \
+    curl "${K8S_API_URL}/namespaces/${POD_NAMESPACE}/pods?$SELECTOR" \
+        --cacert $CERT \
         -H "Authorization: Bearer ${TOKEN}" | jq .items[].status.podIP -r
 }
 
 function get_current_pod {
-    curl "${K8S_API_URL}/api/v1/namespaces/${POD_NAMESPACE}/pods?fieldSelector=metadata.name%3D${HOSTNAME}" \
-        --cacert $CERT   \
+    curl "${K8S_API_URL}/namespaces/${POD_NAMESPACE}/pods?fieldSelector=metadata.name%3D${HOSTNAME}" \
+        --cacert $CERT \
         -H "Authorization: Bearer ${TOKEN}"
 }
 

--- a/manifests/operator-service-account-rbac.yaml
+++ b/manifests/operator-service-account-rbac.yaml
@@ -106,12 +106,6 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - deployments
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
   - statefulsets
   verbs:
   - create

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -493,7 +493,7 @@ func generatePodTemplate(
 		Spec: podSpec,
 	}
 	if kubeIAMRole != "" {
-		if template.Annotations == nil{
+		if template.Annotations == nil {
 			template.Annotations = make(map[string]string)
 		}
 		template.Annotations[constants.KubeIAmAnnotation] = kubeIAMRole
@@ -967,7 +967,7 @@ func (c *Cluster) generatePodAnnotations(spec *acidv1.PostgresSpec) map[string]s
 			annotations[k] = v
 		}
 	}
-	
+
 	if len(annotations) == 0 {
 		return nil
 	}
@@ -1556,6 +1556,10 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 		{
 			Name:  "SCOPE",
 			Value: c.Name,
+		},
+		{
+			Name:  "CLUSTER_NAME_LABEL",
+			Value: c.OpConfig.ClusterNameLabel,
 		},
 		{
 			Name: "POD_NAMESPACE",


### PR DESCRIPTION
Why complicated querying for the cluster name label when we can inject it into the logical backup pod?

Closes: #718 
Fixes: #692 
Fixes: #642 

Thanks to
@bchrobot pointing out the limitation for calling resources only on the default namespace,
@OlleLarsson for checking config call and
@yujunz for raising the awareness of not using a hard-coded cluster name label