### PR TITLE
Allow nodePort value for the postgres-operator-ui service

### DIFF
--- a/charts/postgres-operator-ui/templates/service.yaml
+++ b/charts/postgres-operator-ui/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: 8081
-      {{- if .Values.service.nodePort }}
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
       protocol: TCP

--- a/charts/postgres-operator-ui/templates/service.yaml
+++ b/charts/postgres-operator-ui/templates/service.yaml
@@ -11,6 +11,9 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: 8081
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
       protocol: TCP
   selector:
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/postgres-operator-ui/templates/service.yaml
+++ b/charts/postgres-operator-ui/templates/service.yaml
@@ -11,9 +11,7 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: 8081
-      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
-      {{- end }}
       protocol: TCP
   selector:
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/postgres-operator-ui/templates/service.yaml
+++ b/charts/postgres-operator-ui/templates/service.yaml
@@ -11,7 +11,9 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: 8081
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
       protocol: TCP
   selector:
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/postgres-operator-ui/values.yaml
+++ b/charts/postgres-operator-ui/values.yaml
@@ -42,6 +42,9 @@ envs:
 service:
   type: "ClusterIP"
   port: "8080"
+  # If the type of the service is NodePort a port can be specified using the nodePort field
+  # If the nodePort field is not specified, or if it has no value, then a random port is used
+  # notePort: 32521
 
 # configure UI ingress. If needed: "enabled: true"
 ingress:

--- a/charts/postgres-operator-ui/values.yaml
+++ b/charts/postgres-operator-ui/values.yaml
@@ -42,7 +42,6 @@ envs:
 service:
   type: "ClusterIP"
   port: "8080"
-  nodePort:
 
 # configure UI ingress. If needed: "enabled: true"
 ingress:

--- a/charts/postgres-operator-ui/values.yaml
+++ b/charts/postgres-operator-ui/values.yaml
@@ -42,6 +42,7 @@ envs:
 service:
   type: "ClusterIP"
   port: "8080"
+  nodePort:
 
 # configure UI ingress. If needed: "enabled: true"
 ingress:


### PR DESCRIPTION
Added support for specifying a nodePort value for the postgres-operator-ui service when the service type is NodePort.