### PR TITLE
when kubernetes_use_configmaps -> skip further endpoints actions even delete

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1168,10 +1168,10 @@ func (c *Cluster) deletePatroniClusterObjects() error {
 		c.logger.Infof("not cleaning up Etcd Patroni objects on cluster delete")
 	}
 
-	if c.patroniKubernetesUseConfigMaps() {
-		actionsList = append(actionList, c.deletePatroniClusterEndpoints)
+	if !c.patroniKubernetesUseConfigMaps() {
+		actionsList = append(actionsList, c.deletePatroniClusterEndpoints)
 	}
-	actionsList = append(actionList, c.deletePatroniClusterServices, c.deletePatroniClusterConfigMaps)
+	actionsList = append(actionsList, c.deletePatroniClusterServices, c.deletePatroniClusterConfigMaps)
 
 	c.logger.Debugf("removing leftover Patroni objects (endpoints / services and configmaps)")
 	for _, deleter := range actionsList {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1169,12 +1169,9 @@ func (c *Cluster) deletePatroniClusterObjects() error {
 	}
 
 	if c.patroniKubernetesUseConfigMaps() {
-		actionsList = []simpleActionWithResult{c.deletePatroniClusterServices, c.deletePatroniClusterConfigMaps}
-		c.logger.Debugf("removing leftover Patroni objects (services and configmaps)")
-	} else {
-		c.logger.Debugf("removing leftover Patroni objects (endpoints, services and configmaps)")
-		actionsList = []simpleActionWithResult{c.deletePatroniClusterEndpoints, c.deletePatroniClusterServices, c.deletePatroniClusterConfigMaps}
+		actionsList = append(actionList, c.deletePatroniClusterEndpoints)
 	}
+	actionsList = append(actionList, c.deletePatroniClusterServices, c.deletePatroniClusterConfigMaps)
 
 	for _, deleter := range actionsList {
 		if err := deleter(); err != nil {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -783,8 +783,10 @@ func (c *Cluster) Delete() {
 
 	for _, role := range []PostgresRole{Master, Replica} {
 
-		if err := c.deleteEndpoint(role); err != nil {
-			c.logger.Warningf("could not delete %s endpoint: %v", role, err)
+		if !c.patroniKubernetesUseConfigMaps() {
+			if err := c.deleteEndpoint(role); err != nil {
+				c.logger.Warningf("could not delete %s endpoint: %v", role, err)
+			}
 		}
 
 		if err := c.deleteService(role); err != nil {
@@ -1160,11 +1162,21 @@ type clusterObjectDelete func(name string) error
 
 func (c *Cluster) deletePatroniClusterObjects() error {
 	// TODO: figure out how to remove leftover patroni objects in other cases
+	var actionsList []simpleActionWithResult
+
 	if !c.patroniUsesKubernetes() {
 		c.logger.Infof("not cleaning up Etcd Patroni objects on cluster delete")
 	}
-	c.logger.Debugf("removing leftover Patroni objects (endpoints, services and configmaps)")
-	for _, deleter := range []simpleActionWithResult{c.deletePatroniClusterEndpoints, c.deletePatroniClusterServices, c.deletePatroniClusterConfigMaps} {
+
+	if c.patroniKubernetesUseConfigMaps() {
+		actionsList = []simpleActionWithResult{c.deletePatroniClusterServices, c.deletePatroniClusterConfigMaps}
+		c.logger.Debugf("removing leftover Patroni objects (services and configmaps)")
+	} else {
+		c.logger.Debugf("removing leftover Patroni objects (endpoints, services and configmaps)")
+		actionsList = []simpleActionWithResult{c.deletePatroniClusterEndpoints, c.deletePatroniClusterServices, c.deletePatroniClusterConfigMaps}
+	}
+
+	for _, deleter := range actionsList {
 		if err := deleter(); err != nil {
 			return err
 		}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1173,6 +1173,7 @@ func (c *Cluster) deletePatroniClusterObjects() error {
 	}
 	actionsList = append(actionList, c.deletePatroniClusterServices, c.deletePatroniClusterConfigMaps)
 
+	c.logger.Debugf("removing leftover Patroni objects (endpoints / services and configmaps)")
 	for _, deleter := range actionsList {
 		if err := deleter(); err != nil {
 			return err

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -122,10 +122,11 @@ func (c *Cluster) syncServices() error {
 	for _, role := range []PostgresRole{Master, Replica} {
 		c.logger.Debugf("syncing %s service", role)
 
-		if err := c.syncEndpoint(role); err != nil {
-			return fmt.Errorf("could not sync %s endpoint: %v", role, err)
+		if !c.patroniKubernetesUseConfigMaps() {
+			if err := c.syncEndpoint(role); err != nil {
+				return fmt.Errorf("could not sync %s endpoint: %v", role, err)
+			}
 		}
-
 		if err := c.syncService(role); err != nil {
 			return fmt.Errorf("could not sync %s service: %v", role, err)
 		}


### PR DESCRIPTION
code was still trying to remove endpoints even when kubernetes_use_configmaps was true (continuation of https://github.com/zalando/postgres-operator/pull/887)
It is desired to inhibit the delete as well, as there might be no perms to make any actions against them, so, to be on the safe side, we are inhibiting this delete when it is not required.