### PR TITLE
TLS - add OpenShift compatibility

### DIFF
--- a/docs/user.md
+++ b/docs/user.md
@@ -572,12 +572,15 @@ However, this certificate cannot be verified and thus doesn't protect from
 active MITM attacks. In this section we show how to specify a custom TLS
 certificate which is mounted in the database pods via a K8s Secret.
 
-Before applying these changes, in k8s (not in OpenShift) the operator must also 
-be configured with the `spilo_fsgroup` set to the GID matching the postgres user 
-group. If you don't know the value, use `103` which is the GID from the default 
-spilo image (`spilo_fsgroup=103` in the cluster request spec).
-If the value is not provided and you are in k8s (not OpenShift), the certificates 
-will not have proper permissions and the server will not work as desired.
+Before applying these changes, in k8s the operator must also be configured with
+the `spilo_fsgroup` set to the GID matching the postgres user group. If you
+don't know the value, use `103` which is the GID from the default spilo image
+(`spilo_fsgroup=103` in the cluster request spec).
+
+OpenShift allocates the users and groups dynamically (based on scc), and their
+range is different in every namespace. Due to this dynamic behaviour, it's not
+trivial to know at deploy time the uid/gid of the user in the cluster.
+This way, in OpenShift, you may want to skip the spilo_fsgroup setting.
 
 Upload the cert as a kubernetes secret:
 ```sh

--- a/docs/user.md
+++ b/docs/user.md
@@ -572,10 +572,12 @@ However, this certificate cannot be verified and thus doesn't protect from
 active MITM attacks. In this section we show how to specify a custom TLS
 certificate which is mounted in the database pods via a K8s Secret.
 
-Before applying these changes, the operator must also be configured with the
-`spilo_fsgroup` set to the GID matching the postgres user group. If the value
-is not provided, the cluster will default to `103` which is the GID from the
-default spilo image.
+Before applying these changes, in k8s (not in OpenShift) the operator must also 
+be configured with the `spilo_fsgroup` set to the GID matching the postgres user 
+group. If you don't know the value, use `103` which is the GID from the default 
+spilo image (`spilo_fsgroup=103` in the cluster request spec).
+If the value is not provided and you are in k8s (not OpenShift), the certificates 
+will not have proper permissions and the server will not work as desired.
 
 Upload the cert as a kubernetes secret:
 ```sh

--- a/manifests/complete-postgres-manifest.yaml
+++ b/manifests/complete-postgres-manifest.yaml
@@ -109,3 +109,5 @@ spec:
     certificateFile: "tls.crt"
     privateKeyFile: "tls.key"
     caFile: ""  # optionally configure Postgres with a CA certificate
+# When TLS is enabled, also set spiloFSGroup parameter above to the relevant value.
+# if unknown, set it to 103 which is the usual value in the default spilo images.

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -980,8 +980,8 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 
 	// configure TLS with a custom secret volume
 	if spec.TLS != nil && spec.TLS.SecretName != "" {
-		// this is combined with the FSGroup in the section above will
-		// give read access to the postgres user
+		// this is combined with the FSGroup in the section above
+		// to give read access to the postgres user
 		defaultMode := int32(0640)
 		volumes = append(volumes, v1.Volume{
 			Name: "tls-secret",

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -36,9 +36,6 @@ const (
 	localHost                        = "127.0.0.1/32"
 	connectionPoolContainer          = "connection-pool"
 	pgPort                           = 5432
-
-	// the gid of the postgres user in the default spilo image
-	spiloPostgresGID = 103
 )
 
 type pgUser struct {
@@ -983,13 +980,8 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 
 	// configure TLS with a custom secret volume
 	if spec.TLS != nil && spec.TLS.SecretName != "" {
-		if effectiveFSGroup == nil {
-			c.logger.Warnf("Setting the default FSGroup to satisfy the TLS configuration")
-			fsGroup := int64(spiloPostgresGID)
-			effectiveFSGroup = &fsGroup
-		}
-		// this is combined with the FSGroup above to give read access to the
-		// postgres user
+		// this is combined with the FSGroup in the section above will
+		// give read access to the postgres user
 		defaultMode := int32(0640)
 		volumes = append(volumes, v1.Volume{
 			Name: "tls-secret",


### PR DESCRIPTION
Adds OpenShift compatibility by removing forced injection of fsGroup.
In it's current format, there is no workaround to use TLS in non-priviledged, non-root OpenShift, where fsGroup **must not be set** , as it's dynamically allocated at creation time.
Solves: https://github.com/zalando/postgres-operator/pull/798#issuecomment-605201260
@zimbatm and @FxKu - please review.