### PR TITLE
Update release image

### DIFF
--- a/charts/postgres-operator/values-crd.yaml
+++ b/charts/postgres-operator/values-crd.yaml
@@ -1,7 +1,7 @@
 image:
   registry: registry.opensource.zalan.do
   repository: acid/postgres-operator
-  tag: v1.3.0
+  tag: v1.3.0-1-gf2695c7f
   pullPolicy: "IfNotPresent"
 
 # Optionally specify an array of imagePullSecrets.

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -1,7 +1,7 @@
 image:
   registry: registry.opensource.zalan.do
   repository: acid/postgres-operator
-  tag: v1.3.0
+  tag: v1.3.0-1-gf2695c7f
   pullPolicy: "IfNotPresent"
 
 # Optionally specify an array of imagePullSecrets.

--- a/manifests/postgres-operator.yaml
+++ b/manifests/postgres-operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: zalando-postgres-operator
       containers:
       - name: postgres-operator
-        image: registry.opensource.zalan.do/acid/postgres-operator:v1.3.0
+        image: registry.opensource.zalan.do/acid/postgres-operator:v1.3.0-1-gf2695c7f
         imagePullPolicy: IfNotPresent
         resources:
           requests:


### PR DESCRIPTION
the current `v1.3.0` image does not reflect the `latest` state. This PR fixes it. 