### PR TITLE
Increase required instances by number of pods stuck in terminating state

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1282,6 +1282,7 @@ func (c *Cluster) getNumberOfInstances(spec *acidv1.PostgresSpec) int32 {
 	max := c.OpConfig.MaxInstances
 	cur := spec.NumberOfInstances
 	newcur := cur
+	var extra_pods int32 = 0
 
 	if spec.StandbyCluster != nil {
 		if newcur == 1 {
@@ -1300,8 +1301,11 @@ func (c *Cluster) getNumberOfInstances(spec *acidv1.PostgresSpec) int32 {
 	if newcur != cur {
 		c.logger.Infof("adjusted number of instances from %d to %d (min: %d, max: %d)", cur, newcur, min, max)
 	}
+	if c.OpConfig.PodManagementPolicy == "parallel" {
+		extra_pods = c.getTerminatingPodsCount()
+	}
 
-	return newcur
+	return newcur + extra_pods
 }
 
 // To avoid issues with limited /dev/shm inside docker environment, when

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
 
 	"github.com/zalando/postgres-operator/pkg/spec"
 	"github.com/zalando/postgres-operator/pkg/util"
@@ -41,6 +43,33 @@ func (c *Cluster) getRolePods(role PostgresRole) ([]v1.Pod, error) {
 	}
 
 	return pods.Items, nil
+}
+
+func (c *Cluster) getTerminatingPodsCount() (int32) {
+	var count int32
+	listOptions := metav1.ListOptions{
+		LabelSelector: c.labelsSet(false).String(),
+	}
+
+	pods, err := c.KubeClient.Pods(c.Namespace).List(context.TODO(), listOptions)
+	if err != nil {
+		return 0
+	}
+	for _, pod := range pods.Items {
+		if pod.DeletionTimestamp != nil && pod.DeletionGracePeriodSeconds != nil {
+			rc := clock.RealClock{}
+			now := rc.Now()
+			deletionTime := pod.DeletionTimestamp.Time
+			gracePeriod := time.Duration(*pod.DeletionGracePeriodSeconds) * time.Second
+			if now.After(deletionTime.Add(gracePeriod)) {
+				count++
+			}
+		}
+	}
+	c.logger.Debugf("Found %v pods in terminating status after DeletionGracePeriod", count)
+
+	return count
+
 }
 
 func (c *Cluster) deletePods() error {


### PR DESCRIPTION
related to #1005 
i will only add an additional pod if PodManagementPolicy is parallel, otherwise it will need to wait until it's running again.