### PR TITLE
Feature/add pvc delete toggle

### DIFF
--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -32,10 +32,6 @@ spec:
     type: string
     description: Size of the bound volume
     JSONPath: .spec.volume.size
-  - name: KeepPVC
-    type: boolean
-    description: Determines whether the PersistentVolumeClaim should be kept when the manifest is deleted
-    JSONPath: .spec.volume.keepPVC
   - name: CPU-Request
     type: string
     description: Requested CPU for Postgres containers

--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -32,6 +32,10 @@ spec:
     type: string
     description: Size of the bound volume
     JSONPath: .spec.volume.size
+  - name: KeepPVC
+    type: boolean
+    description: Determines whether the PersistentVolumeClaim should be kept when the manifest is deleted
+    JSONPath: .spec.volume.keepPVC
   - name: CPU-Request
     type: string
     description: Requested CPU for Postgres containers
@@ -478,3 +482,5 @@ spec:
                   type: string
                 subPath:
                   type: string
+                keepPVC:
+                  type: boolean

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -284,7 +284,7 @@ manifest files:
 
 Postgres manifest parameters are defined in the [api package](../pkg/apis/acid.zalan.do/v1/postgresql_type.go).
 The operator behavior has to be implemented at least in [k8sres.go](../pkg/cluster/k8sres.go).
-Validation of CRD parameters is controlled in [crd.go](../pkg/apis/acid.zalan.do/v1/crds.go).
+Validation of CRD parameters is controlled in [crds.go](../pkg/apis/acid.zalan.do/v1/crds.go).
 Please, reflect your changes in tests, for example in:
 * [config_test.go](../pkg/util/config/config_test.go)
 * [k8sres_test.go](../pkg/cluster/k8sres_test.go)

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -154,6 +154,9 @@ These parameters are grouped directly under  the `spec` key in the manifest.
   [the reference schedule format](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule)
   into account. Optional. Default is: "30 00 \* \* \*"
 
+* **volume**
+  Specifies the size and StorageClass of the PersistentVolumeClaim. By default, this PVC is deleted when the manifest is uninstalled. To keep the PVC, set the volume's `keepPVC` attribute to `true`.
+
 * **additionalVolumes**
   List of additional volumes to mount in each container of the statefulset pod.
   Each item must contain a `name`, `mountPath`, and `volumeSource` which is a

--- a/manifests/complete-postgres-manifest.yaml
+++ b/manifests/complete-postgres-manifest.yaml
@@ -40,6 +40,7 @@ spec:
       log_statement: "all"
   volume:
     size: 1Gi
+    keepPVC: false
 #    storageClass: my-sc
   additionalVolumes:
     - name: empty

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -28,10 +28,6 @@ spec:
     type: string
     description: Size of the bound volume
     JSONPath: .spec.volume.size
-  - name: KeepPVC
-    type: boolean
-    description: Determines whether the PersistentVolumeClaim should be kept when the manifest is deleted
-    JSONPath: .spec.volume.keepPVC
   - name: CPU-Request
     type: string
     description: Requested CPU for Postgres containers

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -28,6 +28,10 @@ spec:
     type: string
     description: Size of the bound volume
     JSONPath: .spec.volume.size
+  - name: KeepPVC
+    type: boolean
+    description: Determines whether the PersistentVolumeClaim should be kept when the manifest is deleted
+    JSONPath: .spec.volume.keepPVC
   - name: CPU-Request
     type: string
     description: Requested CPU for Postgres containers
@@ -237,12 +241,12 @@ spec:
                   type: integer
                 retry_timeout:
                   type: integer
-                maximum_lag_on_failover:
-                  type: integer
                 synchronous_mode:
                   type: boolean
                 synchronous_mode_strict:
                   type: boolean
+                maximum_lag_on_failover:
+                  type: integer
             podAnnotations:
               type: object
               additionalProperties:
@@ -474,7 +478,5 @@ spec:
                   type: string
                 subPath:
                   type: string
-        status:
-          type: object
-          additionalProperties:
-            type: string
+                keepPVC:
+                  type: boolean

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -46,6 +46,12 @@ var PostgresCRDResourceColumns = []apiextv1beta1.CustomResourceColumnDefinition{
 		JSONPath:    ".spec.volume.size",
 	},
 	{
+		Name:        "KeepPVC",
+		Type:        "boolean",
+		Description: "Determines whether the PersistentVolumeClaim should be kept when the manifest is deleted",
+		JSONPath:    ".spec.volume.keepPVC",
+	},
+	{
 		Name:        "CPU-Request",
 		Type:        "string",
 		Description: "Requested CPU for Postgres containers",
@@ -720,6 +726,9 @@ var PostgresCRDResourceValidation = apiextv1beta1.CustomResourceValidation{
 							"subPath": {
 								Type: "string",
 							},
+							"keepPVC": {
+								Type: "boolean",
+							},
 						},
 					},
 					"additionalVolumes": {
@@ -980,7 +989,7 @@ var OperatorConfigCRDResourceValidation = apiextv1beta1.CustomResourceValidation
 							"spilo_privileged": {
 								Type: "boolean",
 							},
-                                                      "storage_resize_mode": {
+							"storage_resize_mode": {
 								Type: "string",
 								Enum: []apiextv1beta1.JSON{
 									{

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -46,12 +46,6 @@ var PostgresCRDResourceColumns = []apiextv1beta1.CustomResourceColumnDefinition{
 		JSONPath:    ".spec.volume.size",
 	},
 	{
-		Name:        "KeepPVC",
-		Type:        "boolean",
-		Description: "Determines whether the PersistentVolumeClaim should be kept when the manifest is deleted",
-		JSONPath:    ".spec.volume.keepPVC",
-	},
-	{
 		Name:        "CPU-Request",
 		Type:        "string",
 		Description: "Requested CPU for Postgres containers",

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -111,6 +111,7 @@ type Volume struct {
 	Size         string `json:"size"`
 	StorageClass string `json:"storageClass"`
 	SubPath      string `json:"subPath,omitempty"`
+	KeepPVC      bool   `json:"keepPVC,omitempty"`
 }
 
 type AdditionalVolume struct {

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -486,8 +486,11 @@ func (c *Cluster) deleteStatefulSet() error {
 		return fmt.Errorf("could not delete pods: %v", err)
 	}
 
-	if err := c.deletePersistentVolumeClaims(); err != nil {
-		return fmt.Errorf("could not delete PersistentVolumeClaims: %v", err)
+	c.logger.Debugf("c.Postgresql.Spec.Volume.KeepPVC = %t", c.Postgresql.Spec.Volume.KeepPVC)
+	if c.Postgresql.Spec.Volume.KeepPVC == false {
+		if err := c.deletePersistentVolumeClaims(); err != nil {
+			return fmt.Errorf("could not delete PersistentVolumeClaims: %v", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
In our setup, the postgresql custom resource is often deleted. The operator will first delete the StatefulSets and then explicitly delete the PersistentVolumeClaims. However, we would like to keep our data. A simple solution is to add a toggle for this: .spec.volume.keepPVC, which defaults to false. 