### PR TITLE
Change `logging_rest_api.api_port` to `8080` instead of `8008`

### DIFF
--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -110,7 +110,7 @@ configuration:
       log_statement: all
     # teams_api_url: ""
   logging_rest_api:
-    api_port: 8008
+    api_port: 8080
     cluster_history_entries: 1000
     ring_log_lines: 100
   scalyr:


### PR DESCRIPTION
The documentation states that the default operator REST service is at port `8080`, but the current default CRD based configuration is `8008`. Changing the default config to match documentation.