### PR TITLE
WIP: Allow NodePort type for master service

### DIFF
--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -42,6 +42,8 @@ type PostgresSpec struct {
 	EnableMasterLoadBalancer  *bool `json:"enableMasterLoadBalancer,omitempty"`
 	EnableReplicaLoadBalancer *bool `json:"enableReplicaLoadBalancer,omitempty"`
 
+	// User nodeport as service type
+	ServiceNodePort *int32 `json:"serviceNodePort,omitempty"`
 	// deprecated load balancer settings maintained for backward compatibility
 	// see "Load balancers" operator docs
 	UseLoadBalancer     *bool `json:"useLoadBalancer,omitempty"`

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1531,6 +1531,13 @@ func (c *Cluster) generateService(role PostgresRole, spec *acidv1.PostgresSpec) 
 		Type:  v1.ServiceTypeClusterIP,
 	}
 
+	if spec.ServiceNodePort != nil  && role == Master {
+		serviceSpec.Type =  v1.ServiceTypeNodePort
+		if *spec.ServiceNodePort > 0 {
+			servicePort := &serviceSpec
+			servicePort.Ports[0].NodePort = *spec.ServiceNodePort
+		}
+	}
 	if role == Replica || c.patroniKubernetesUseConfigMaps() {
 		serviceSpec.Selector = c.roleLabelsSet(false, role)
 	}


### PR DESCRIPTION
This commit introduces new property to a postgresql spec
serviceNodePort. It enable NodePort type service for master role with
automatic port allocation if value is 0. Othewise it takes desired port
number like 30025.

closes #751

Signed-off-by: Dinar Valeev <k0da@opensuse.org>