### PR TITLE
Make selector match labels defined in the deployment

### DIFF
--- a/ui/manifests/service.yaml
+++ b/ui/manifests/service.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   type: "ClusterIP"
   selector:
-    application: "postgres-operator-ui"
+    name: "postgres-operator-ui"
   ports:
     - port: 80
       protocol: "TCP"


### PR DESCRIPTION
Currently, the deployment manifest specifies two labels: `name` and `team`.
This fixes the service not matching the deployed pods by chosing a correct selector.