### PR TITLE
added pinned werkzeug dep to UI requirements

### DIFF
--- a/ui/requirements.txt
+++ b/ui/requirements.txt
@@ -12,3 +12,4 @@ kubernetes==3.0.0
 requests==2.22.0
 stups-tokens>=1.1.19
 wal_e==1.1.0
+werkzeug==0.16.1


### PR DESCRIPTION
since werkzeug 1.0.0 flask has [problems](https://github.com/pallets/werkzeug/issues/1714). Pinning last version before 1.0.0

logs from UI pod after applying the manifests
```
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/operator_ui/__main__.py", line 1, in <module>
    from .main import main
  File "/operator_ui/main.py", line 25, in <module>
    from flask_oauthlib.client import OAuth
  File "/usr/lib/python3.6/site-packages/flask_oauthlib/client.py", line 18, in <module>
    from werkzeug import url_quote, url_decode, url_encode
ImportError: cannot import name 'url_quote'
```