### PR TITLE
enable controllerID for chart and allow configurable pod cluster role

### DIFF
--- a/charts/postgres-operator/templates/_helpers.tpl
+++ b/charts/postgres-operator/templates/_helpers.tpl
@@ -32,6 +32,20 @@ Create a service account name.
 {{- end -}}
 
 {{/*
+Create a pod service account name.
+*/}}
+{{- define "postgres-pod.serviceAccountName" -}}
+{{ default (printf "%s-%v" (include "postgres-operator.fullname" .) "pod") .Values.podServiceAccount.name }}
+{{- end -}}
+
+{{/*
+Create a controller ID.
+*/}}
+{{- define "postgres-operator.controllerID" -}}
+{{ default (include "postgres-operator.fullname" .) .Values.controllerID.name }}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "postgres-operator.chart" -}}

--- a/charts/postgres-operator/templates/clusterrole-postgres-pod.yaml
+++ b/charts/postgres-operator/templates/clusterrole-postgres-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: postgres-pod
+  name: {{ include "postgres-pod.serviceAccountName" . }}
   labels:
     app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
     helm.sh/chart: {{ template "postgres-operator.chart" . }}

--- a/charts/postgres-operator/templates/configmap.yaml
+++ b/charts/postgres-operator/templates/configmap.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 data:
+  pod_service_account_name: {{ include "postgres-pod.serviceAccountName" . }}
 {{ toYaml .Values.configGeneral | indent 2 }}
 {{ toYaml .Values.configUsers | indent 2 }}
 {{ toYaml .Values.configKubernetes | indent 2 }}

--- a/charts/postgres-operator/templates/deployment.yaml
+++ b/charts/postgres-operator/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
         - name: POSTGRES_OPERATOR_CONFIGURATION_OBJECT
           value: {{ template "postgres-operator.fullname" . }}
       {{- end }}
+      {{- if .Values.controllerID.create }}
+        - name: CONTROLLER_ID
+          value: {{ template "postgres-operator.controllerID" . }}
+      {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       {{- if .Values.imagePullSecrets }}

--- a/charts/postgres-operator/templates/operatorconfiguration.yaml
+++ b/charts/postgres-operator/templates/operatorconfiguration.yaml
@@ -13,6 +13,7 @@ configuration:
   users:
 {{ toYaml .Values.configUsers | indent 4 }}
   kubernetes:
+    pod_service_account_name: {{ include "postgres-pod.serviceAccountName" . }}
     oauth_token_secret_name: {{ template "postgres-operator.fullname" . }}
 {{ toYaml .Values.configKubernetes | indent 4 }}
   postgres_pod_resources:

--- a/charts/postgres-operator/values-crd.yaml
+++ b/charts/postgres-operator/values-crd.yaml
@@ -103,8 +103,6 @@ configKubernetes:
   # service account definition as JSON/YAML string to be used by postgres cluster pods
   # pod_service_account_definition: ""
 
-  # name of service account to be used by postgres cluster pods
-  pod_service_account_name: "postgres-pod"
   # role binding definition as JSON/YAML string to be used by pod service account
   # pod_service_account_role_binding_definition: ""
 
@@ -284,6 +282,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+podServiceAccount:
+  # The name of the ServiceAccount to be used by postgres cluster pods
+  # If not set a name is generated using the fullname template and "-pod" suffix
+  name: "postgres-pod"
+
 priorityClassName: ""
 
 resources:
@@ -305,3 +308,12 @@ tolerations: []
 # Node labels for pod assignment
 # Ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
+
+controllerID:
+  # Specifies whether a controller ID should be defined for the operator
+  # Note, all postgres manifest must then contain the following annotation to be found by this operator
+  # "acid.zalan.do/controller": <controller-ID-of-the-operator>
+  create: false
+  # The name of the controller ID to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -96,8 +96,6 @@ configKubernetes:
   # service account definition as JSON/YAML string to be used by postgres cluster pods
   # pod_service_account_definition: ""
 
-  # name of service account to be used by postgres cluster pods
-  pod_service_account_name: "postgres-pod"
   # role binding definition as JSON/YAML string to be used by pod service account
   # pod_service_account_role_binding_definition: ""
 
@@ -260,6 +258,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+podServiceAccount:
+  # The name of the ServiceAccount to be used by postgres cluster pods
+  # If not set a name is generated using the fullname template and "-pod" suffix
+  name: "postgres-pod"
+
 priorityClassName: ""
 
 resources:
@@ -281,3 +284,12 @@ tolerations: []
 # Node labels for pod assignment
 # Ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
+
+controllerID:
+  # Specifies whether a controller ID should be defined for the operator
+  # Note, all postgres manifest must then contain the following annotation to be found by this operator
+  # "acid.zalan.do/controller": <controller-ID-of-the-operator>
+  create: false
+  # The name of the controller ID to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:


### PR DESCRIPTION
The PR fixes #875 and also adds the controller ID feature introduced with #802.
The pod service account name will be `postgres-pod` by default, but it can also be generated by helm. The controller ID is not defined by default.