### PR TITLE
Update Kind to version 0.8.1 (Kubernetes 1.18.0) 

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -42,7 +42,7 @@ push: docker
 
 tools: docker
 	# install pinned version of 'kind'
-	GO111MODULE=on go get sigs.k8s.io/kind@v0.7.0
+	GO111MODULE=on go get sigs.k8s.io/kind@v0.8.1
 
 e2etest:
 	./run.sh

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -42,7 +42,7 @@ push: docker
 
 tools: docker
 	# install pinned version of 'kind'
-	GO111MODULE=on go get sigs.k8s.io/kind@v0.5.1
+	GO111MODULE=on go get sigs.k8s.io/kind@v0.7.0
 
 e2etest:
 	./run.sh

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,3 +1,3 @@
-kubernetes==9.0.0
+kubernetes==11.0.0
 timeout_decorator==0.4.1
 pyyaml==5.1

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -45,13 +45,12 @@ function set_kind_api_server_ip(){
   # use the actual kubeconfig to connect to the 'kind' API server
   # but update the IP address of the API server to the one from the Docker 'bridge' network
   readonly local kind_api_server_port=6443 # well-known in the 'kind' codebase
-  readonly local kind_api_server=$(docker inspect --format "{{ .NetworkSettings.IPAddress }}:${kind_api_server_port}" "${cluster_name}"-control-plane)
+  readonly local kind_api_server=$(docker inspect --format "{{ .NetworkSettings.Networks.kind.IPAddress }}:${kind_api_server_port}" "${cluster_name}"-control-plane)
   sed -i "s/server.*$/server: https:\/\/$kind_api_server/g" "${kubeconfig_path}"
 }
 
 function run_tests(){
-
-  docker run --rm --mount type=bind,source="$(readlink -f ${kubeconfig_path})",target=/root/.kube/config -e OPERATOR_IMAGE="${operator_image}" "${e2e_test_image}"
+  docker run --rm --network kind --mount type=bind,source="$(readlink -f ${kubeconfig_path})",target=/root/.kube/config -e OPERATOR_IMAGE="${operator_image}" "${e2e_test_image}"
 }
 
 function clean_up(){

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -35,17 +35,15 @@ function start_kind(){
     kind delete cluster --name ${cluster_name}
   fi
 
+  export KUBECONFIG="${kubeconfig_path}"
   kind create cluster --name ${cluster_name} --config kind-cluster-postgres-operator-e2e-tests.yaml
   kind load docker-image "${operator_image}" --name ${cluster_name}
   kind load docker-image "${e2e_test_image}" --name ${cluster_name}
-  KUBECONFIG="$(kind get kubeconfig-path --name=${cluster_name})"
-  export KUBECONFIG
 }
 
 function set_kind_api_server_ip(){
   # use the actual kubeconfig to connect to the 'kind' API server
   # but update the IP address of the API server to the one from the Docker 'bridge' network
-  cp "${KUBECONFIG}" /tmp
   readonly local kind_api_server_port=6443 # well-known in the 'kind' codebase
   readonly local kind_api_server=$(docker inspect --format "{{ .NetworkSettings.IPAddress }}:${kind_api_server_port}" "${cluster_name}"-control-plane)
   sed -i "s/server.*$/server: https:\/\/$kind_api_server/g" "${kubeconfig_path}"


### PR DESCRIPTION
It would be nice if the e2e tests would run on a more recent kind version. Since most of the k8s versions are newer, it makes sense to test the operator with a more recent api. 

- [x] Adjust _kubeconfig_ management according to https://github.com/kubernetes-sigs/kind/pull/1029.
- [x] Update [kind](https://github.com/kubernetes-sigs/kind) from 0.5.1 -> 0.70