### PR TITLE
include volume in list of required fields

### DIFF
--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -73,6 +73,7 @@ spec:
             - numberOfInstances
             - teamId
             - postgresql
+            - volume
           properties:
             additionalVolumes:
               type: array

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -69,6 +69,7 @@ spec:
             - numberOfInstances
             - teamId
             - postgresql
+            - volume
           properties:
             additionalVolumes:
               type: array

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -132,7 +132,7 @@ var PostgresCRDResourceValidation = apiextv1beta1.CustomResourceValidation{
 			},
 			"spec": {
 				Type:     "object",
-				Required: []string{"numberOfInstances", "teamId", "postgresql"},
+				Required: []string{"numberOfInstances", "teamId", "postgresql", "volume"},
 				Properties: map[string]apiextv1beta1.JSONSchemaProps{
 					"allowedSourceRanges": {
 						Type:     "array",


### PR DESCRIPTION
If volume section is left out in manifest, cluster setup fails. So CRD validation should mark this field as required.