### PR TITLE
delete secrets of system users too

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -822,10 +822,6 @@ func (c *Cluster) Delete() {
 	}
 
 	for _, obj := range c.Secrets {
-		if doDelete, user := c.shouldDeleteSecret(obj); !doDelete {
-			c.logger.Warningf("not removing secret %q for the system user %q", obj.GetName(), user)
-			continue
-		}
 		if err := c.deleteSecret(obj); err != nil {
 			c.logger.Warningf("could not delete secret: %v", err)
 		}
@@ -1298,11 +1294,6 @@ func (c *Cluster) Lock() {
 // Unlock unlocks the cluster
 func (c *Cluster) Unlock() {
 	c.mu.Unlock()
-}
-
-func (c *Cluster) shouldDeleteSecret(secret *v1.Secret) (delete bool, userName string) {
-	secretUser := string(secret.Data["username"])
-	return (secretUser != c.OpConfig.ReplicationUsername && secretUser != c.OpConfig.SuperUsername), secretUser
 }
 
 type simpleActionWithResult func() error

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/zalando/postgres-operator/pkg/util/constants"
 	"github.com/zalando/postgres-operator/pkg/util/k8sutil"
 	"github.com/zalando/postgres-operator/pkg/util/teams"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 )
@@ -330,36 +329,6 @@ func TestInitHumanUsersWithSuperuserTeams(t *testing.T) {
 
 		if !reflect.DeepEqual(cl.pgUsers, tt.result) {
 			t.Errorf("%s expects %#v, got %#v", testName, tt.result, cl.pgUsers)
-		}
-	}
-}
-
-func TestShouldDeleteSecret(t *testing.T) {
-	testName := "TestShouldDeleteSecret"
-
-	tests := []struct {
-		secret  *v1.Secret
-		outcome bool
-	}{
-		{
-			secret:  &v1.Secret{Data: map[string][]byte{"username": []byte("foobar")}},
-			outcome: true,
-		},
-		{
-			secret: &v1.Secret{Data: map[string][]byte{"username": []byte(superUserName)}},
-
-			outcome: false,
-		},
-		{
-			secret:  &v1.Secret{Data: map[string][]byte{"username": []byte(replicationUserName)}},
-			outcome: false,
-		},
-	}
-
-	for _, tt := range tests {
-		if outcome, username := cl.shouldDeleteSecret(tt.secret); outcome != tt.outcome {
-			t.Errorf("%s expects the check for deletion of the username %q secret to return %t, got %t",
-				testName, username, tt.outcome, outcome)
 		}
 	}
 }


### PR DESCRIPTION
As we can clone or restore clusters, new secrets will get created and passwords get reset. Issue from #173 is obsolete by now.