### PR TITLE
fix typo in additionalVolume struct

### DIFF
--- a/manifests/complete-postgres-manifest.yaml
+++ b/manifests/complete-postgres-manifest.yaml
@@ -31,28 +31,28 @@ spec:
     size: 1Gi
 #    storageClass: my-sc
   additionalVolumes:
-    - name: data
-      mountPath: /home/postgres/pgdata/partitions
-      targetContainers:
-        - postgres
-      volumeSource:
-        PersistentVolumeClaim:
-          claimName: pvc-postgresql-data-partitions
-          readyOnly: false
-    - name: conf
-      mountPath: /etc/telegraf
-      subPath: telegraf.conf
-      targetContainers:
-        - telegraf-sidecar
-      volumeSource:
-        configMap:
-          name: my-config-map
     - name: empty
       mountPath: /opt/empty
       targetContainers:
         - all
       volumeSource:
         emptyDir: {}
+#    - name: data
+#      mountPath: /home/postgres/pgdata/partitions
+#      targetContainers:
+#        - postgres
+#      volumeSource:
+#        PersistentVolumeClaim:
+#          claimName: pvc-postgresql-data-partitions
+#          readyOnly: false
+#    - name: conf
+#      mountPath: /etc/telegraf
+#      subPath: telegraf.conf
+#      targetContainers:
+#        - telegraf-sidecar
+#      volumeSource:
+#        configMap:
+#          name: my-config-map
 
   enableShmVolume: true
 #  spiloFSGroup: 103

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -104,7 +104,7 @@ type AdditionalVolume struct {
 	MountPath        string          `json:"mountPath"`
 	SubPath          string          `json:"subPath"`
 	TargetContainers []string        `json:"targetContainers"`
-	VolumeSource     v1.VolumeSource `json:"volume"`
+	VolumeSource     v1.VolumeSource `json:"volumeSource"`
 }
 
 // PostgresqlParam describes PostgreSQL version and pairs of configuration parameter name - values.


### PR DESCRIPTION
related to PR #736:

It is not possible to specify a `volumeSource` based on the given cluster manifests examples and the documentation: The name of the json field within the `AdditionalVolume` struct is `volume`. The name specified in the CRD is `volumeSource`: https://github.com/zalando/postgres-operator/blob/3c91bdeffadb5ec736a63548b5ffa08517c59de8/manifests/postgresql.crd.yaml#L45-L48