### PR TITLE
Changed order of sidecar env vars

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -531,7 +531,7 @@ func patchSidecarContainers(in []v1.Container, volumeMounts []v1.VolumeMount, su
 				},
 			},
 		}
-		mergedEnv := append(container.Env, env...)
+		mergedEnv := append(env, container.Env...)
 		container.Env = deduplicateEnvVars(mergedEnv, container.Name, logger)
 		result = append(result, container)
 	}

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -1394,7 +1394,7 @@ func TestSidecars(t *testing.T) {
 
 	// replaced sidecar
 	// the order in env is important
-	scalyrEnv := append(env, []v1.EnvVar{v1.EnvVar{Name: "SCALYR_API_KEY", Value: "abc"}, v1.EnvVar{Name: "SCALYR_SERVER_HOST", Value: ""}}...)
+	scalyrEnv := append(env, v1.EnvVar{Name: "SCALYR_API_KEY", Value: "abc"}, v1.EnvVar{Name: "SCALYR_SERVER_HOST", Value: ""})
 	assert.Contains(t, s.Spec.Template.Spec.Containers, v1.Container{
 		Name:            "scalyr-sidecar",
 		Image:           "scalyr-image",

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -1394,7 +1394,7 @@ func TestSidecars(t *testing.T) {
 
 	// replaced sidecar
 	// the order in env is important
-	scalyrEnv := append([]v1.EnvVar{v1.EnvVar{Name: "SCALYR_API_KEY", Value: "abc"}, v1.EnvVar{Name: "SCALYR_SERVER_HOST", Value: ""}}, env...)
+	scalyrEnv := append(env, []v1.EnvVar{v1.EnvVar{Name: "SCALYR_API_KEY", Value: "abc"}, v1.EnvVar{Name: "SCALYR_SERVER_HOST", Value: ""}}...)
 	assert.Contains(t, s.Spec.Template.Spec.Containers, v1.Container{
 		Name:            "scalyr-sidecar",
 		Image:           "scalyr-image",


### PR DESCRIPTION
Related to https://github.com/zalando/postgres-operator/issues/979

Changing the order of which env variables are added to sidecars containers to support referencing common fields that are injected in other env vars.