### PR TITLE
double check before recreate

### DIFF
--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"reflect"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -344,7 +343,7 @@ func (c *Cluster) recreatePods() error {
 		role := PostgresRole(pod.Labels[c.OpConfig.PodRoleLabel])
 
 		// final check if spec of running pod differs from template
-		if reflect.DeepEqual(pod.Spec, c.Statefulset.Spec.Template.Spec) {
+		if pod.ObjectMeta.Labels["controller-revision-hash"] == c.Statefulset.Status.CurrentRevision {
 			c.logger.Infof("%q pod %q already updated", role, podName)
 			continue
 		}

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -343,7 +343,7 @@ func (c *Cluster) recreatePods() error {
 		role := PostgresRole(pod.Labels[c.OpConfig.PodRoleLabel])
 
 		// final check if spec of running pod differs from template
-		if pod.ObjectMeta.Labels["controller-revision-hash"] == c.Statefulset.Status.CurrentRevision {
+		if pod.ObjectMeta.Labels["controller-revision-hash"] == c.Statefulset.Status.UpdateRevision {
 			c.logger.Infof("%q pod %q already updated", role, podName)
 			continue
 		}

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -343,7 +343,8 @@ func (c *Cluster) recreatePods() error {
 		role := PostgresRole(pod.Labels[c.OpConfig.PodRoleLabel])
 
 		// final check if spec of running pod differs from template
-		if pod.ObjectMeta.Labels["controller-revision-hash"] == c.Statefulset.Status.UpdateRevision {
+		if c.Statefulset.Status.CurrentRevision != c.Statefulset.Status.UpdateRevision &&
+			pod.ObjectMeta.Labels["controller-revision-hash"] == c.Statefulset.Status.UpdateRevision {
 			c.logger.Infof("%q pod %q already updated", role, podName)
 			continue
 		}


### PR DESCRIPTION
When a replica is recreated during a rolling update and the bootstrap process takes longer then the configured `pod_label_wait_timeout`, the rolling update fails and is retried on next sync. Since #903 it will not be killed when Patroni says it's still bootstrapping. In the meantime the pod might come up but is then finally recreated by the pending rolling update, although the pod spec has already the latest version from the stateful set.

This PR suggests to do a final check if the `controller-revision-hash` label of the Pod differs from the `updateRevision` status of the stateful set when `currentRevision` and `updateRevision` are not equal. See more details [here](https://stupefied-goodall-e282f7.netlify.app/contributors/design-proposals/apps/statefulset-update/#target-pod-state). If not, nothing happens and the rolling update will complete.

To reproduce the "bug", set `pod_label_wait_timeout` very low, e.g. `5s` and `resync_period` to something like `3m` to see the effect sooner. It can be discussed if human intervention is expected when a `pod label wait timeout` occurs. If the pod doesn't get into a running state at all, or template differs, it is still a good indicator that somethings is wrong and requires manual interaction.

**EDIT**: Doesn't work as expected. When the `-0` Pod is handled first, `currentRevision` hash of the Stateful Set is already set equal to `updateRevision` - not after all replicas are updated. So this Pod will still get terminated with each sync.