### PR TITLE
Remove all secrets on delete incl. pooler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,8 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/tools v0.0.0-20200729041821-df70183b1872 // indirect
+	golang.org/x/tools v0.0.0-20200809012840-6f4f008689da // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.18.6
 	k8s.io/apiextensions-apiserver v0.18.6

--- a/go.sum
+++ b/go.sum
@@ -395,12 +395,14 @@ golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200729041821-df70183b1872 h1:/U95VAvB4ZsR91rpZX2MwiKpejhWr+UxJ+N2VlJuESk=
-golang.org/x/tools v0.0.0-20200729041821-df70183b1872/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20200809012840-6f4f008689da h1:ml5G98G4/tdKT1XNq+ky5iSRdKKux0TANlLAzmXT/hg=
+golang.org/x/tools v0.0.0-20200809012840-6f4f008689da/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -124,7 +124,7 @@ func New(cfg Config, kubeClient k8sutil.KubernetesClient, pgSpec acidv1.Postgres
 
 		return fmt.Sprintf("%s-%s", e.PodName, e.ResourceVersion), nil
 	})
-	password_encryption, ok :=  pgSpec.Spec.PostgresqlParam.Parameters["password_encryption"]
+	password_encryption, ok := pgSpec.Spec.PostgresqlParam.Parameters["password_encryption"]
 	if !ok {
 		password_encryption = "md5"
 	}

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -771,9 +771,7 @@ func (c *Cluster) deleteSecret(uid types.UID, secret v1.Secret) error {
 	c.setProcessName("deleting secret")
 	c.logger.Debugf("deleting secret %q", util.NameFromMeta(secret.ObjectMeta))
 	err := c.KubeClient.Secrets(secret.Namespace).Delete(context.TODO(), secret.Name, c.deleteOptions)
-	if k8sutil.ResourceNotFound(err) {
-		c.logger.Debugf("Connection pooler secret was already deleted")
-	} else if err != nil {
+	if err != nil {
 		return fmt.Errorf("could not delete secret %q: %v", util.NameFromMeta(secret.ObjectMeta), err)
 	}
 	c.logger.Infof("secret %q has been deleted", util.NameFromMeta(secret.ObjectMeta))

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -227,7 +227,7 @@ func (c *Cluster) deleteConnectionPooler() (err error) {
 		Get(context.TODO(), secretName, metav1.GetOptions{})
 
 	if err != nil {
-		c.logger.Debugf("could not get connection pooler secret %q: %v", secretTemplate.Name, err)
+		c.logger.Debugf("could not get connection pooler secret %q: %v", secretName, err)
 	} else {
 		uid := secret.UID
 		if err = c.deleteSecret(uid, *secret); err != nil {

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -500,6 +500,7 @@ func (c *Cluster) syncSecrets() error {
 				c.logger.Warningf("secret %q does not contain the role %q", secretSpec.Name, secretUsername)
 				continue
 			}
+			c.Secrets[secret.UID] = secret
 			c.logger.Debugf("secret %q already exists, fetching its password", util.NameFromMeta(secret.ObjectMeta))
 			if secretUsername == c.systemUsers[constants.SuperuserKeyName].Name {
 				secretUsername = constants.SuperuserKeyName


### PR DESCRIPTION
This PR sets secrets on SYNC, so that they can be deleted.

On connection pooler deletion the corresponding secret is now removed via API call. Because of the way roles and secrets are synced with the `needCoonectionPooler` condition, the pooler user and secret are no longer set after deletion. But resources would still be there. For the database user it's fine - operator does not delete those in general - but the secret should go.