### PR TITLE
WIP: transition from Helm V2 crd-install hook to Helm v3 crds/

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -3,10 +3,8 @@ kind: CustomResourceDefinition
 metadata:
   name: operatorconfigurations.acid.zalan.do
   labels:
-    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
-    helm.sh/chart: {{ template "postgres-operator.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    #app.kubernetes.io/managed-by: {{ .Release.Service }}
+    #app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   group: acid.zalan.do
   names:

--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -1,0 +1,42 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: operatorconfigurations.acid.zalan.do
+  labels:
+    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
+    helm.sh/chart: {{ template "postgres-operator.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  group: acid.zalan.do
+  names:
+    kind: OperatorConfiguration
+    listKind: OperatorConfigurationList
+    plural: operatorconfigurations
+    singular: operatorconfiguration
+    shortNames:
+    - opconfig
+  additionalPrinterColumns:
+  - name: Image
+    type: string
+    description: Spilo image to be used for Pods
+    JSONPath: .configuration.docker_image
+  - name: Cluster-Label
+    type: string
+    description: Label for K8s resources created by operator
+    JSONPath: .configuration.kubernetes.cluster_name_label
+  - name: Service-Account
+    type: string
+    description: Name of service account to be used
+    JSONPath: .configuration.kubernetes.pod_service_account_name
+  - name: Min-Instances
+    type: integer
+    description: Minimum number of instances per Postgres cluster
+    JSONPath: .configuration.min_instances
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1

--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.crd.create }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -8,8 +7,6 @@ metadata:
     helm.sh/chart: {{ template "postgres-operator.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-  annotations:
-    "helm.sh/hook": crd-install
 spec:
   group: acid.zalan.do
   names:
@@ -55,49 +52,3 @@ spec:
   subresources:
     status: {}
   version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: operatorconfigurations.acid.zalan.do
-  labels:
-    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
-    helm.sh/chart: {{ template "postgres-operator.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-  annotations:
-    "helm.sh/hook": crd-install
-spec:
-  group: acid.zalan.do
-  names:
-    kind: OperatorConfiguration
-    listKind: OperatorConfigurationList
-    plural: operatorconfigurations
-    singular: operatorconfiguration
-    shortNames:
-    - opconfig
-  additionalPrinterColumns:
-  - name: Image
-    type: string
-    description: Spilo image to be used for Pods
-    JSONPath: .configuration.docker_image
-  - name: Cluster-Label
-    type: string
-    description: Label for K8s resources created by operator
-    JSONPath: .configuration.kubernetes.cluster_name_label
-  - name: Service-Account
-    type: string
-    description: Name of service account to be used
-    JSONPath: .configuration.kubernetes.pod_service_account_name
-  - name: Min-Instances
-    type: integer
-    description: Minimum number of instances per Postgres cluster
-    JSONPath: .configuration.min_instances
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
-  scope: Namespaced
-  subresources:
-    status: {}
-  version: v1
-{{ end }}

--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -3,10 +3,8 @@ kind: CustomResourceDefinition
 metadata:
   name: postgresqls.acid.zalan.do
   labels:
-    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
-    helm.sh/chart: {{ template "postgres-operator.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    #app.kubernetes.io/managed-by: {{ .Release.Service }}
+    #app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   group: acid.zalan.do
   names:


### PR DESCRIPTION
Hello. I tried installing postgres-operator with helm v3.

When I did the helm install, it gave me two of this warning:

> manifest_sorter.go:175: info: skipping unknown hook: "crd-install"

Diving into the [Helm hooks docs](https://v3.helm.sh/docs/topics/charts_hooks/), I found this information on the crd-install hook:

>  crd-install: In Helm 2, this executes after templates are rendered, but before the regular installation has been run. In Helm 3, this has been deprecated in favor of the crds/ directory.

In response to this, I moved the `template/customresourcedefinitions.yaml`  files into `crds/operatorconfigurations.yaml` and `crds/postgresqls.yaml` files. I then got some errors with the [templating in the labels](https://github.com/zalando/postgres-operator/compare/master...rektide:v3-helm#diff-63ecfcdb64b48f68d5685a8f34f19b30R6-R9), and created another commit to remove these labels, under the assumption that Helm v3 adds the right labels automatically.

This is still WIP, having some issues getting clean logs at startup, but I think this is a start on getting the chart to be Helm v3 compatible. I don't know what a good practice is for supporting Helm v2 AND Helm v3 users in this repo. Perhaps we need a charts/postgres-operator-v2 and charts/postgres-operator-v3 split? How are other projects handling Helm v3?   


