### PR TITLE
Fix test flakiness on TestSameService

### DIFF
--- a/pkg/util/k8sutil/k8sutil_test.go
+++ b/pkg/util/k8sutil/k8sutil_test.go
@@ -20,7 +20,7 @@ func newsService(ann map[string]string, svcT v1.ServiceType, lbSr []string) *v1.
 	return svc
 }
 
-func TestServiceAnnotations(t *testing.T) {
+func TestSameService(t *testing.T) {
 	tests := []struct {
 		about   string
 		current *v1.Service
@@ -267,8 +267,9 @@ func TestServiceAnnotations(t *testing.T) {
 				},
 				v1.ServiceTypeLoadBalancer,
 				[]string{"128.141.0.0/16", "137.138.0.0/16"}),
-			match:  false,
-			reason: `new service's annotations doesn't match the current one: Removed 'foo'. Added 'bar' with value 'foo'. 'zalan' changed from 'do' to 'do.com'`,
+			match: false,
+			// Test just the prefix to avoid flakiness and map sorting
+			reason: `new service's annotations doesn't match the current one: Removed 'foo'.`,
 		},
 		{
 			about: "service add annotations",
@@ -301,7 +302,7 @@ func TestServiceAnnotations(t *testing.T) {
 			}
 			if !match && !tt.match {
 				if !strings.HasPrefix(reason, tt.reason) {
-					t.Errorf("expected reason '%s', found '%s'", tt.reason, reason)
+					t.Errorf("expected reason prefix '%s', found '%s'", tt.reason, reason)
 					return
 				}
 			}


### PR DESCRIPTION
The code added on #818 depends on map sorting to return a static reason
for service annotation changes. To avoid tests flakiness and map sorting
the tests include a `strings.HasPrefix` instead of comparing the whole
string. One of the test cases,
`service_removes_a_custom_annotation,_adds_a_new_one_and_change_another`,
is trying to test the whole reason string.

This commit replaces the test case reason, for only the reason prefix.
It removes the flakiness from the tests. As all the cases (annotation
adding, removing and value changing) are tested before, it's safe to
test only prefixes.

Also, it renames the test name from `TestServiceAnnotations` to
`TestSameService` and introduces a better description in case of test
failure, describing that only prefixes are tested.