### PR TITLE
Tiny Getting Started documentation fix: port-forward service instead of pod

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -160,7 +160,7 @@ You can now access the web interface by port forwarding the UI pod (mind the
 label selector) and enter `localhost:8081` in your browser:
 
 ```bash
-kubectl port-forward "$(kubectl get pod -l name=postgres-operator-ui --output='name')" 8081
+kubectl port-forward svc/postgres-operator-ui 8081:8081
 ```
 
 Available option are explained in detail in the [UI docs](operator-ui.md).


### PR DESCRIPTION
I was not sure why you guys were making this more difficult then it is :laughing: