### PR TITLE
switch to rbac/v1

### DIFF
--- a/charts/postgres-operator-ui/templates/serviceaccount.yaml
+++ b/charts/postgres-operator-ui/templates/serviceaccount.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "postgres-operator-ui.name" . }}
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/name: {{ template "postgres-operator-ui.name" . }}
     helm.sh/chart: {{ template "postgres-operator-ui.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}  
+    app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
 - apiGroups:
   - acid.zalan.do

--- a/charts/postgres-operator/templates/clusterrole.yaml
+++ b/charts/postgres-operator/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "postgres-operator.serviceAccountName" . }}

--- a/manifests/operator-service-account-rbac.yaml
+++ b/manifests/operator-service-account-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: zalando-postgres-operator

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -15,7 +15,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	policybeta1 "k8s.io/api/policy/v1beta1"
-	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -30,6 +29,7 @@ import (
 	"github.com/zalando/postgres-operator/pkg/util/patroni"
 	"github.com/zalando/postgres-operator/pkg/util/teams"
 	"github.com/zalando/postgres-operator/pkg/util/users"
+	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var (
@@ -45,7 +45,7 @@ type Config struct {
 	RestConfig                   *rest.Config
 	InfrastructureRoles          map[string]spec.PgUser // inherited from the controller
 	PodServiceAccount            *v1.ServiceAccount
-	PodServiceAccountRoleBinding *rbacv1beta1.RoleBinding
+	PodServiceAccountRoleBinding *rbacv1.RoleBinding
 }
 
 type kubeResources struct {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -15,6 +15,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	policybeta1 "k8s.io/api/policy/v1beta1"
+	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -29,7 +30,6 @@ import (
 	"github.com/zalando/postgres-operator/pkg/util/patroni"
 	"github.com/zalando/postgres-operator/pkg/util/teams"
 	"github.com/zalando/postgres-operator/pkg/util/users"
-	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 )
 
 var (

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
-	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -57,7 +57,7 @@ type Controller struct {
 	workerLogs map[uint32]ringlog.RingLogger
 
 	PodServiceAccount            *v1.ServiceAccount
-	PodServiceAccountRoleBinding *rbacv1beta1.RoleBinding
+	PodServiceAccountRoleBinding *rbacv1.RoleBinding
 }
 
 // NewController creates a new controller
@@ -198,7 +198,7 @@ func (c *Controller) initRoleBinding() {
 	if c.opConfig.PodServiceAccountRoleBindingDefinition == "" {
 		c.opConfig.PodServiceAccountRoleBindingDefinition = fmt.Sprintf(`
 		{
-			"apiVersion": "rbac.authorization.k8s.io/v1beta1",
+			"apiVersion": "rbac.authorization.k8s.io/v1",
 			"kind": "RoleBinding",
 			"metadata": {
 				   "name": "%s"
@@ -227,7 +227,7 @@ func (c *Controller) initRoleBinding() {
 	case groupVersionKind.Kind != "RoleBinding":
 		panic(fmt.Errorf("role binding definition in the operator config map defines another type of resource: %v", groupVersionKind.Kind))
 	default:
-		c.PodServiceAccountRoleBinding = obj.(*rbacv1beta1.RoleBinding)
+		c.PodServiceAccountRoleBinding = obj.(*rbacv1.RoleBinding)
 		c.PodServiceAccountRoleBinding.Namespace = ""
 		c.logger.Info("successfully parsed")
 

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -18,7 +18,7 @@ import (
 	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	policyv1beta1 "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
-	rbacv1beta1 "k8s.io/client-go/kubernetes/typed/rbac/v1beta1"
+	rbacv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -39,7 +39,7 @@ type KubernetesClient struct {
 	corev1.NamespacesGetter
 	corev1.ServiceAccountsGetter
 	appsv1.StatefulSetsGetter
-	rbacv1beta1.RoleBindingsGetter
+	rbacv1.RoleBindingsGetter
 	policyv1beta1.PodDisruptionBudgetsGetter
 	apiextbeta1.CustomResourceDefinitionsGetter
 	clientbatchv1beta1.CronJobsGetter
@@ -103,7 +103,7 @@ func NewFromConfig(cfg *rest.Config) (KubernetesClient, error) {
 	kubeClient.StatefulSetsGetter = client.AppsV1()
 	kubeClient.PodDisruptionBudgetsGetter = client.PolicyV1beta1()
 	kubeClient.RESTClient = client.CoreV1().RESTClient()
-	kubeClient.RoleBindingsGetter = client.RbacV1beta1()
+	kubeClient.RoleBindingsGetter = client.RbacV1()
 	kubeClient.CronJobsGetter = client.BatchV1beta1()
 
 	apiextClient, err := apiextclient.NewForConfig(cfg)

--- a/ui/manifests/ui-service-account-rbac.yaml
+++ b/ui/manifests/ui-service-account-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: postgres-operator-ui


### PR DESCRIPTION
TL;DR: first change RBAC apiVersion, then enable namespaced roles

Deploying the operator with namespaced roles support (see #786) creates the `postgres-pod` role in each namespace. If we want to bind to a clusterrole instead we must then overwrite the [internal definition](https://github.com/zalando/postgres-operator/blob/3b10dc645dd3f4112df7d15042f335b86c01b3fc/pkg/controller/controller.go#L199) by setting the `pod_service_account_role_binding_definition` in the configmap. So we should first configure the operator and then deploy.

And here's the problem: When changing the RBAC version within the same PR, the apiVersion in the role definition must be of version `v1` do be supported by the new operator. But the current operator only understands `v1beta1`. Everything could be done in one go, but it's safer to do this step here first. Everyone using these definition options must switch to `v1` then, but they would need to do this anyway at some point.