### PR TITLE
chart ui: fix target namespace to allow '*'

### DIFF
--- a/charts/postgres-operator-ui/templates/deployment.yaml
+++ b/charts/postgres-operator-ui/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             - name: "RESOURCES_VISIBLE"
               value: "{{ .Values.envs.resourcesVisible }}"
             - name: "TARGET_NAMESPACE"
-              value: {{ .Values.envs.targetNamespace }}
+              value: "{{ .Values.envs.targetNamespace }}"
             - name: "TEAMS"
               value: |-
                 [


### PR DESCRIPTION
This PR addresses #1081.
fixes #978
This change allows the `targetNamespace` to be set to `"*"` to watch all namespaces, and maintains the ability to set the `targetNamespace` to a particular namespace of type string.