### PR TITLE
add service for exposing operator api

### DIFF
--- a/charts/postgres-operator/templates/service.yaml
+++ b/charts/postgres-operator/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
+    helm.sh/chart: {{ template "postgres-operator.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ template "postgres-operator.fullname" . }}
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}


### PR DESCRIPTION
I added a k8s service (Helm template) for exposing the operator api. I needed it for running the UI as a separate pod.