### PR TITLE
Fix MasterPodMoveTimeout field that cannot be unmarshalled

### DIFF
--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -67,7 +67,7 @@ type KubernetesMetaConfiguration struct {
 	// TODO: use namespacedname
 	PodEnvironmentConfigMap    string        `json:"pod_environment_configmap,omitempty"`
 	PodPriorityClassName       string        `json:"pod_priority_class_name,omitempty"`
-	MasterPodMoveTimeout       time.Duration `json:"master_pod_move_timeout,omitempty"`
+	MasterPodMoveTimeout       Duration      `json:"master_pod_move_timeout,omitempty"`
 	EnablePodAntiAffinity      bool          `json:"enable_pod_antiaffinity,omitempty"`
 	PodAntiAffinityTopologyKey string        `json:"pod_antiaffinity_topology_key,omitempty"`
 	PodManagementPolicy        string        `json:"pod_management_policy,omitempty"`

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -66,7 +66,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.NodeReadinessLabel = fromCRD.Kubernetes.NodeReadinessLabel
 	result.PodPriorityClassName = fromCRD.Kubernetes.PodPriorityClassName
 	result.PodManagementPolicy = fromCRD.Kubernetes.PodManagementPolicy
-	result.MasterPodMoveTimeout = fromCRD.Kubernetes.MasterPodMoveTimeout
+	result.MasterPodMoveTimeout = time.Duration(fromCRD.Kubernetes.MasterPodMoveTimeout)
 	result.EnablePodAntiAffinity = fromCRD.Kubernetes.EnablePodAntiAffinity
 	result.PodAntiAffinityTopologyKey = fromCRD.Kubernetes.PodAntiAffinityTopologyKey
 


### PR DESCRIPTION
I tried using the default CRD-based operator configuration from [here](https://github.com/zalando/postgres-operator/blob/master/manifests/operatorconfiguration.crd.yaml), but it failed:

```
time="2020-02-05T13:48:02Z" level=fatal msg="unable to read operator configuration: could not get operator configuration object \"postgres-operator-configuration\": v1.OperatorConfiguration.Configuration: v1.OperatorConfigurationData.Kubernetes: v1.KubernetesMetaConfiguration.MasterPodMoveTimeout: readUint64: unexpected character: \xff, error found in #10 byte of ...|timeout\":\"20m\",\"oaut|..., bigger context ...|\"enable_sidecars\":true,\"master_pod_move_timeout\":\"20m\",\"oauth_token_secret_name\":\"postgresql-operato|..." pkg=controller
```

From what I can tell,  attempting to unmarshal the `MasterPodMoveTimeout` field from a CRD-based operator configuration fails because the `time.Duration` type is not unmarshallable.

The solution to this seems to be to use the `Duration` type instead:

https://github.com/zalando/postgres-operator/blob/8794e4f9acad87c8acbb0e4dd13b952fcd38f89e/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go#L192-L193

That type seems to be what's consistently used for other fields, and it is unmarshallable:

https://github.com/zalando/postgres-operator/blob/8794e4f9acad87c8acbb0e4dd13b952fcd38f89e/pkg/apis/acid.zalan.do/v1/marshal.go#L128-L152

I've tested locally and with this change the error disappeared.