### PR TITLE
set search_path for default roles

### DIFF
--- a/manifests/postgres-operator.yaml
+++ b/manifests/postgres-operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: postgres-operator
       containers:
       - name: postgres-operator
-        image: registry.opensource.zalan.do/acid/postgres-operator:v1.5.0-19-g37596342-dirty
+        image: registry.opensource.zalan.do/acid/postgres-operator:v1.5.0
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/manifests/postgres-operator.yaml
+++ b/manifests/postgres-operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: postgres-operator
       containers:
       - name: postgres-operator
-        image: registry.opensource.zalan.do/acid/postgres-operator:v1.5.0
+        image: registry.opensource.zalan.do/acid/postgres-operator:v1.5.0-19-g37596342-dirty
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -955,32 +955,42 @@ func (c *Cluster) initPreparedDatabaseRoles() error {
 	}
 
 	for preparedDbName, preparedDB := range c.Spec.PreparedDatabases {
+		// get list of prepared schemas to set in search_path
+		preparedSchemas := preparedDB.PreparedSchemas
+		if len(preparedDB.PreparedSchemas) == 0 {
+			preparedSchemas = map[string]acidv1.PreparedSchema{"data": {DefaultRoles: util.True()}}
+		}
+
+		var searchPath strings.Builder
+		searchPath.WriteString(constants.DefaultSearchPath)
+		for preparedSchemaName := range preparedSchemas {
+			searchPath.WriteString(", " + preparedSchemaName)
+		}
+
 		// default roles per database
-		if err := c.initDefaultRoles(defaultRoles, "admin", preparedDbName); err != nil {
+		if err := c.initDefaultRoles(defaultRoles, "admin", preparedDbName, searchPath.String()); err != nil {
 			return fmt.Errorf("could not initialize default roles for database %s: %v", preparedDbName, err)
 		}
 		if preparedDB.DefaultUsers {
-			if err := c.initDefaultRoles(defaultUsers, "admin", preparedDbName); err != nil {
+			if err := c.initDefaultRoles(defaultUsers, "admin", preparedDbName, searchPath.String()); err != nil {
 				return fmt.Errorf("could not initialize default roles for database %s: %v", preparedDbName, err)
 			}
 		}
 
 		// default roles per database schema
-		preparedSchemas := preparedDB.PreparedSchemas
-		if len(preparedDB.PreparedSchemas) == 0 {
-			preparedSchemas = map[string]acidv1.PreparedSchema{"data": {DefaultRoles: util.True()}}
-		}
 		for preparedSchemaName, preparedSchema := range preparedSchemas {
 			if preparedSchema.DefaultRoles == nil || *preparedSchema.DefaultRoles {
 				if err := c.initDefaultRoles(defaultRoles,
 					preparedDbName+constants.OwnerRoleNameSuffix,
-					preparedDbName+"_"+preparedSchemaName); err != nil {
+					preparedDbName+"_"+preparedSchemaName,
+					constants.DefaultSearchPath+", "+preparedSchemaName); err != nil {
 					return fmt.Errorf("could not initialize default roles for database schema %s: %v", preparedSchemaName, err)
 				}
 				if preparedSchema.DefaultUsers {
 					if err := c.initDefaultRoles(defaultUsers,
 						preparedDbName+constants.OwnerRoleNameSuffix,
-						preparedDbName+"_"+preparedSchemaName); err != nil {
+						preparedDbName+"_"+preparedSchemaName,
+						constants.DefaultSearchPath+", "+preparedSchemaName); err != nil {
 						return fmt.Errorf("could not initialize default users for database schema %s: %v", preparedSchemaName, err)
 					}
 				}
@@ -990,7 +1000,7 @@ func (c *Cluster) initPreparedDatabaseRoles() error {
 	return nil
 }
 
-func (c *Cluster) initDefaultRoles(defaultRoles map[string]string, admin, prefix string) error {
+func (c *Cluster) initDefaultRoles(defaultRoles map[string]string, admin, prefix string, searchPath string) error {
 
 	for defaultRole, inherits := range defaultRoles {
 
@@ -1014,12 +1024,13 @@ func (c *Cluster) initDefaultRoles(defaultRoles map[string]string, admin, prefix
 		}
 
 		newRole := spec.PgUser{
-			Origin:    spec.RoleOriginBootstrap,
-			Name:      roleName,
-			Password:  util.RandomPassword(constants.PasswordLength),
-			Flags:     flags,
-			MemberOf:  memberOf,
-			AdminRole: adminRole,
+			Origin:     spec.RoleOriginBootstrap,
+			Name:       roleName,
+			Password:   util.RandomPassword(constants.PasswordLength),
+			Flags:      flags,
+			MemberOf:   memberOf,
+			Parameters: map[string]string{"search_path": searchPath},
+			AdminRole:  adminRole,
 		}
 		if currentRole, present := c.pgUsers[roleName]; present {
 			c.pgUsers[roleName] = c.resolveNameConflict(&currentRole, &newRole)

--- a/pkg/util/constants/roles.go
+++ b/pkg/util/constants/roles.go
@@ -2,20 +2,21 @@ package constants
 
 // Roles specific constants
 const (
-	PasswordLength            = 64
-	SuperuserKeyName          = "superuser"
+	PasswordLength              = 64
+	SuperuserKeyName            = "superuser"
 	ConnectionPoolerUserKeyName = "pooler"
-	ReplicationUserKeyName    = "replication"
-	RoleFlagSuperuser         = "SUPERUSER"
-	RoleFlagInherit           = "INHERIT"
-	RoleFlagLogin             = "LOGIN"
-	RoleFlagNoLogin           = "NOLOGIN"
-	RoleFlagCreateRole        = "CREATEROLE"
-	RoleFlagCreateDB          = "CREATEDB"
-	RoleFlagReplication       = "REPLICATION"
-	RoleFlagByPassRLS         = "BYPASSRLS"
-	OwnerRoleNameSuffix       = "_owner"
-	ReaderRoleNameSuffix      = "_reader"
-	WriterRoleNameSuffix      = "_writer"
-	UserRoleNameSuffix        = "_user"
+	ReplicationUserKeyName      = "replication"
+	RoleFlagSuperuser           = "SUPERUSER"
+	RoleFlagInherit             = "INHERIT"
+	RoleFlagLogin               = "LOGIN"
+	RoleFlagNoLogin             = "NOLOGIN"
+	RoleFlagCreateRole          = "CREATEROLE"
+	RoleFlagCreateDB            = "CREATEDB"
+	RoleFlagReplication         = "REPLICATION"
+	RoleFlagByPassRLS           = "BYPASSRLS"
+	OwnerRoleNameSuffix         = "_owner"
+	ReaderRoleNameSuffix        = "_reader"
+	WriterRoleNameSuffix        = "_writer"
+	UserRoleNameSuffix          = "_user"
+	DefaultSearchPath           = "\"$user\""
 )

--- a/pkg/util/users/users.go
+++ b/pkg/util/users/users.go
@@ -113,14 +113,14 @@ func (strategy DefaultUserSyncStrategy) ExecuteSyncRequests(requests []spec.PgSy
 
 	return nil
 }
-func (strategy DefaultUserSyncStrategy) alterPgUserSet(user spec.PgUser, db *sql.DB) (err error) {
+
+func (strategy DefaultUserSyncStrategy) alterPgUserSet(user spec.PgUser, db *sql.DB) error {
 	queries := produceAlterRoleSetStmts(user)
 	query := fmt.Sprintf(doBlockStmt, strings.Join(queries, ";"))
-	if _, err = db.Exec(query); err != nil {
-		err = fmt.Errorf("dB error: %v, query: %s", err, query)
-		return
+	if _, err := db.Exec(query); err != nil {
+		return fmt.Errorf("dB error: %v, query: %s", err, query)
 	}
-	return
+	return nil
 }
 
 func (strategy DefaultUserSyncStrategy) createPgUser(user spec.PgUser, db *sql.DB) error {
@@ -146,6 +146,12 @@ func (strategy DefaultUserSyncStrategy) createPgUser(user spec.PgUser, db *sql.D
 
 	if _, err := db.Exec(query); err != nil { // TODO: Try several times
 		return fmt.Errorf("dB error: %v, query: %s", err, query)
+	}
+
+	if len(user.Parameters) > 0 {
+		if err := strategy.alterPgUserSet(user, db); err != nil {
+			return fmt.Errorf("incomplete setup for user %s: %v", user.Name, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
fixes #1014

When creating databases through the `preparedDatabases` feature the `search_path` is not configured hence all created roles need to put schema qualifiers in their queries. But, the existing `PgUser` user type already has a field `Parameters` to allow for setting `search_path` individually. Even code for altering the role has already been there, although it wasn't used probably.

This PR defines a default `search_path: "$user"` for each role (note `public` is not included) and then appends all schemas, if it's a `<dbname>_[owner|reader|writer]` role or only one schema when it's a  `<dbname>_<schema>_[owner|reader|writer]` role.

Adding databases with two schemas will have the following settings:

```
  preparedDatabases:
    bar:
      schemas:
        prod: {}
        audit: {}

SELECT r.rolname, d.datname, rs.setconfig
  FROM pg_db_role_setting rs
  LEFT JOIN pg_roles r ON r.oid = rs.setrole
  LEFT JOIN pg_database d ON d.oid = rs.setdatabase
  ORDER BY rolname;

     rolname      | datname |               setconfig                
------------------+---------+----------------------------------------
 bar_audit_owner  |         | {"search_path=\"$user\", audit"}
 bar_audit_reader |         | {"search_path=\"$user\", audit"}
 bar_audit_writer |         | {"search_path=\"$user\", audit"}
 bar_owner        |         | {"search_path=\"$user\", audit, prod"}
 bar_prod_owner   |         | {"search_path=\"$user\", prod"}
 bar_prod_reader  |         | {"search_path=\"$user\", prod"}
 bar_prod_writer  |         | {"search_path=\"$user\", prod"}
 bar_reader       |         | {"search_path=\"$user\", audit, prod"}
 bar_writer       |         | {"search_path=\"$user\", audit, prod"}
```

**Open question 1:**
If the database already contains roles that follow the naming pattern and existing databases and schemas are moved under the `preparedDatabases` key, existing `search_path` settings will be overwritten. Other example: The minimal cluster defines no schemas which would create a default schema `data`. At one point somebody defines new `schemas` under `preparedDatabases` and only these schemas are put into the search_path for the `<dbname>_[owner|reader|writer]` roles. `data` is lost. Solution: Get the current search_path and merge / concat it with the new one.

**Open question 2:**
Should the ALTER ROLE command be enriched with the IN DATABASE term? Probably, it's already fine because of default access privileges.

**Open question 3:**
Should there be an option to add `public` to the default `search_path` even if it's not that safe.

**Open question 4:**
In case the user is called like the schema, the default "$user" is good enough. Should we still append the schema name in case the role is renamed at some point in the future.