### PR TITLE
fix type error in values-crd.yaml

### DIFF
--- a/charts/postgres-operator/values-crd.yaml
+++ b/charts/postgres-operator/values-crd.yaml
@@ -262,11 +262,11 @@ configConnectionPooler:
   # docker image
   connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer"
   # max db connections the pooler should hold
-  connection_pooler_max_db_connections: "60"
+  connection_pooler_max_db_connections: 60
   # default pooling mode
   connection_pooler_mode: "transaction"
   # number of pooler instances
-  connection_pooler_number_of_instances: "2"
+  connection_pooler_number_of_instances: 2
   # default resources
   connection_pooler_default_cpu_request: 500m
   connection_pooler_default_memory_request: 100Mi


### PR DESCRIPTION
**connection_pooler_max_db_connections**  and **connection_pooler_number_of_instances** should be integer. as the issue describe [#950 ](https://github.com/zalando/postgres-operator/issues/950)