### PR TITLE
Disable WAL archiving

### DIFF
--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -197,6 +197,8 @@ spec:
                 type: boolean
               enableLogicalBackup:
                 type: boolean
+              enableWALArchiving:
+                type: boolean
               enableMasterLoadBalancer:
                 type: boolean
               enableReplicaLoadBalancer:

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -184,6 +184,10 @@ These parameters are grouped directly under  the `spec` key in the manifest.
   If `targetContainers` is empty, additional volumes will be mounted only in the `postgres` container.
   If you set the `all` special item, it will be mounted in all containers (postgres + sidecars).
   Else you can set the list of target containers in which the additional volumes will be mounted (eg : postgres, telegraf)
+  
+* **EnableWALArchiving**
+  Enables archiving of WAL logs and uploading to S3. If set to false the WAL_S3_BUCKET environment variable 
+  in the operator configuration will be overridden to blank which tells Spilo to skip WAL archiving. Default: true. Optional.
 
 ## Postgres parameters
 

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -193,6 +193,8 @@ spec:
                 type: boolean
               enableLogicalBackup:
                 type: boolean
+              enableWALArchiving:
+                type: boolean
               enableMasterLoadBalancer:
                 type: boolean
               enableReplicaLoadBalancer:

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -300,6 +300,9 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 					"enableLogicalBackup": {
 						Type: "boolean",
 					},
+					"enableWALArchiving": {
+						Type: "boolean",
+					},
 					"enableMasterLoadBalancer": {
 						Type: "boolean",
 					},

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -74,6 +74,7 @@ type PostgresSpec struct {
 	ServiceAnnotations    map[string]string           `json:"serviceAnnotations,omitempty"`
 	TLS                   *TLSDescription             `json:"tls,omitempty"`
 	AdditionalVolumes     []AdditionalVolume          `json:"additionalVolumes,omitempty"`
+	EnableWALArchiving    bool                        `json:"enableWALArchiving,omitempty" defaults:"true"`
 
 	// deprecated json tags
 	InitContainersOld       []v1.Container `json:"init_containers,omitempty"`

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -657,7 +657,7 @@ func (c *Cluster) generatePodTemplate(
 }
 
 // generatePodEnvVars generates environment variables for the Spilo Pod
-func (c *Cluster) generateSpiloPodEnvVars(uid types.UID, spiloConfiguration string, cloneDescription *acidv1.CloneDescription, standbyDescription *acidv1.StandbyDescription, customPodEnvVarsList []v1.EnvVar) []v1.EnvVar {
+func (c *Cluster) generateSpiloPodEnvVars(uid types.UID, spiloConfiguration string, cloneDescription *acidv1.CloneDescription, standbyDescription *acidv1.StandbyDescription, enableWALArchiving bool, customPodEnvVarsList []v1.EnvVar) []v1.EnvVar {
 	envVars := []v1.EnvVar{
 		{
 			Name:  "SCOPE",
@@ -769,7 +769,7 @@ func (c *Cluster) generateSpiloPodEnvVars(uid types.UID, spiloConfiguration stri
 		envVars = append(envVars, customPodEnvVarsList...)
 	}
 
-	if c.OpConfig.WALES3Bucket != "" {
+	if c.OpConfig.WALES3Bucket != "" && enableWALArchiving {
 		envVars = append(envVars, v1.EnvVar{Name: "WAL_S3_BUCKET", Value: c.OpConfig.WALES3Bucket})
 		envVars = append(envVars, v1.EnvVar{Name: "WAL_BUCKET_SCOPE_SUFFIX", Value: getBucketScopeSuffix(string(uid))})
 		envVars = append(envVars, v1.EnvVar{Name: "WAL_BUCKET_SCOPE_PREFIX", Value: ""})
@@ -1073,6 +1073,7 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 		spiloConfiguration,
 		spec.Clone,
 		spec.StandbyCluster,
+		spec.EnableWALArchiving,
 		customPodEnvVarsList,
 	)
 

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -168,6 +168,7 @@ func TestGenerateSpiloPodEnvVars(t *testing.T) {
 		standbyDescription *acidv1.StandbyDescription
 		customEnvList      []v1.EnvVar
 		expectedValues     []ExpectedValue
+		enableWALArchiving bool
 	}{
 		{
 			subTest: "Will set WAL_GS_BUCKET env",
@@ -180,6 +181,7 @@ func TestGenerateSpiloPodEnvVars(t *testing.T) {
 			standbyDescription: &acidv1.StandbyDescription{},
 			customEnvList:      []v1.EnvVar{},
 			expectedValues:     expectedValuesGSBucket,
+			enableWALArchiving: true,
 		},
 		{
 			subTest: "Will set GOOGLE_APPLICATION_CREDENTIALS env",
@@ -193,13 +195,14 @@ func TestGenerateSpiloPodEnvVars(t *testing.T) {
 			standbyDescription: &acidv1.StandbyDescription{},
 			customEnvList:      []v1.EnvVar{},
 			expectedValues:     expectedValuesGCPCreds,
+			enableWALArchiving: true,
 		},
 	}
 
 	for _, tt := range tests {
 		cluster.OpConfig = tt.opConfig
 
-		actualEnvs := cluster.generateSpiloPodEnvVars(tt.uid, tt.spiloConfig, tt.cloneDescription, tt.standbyDescription, tt.customEnvList)
+		actualEnvs := cluster.generateSpiloPodEnvVars(tt.uid, tt.spiloConfig, tt.cloneDescription, tt.standbyDescription, tt.enableWALArchiving, tt.customEnvList)
 
 		for _, ev := range tt.expectedValues {
 			env := actualEnvs[ev.envIndex]


### PR DESCRIPTION
This PR adds a disableWALArchiving option in the cluster-spec allowing to override the WAL_S3_BUCKET environment variable and setting it to blank. This will tell Spilo to disable the WAL archiving.


Relevant Spilo code:
https://github.com/zalando/spilo/blob/01a3a99db55c6f4e38a29528fee4c6c7619d719a/postgres-appliance/scripts/configure_spilo.py#L999

https://github.com/zalando/spilo/blob/01a3a99db55c6f4e38a29528fee4c6c7619d719a/postgres-appliance/scripts/configure_spilo.py#L551

https://github.com/zalando/spilo/blob/01a3a99db55c6f4e38a29528fee4c6c7619d719a/postgres-appliance/scripts/configure_spilo.py#L42