### PR TITLE
be more permissive with standbys

### DIFF
--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -11,11 +11,11 @@ switchover (planned failover) of the master to the Pod with new minor version.
 The switch should usually take less than 5 seconds, still clients have to
 reconnect.
 
-Major version upgrades are supported via [cloning](user.md#clone-directly). The
-new cluster manifest must have a higher `version` string than the source cluster
-and will be created from a basebackup. Depending of the cluster size, downtime
-in this case can be significant as writes to the database should be stopped and
-all WAL files should be archived first before cloning is started.
+Major version upgrades are supported via [cloning](user.md#how-to-clone-an-existing-postgresql-cluster).
+The new cluster manifest must have a higher `version` string than the source
+cluster and will be created from a basebackup. Depending of the cluster size,
+downtime in this case can be significant as writes to the database should be
+stopped and all WAL files should be archived first before cloning is started.
 
 Note, that simply changing the version string in the `postgresql` manifest does
 not work at present and leads to errors. Neither Patroni nor Postgres Operator

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -110,8 +110,9 @@ Those are top-level keys, containing both leaf keys and groups.
 
 * **min_instances**
   operator will run at least the number of instances for any given Postgres
-  cluster equal to the value of this parameter. When `-1` is specified, no
-  limits are applied. The default is `-1`.
+  cluster equal to the value of this parameter, except for standby clusters
+  which run with one pod if `numberOfInstances` is set to 1. When `-1` is
+  specified for `min_instances`, no limits are applied. The default is `-1`.
 
 * **resync_period**
   period between consecutive sync requests. The default is `30m`.

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -110,9 +110,10 @@ Those are top-level keys, containing both leaf keys and groups.
 
 * **min_instances**
   operator will run at least the number of instances for any given Postgres
-  cluster equal to the value of this parameter, except for standby clusters
-  which run with one pod if `numberOfInstances` is set to 1. When `-1` is
-  specified for `min_instances`, no limits are applied. The default is `-1`.
+  cluster equal to the value of this parameter. Standby clusters can still run
+  with `numberOfInstances: 1` as this is the [recommended setup](../user.md#setting-up-a-standby-cluster).
+  When `-1` is specified for `min_instances`, no limits are applied. The default
+  is `-1`.
 
 * **resync_period**
   period between consecutive sync requests. The default is `30m`.

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1049,11 +1049,11 @@ func (c *Cluster) getNumberOfInstances(spec *acidv1.PostgresSpec) int32 {
 	newcur := cur
 
 	if spec.StandbyCluster != nil {
-		if newcur > 1 {
-			c.logger.Warningf("operator only supports standby clusters with 1 pod")
-		} else {
+		if newcur == 1 {
 			min = newcur
 			max = newcur
+		} else {
+			c.logger.Warningf("operator only supports standby clusters with 1 pod")
 		}
 	}
 	if max >= 0 && newcur > max {

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1048,11 +1048,13 @@ func (c *Cluster) getNumberOfInstances(spec *acidv1.PostgresSpec) int32 {
 	cur := spec.NumberOfInstances
 	newcur := cur
 
-	/* Limit the max number of pods to one, if this is standby-cluster */
 	if spec.StandbyCluster != nil {
-		c.logger.Info("Standby cluster can have maximum of 1 pod")
-		min = 1
-		max = 1
+		if newcur > 1 {
+			c.logger.Warningf("operator only supports standby clusters with 1 pod")
+		} else {
+			min = newcur
+			max = newcur
+		}
 	}
 	if max >= 0 && newcur > max {
 		newcur = max


### PR DESCRIPTION
If somebody is already running a standby with more than one instance, the operator should not terminate the replicas, but give a warning instead that we recommend `1`.

The docs on standby clusters should also be more clear now on what is possible and how to set it up.