### PR TITLE
reduce tracing of dumps and include Pg12

### DIFF
--- a/docker/logical-backup/Dockerfile
+++ b/docker/logical-backup/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update     \
     && curl --silent https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
     && apt-get install --no-install-recommends -y  \
+        postgresql-client-12  \
         postgresql-client-11  \
         postgresql-client-10  \
         postgresql-client-9.6 \
@@ -28,6 +29,6 @@ RUN apt-get update     \
 
 COPY dump.sh ./
 
-ENV PG_DIR=/usr/lib/postgresql/
+ENV PG_DIR=/usr/lib/postgresql
 
 ENTRYPOINT ["/dump.sh"]


### PR DESCRIPTION
* enable and disable tracing only for dump - S3 upload pipeline to avoid logging tokens
* use PIPESTATUS to print all error codes
* include Pg 12 client
* remove tailing `/` for PG_DIR env variable

fixes #790