### PR TITLE
standby clusters can only have 1 pod for now

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1051,6 +1051,7 @@ func (c *Cluster) getNumberOfInstances(spec *acidv1.PostgresSpec) int32 {
 	/* Limit the max number of pods to one, if this is standby-cluster */
 	if spec.StandbyCluster != nil {
 		c.logger.Info("Standby cluster can have maximum of 1 pod")
+		min = 1
 		max = 1
 	}
 	if max >= 0 && newcur > max {


### PR DESCRIPTION
If `min_instances` is configured to be > 1 (in case you always want a replica), standby cluster end up with two pods, which is currently not properly supported. Workaround would be to copy secrets from the source cluster.