### PR TITLE
Fixes #1130

### DIFF
--- a/pkg/cluster/database.go
+++ b/pkg/cluster/database.go
@@ -329,8 +329,7 @@ func (c *Cluster) execCreateDatabaseSchema(databaseName, schemaName, dbOwner, sc
 	if !c.databaseSchemaNameValid(schemaName) {
 		return nil
 	}
-	//c.logger.Infof("%s %q owner %q", doing, schemaName, schemaOwner)
-	c.logger.Debugf("%s with schemaName:%q schemaOwner:%q dbOwner:%q databaseName:%q statement:%q operation:%q", doing, schemaName, schemaOwner, dbOwner, databaseName, statement , operation)
+	c.logger.Infof("%s %q owner %q", doing, schemaName, schemaOwner)
 	if _, err := c.pgDb.Exec(fmt.Sprintf(statement, dbOwner, schemaName, schemaOwner)); err != nil {
 		return fmt.Errorf("could not execute %s: %v", operation, err)
 	}

--- a/pkg/cluster/database.go
+++ b/pkg/cluster/database.go
@@ -329,7 +329,8 @@ func (c *Cluster) execCreateDatabaseSchema(databaseName, schemaName, dbOwner, sc
 	if !c.databaseSchemaNameValid(schemaName) {
 		return nil
 	}
-	c.logger.Infof("%s %q owner %q", doing, schemaName, schemaOwner)
+	//c.logger.Infof("%s %q owner %q", doing, schemaName, schemaOwner)
+	c.logger.Debugf("%s with schemaName:%q schemaOwner:%q dbOwner:%q databaseName:%q statement:%q operation:%q", doing, schemaName, schemaOwner, dbOwner, databaseName, statement , operation)
 	if _, err := c.pgDb.Exec(fmt.Sprintf(statement, dbOwner, schemaName, schemaOwner)); err != nil {
 		return fmt.Errorf("could not execute %s: %v", operation, err)
 	}

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -699,7 +699,7 @@ func (c *Cluster) syncPreparedDatabases() error {
 			c.logger.Debugf("opened preparedDbName: %s", preparedDbName)
 		}
 
-		c.logger.Debugf("working on preparedDbName: %s", preparedDbName)
+		c.logger.Debugf("syncing prepared database %q", preparedDbName)
 		// now, prepare defined schemas
 		preparedSchemas := preparedDB.PreparedSchemas
 		if len(preparedDB.PreparedSchemas) == 0 {

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -695,8 +695,6 @@ func (c *Cluster) syncPreparedDatabases() error {
 	for preparedDbName, preparedDB := range c.Spec.PreparedDatabases {
 		if err := c.initDbConnWithName(preparedDbName); err != nil {
 			return fmt.Errorf("could not init connection to database %s: %v", preparedDbName, err)
-		} else {
-			c.logger.Debugf("opened preparedDbName: %s", preparedDbName)
 		}
 
 		c.logger.Debugf("syncing prepared database %q", preparedDbName)

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -714,8 +714,6 @@ func (c *Cluster) syncPreparedDatabases() error {
 
 		if err := c.closeDbConn(); err != nil {
 			c.logger.Errorf("could not close database connection: %v", err)
-		} else {
-			c.logger.Debugf("closed preparedDbName: %s", preparedDbName)
 		}
 	}
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -695,13 +695,11 @@ func (c *Cluster) syncPreparedDatabases() error {
 	for preparedDbName, preparedDB := range c.Spec.PreparedDatabases {
 		if err := c.initDbConnWithName(preparedDbName); err != nil {
 			return fmt.Errorf("could not init connection to database %s: %v", preparedDbName, err)
+		} else {
+			c.logger.Debugf("opened preparedDbName: %s", preparedDbName)
 		}
-		defer func() {
-			if err := c.closeDbConn(); err != nil {
-				c.logger.Errorf("could not close database connection: %v", err)
-			}
-		}()
 
+		c.logger.Debugf("working on preparedDbName: %s", preparedDbName)
 		// now, prepare defined schemas
 		preparedSchemas := preparedDB.PreparedSchemas
 		if len(preparedDB.PreparedSchemas) == 0 {
@@ -714,6 +712,12 @@ func (c *Cluster) syncPreparedDatabases() error {
 		// install extensions
 		if err := c.syncExtensions(preparedDB.Extensions); err != nil {
 			return err
+		}
+
+		if err := c.closeDbConn(); err != nil {
+			c.logger.Errorf("could not close database connection: %v", err)
+		} else {
+			c.logger.Debugf("closed preparedDbName: %s", preparedDbName)
 		}
 	}
 


### PR DESCRIPTION
Hi,

Problem was: defer should not be used in for loops. 
Link:  https://stackoverflow.com/questions/45617758/defer-in-the-loop-what-will-be-better 

Fixes #1130 

```
time="2020-09-11T13:08:11Z" level=debug msg="syncing roles" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:16Z" level=debug msg="closing database connection" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:16Z" level=info msg="syncing databases" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:16Z" level=info msg="creating database \"a3db\" owner \"a3db_owner\"" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:16Z" level=info msg="creating database \"a4db\" owner \"a4db_owner\"" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:16Z" level=debug msg="closing database connection" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:16Z" level=info msg="syncing prepared databases" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:16Z" level=info msg="Opened preparedDbName: a2db" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:16Z" level=info msg="Working on preparedDbName: a2db" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:16Z" level=info msg="doing:creating database schema schemaName:\"a2schema2\" schemaOwner:\"a2db_a2schema2_owner\" dnOwner:\"a2db_owner\" databaseName:\"a2db\" statement:\"SET ROLE TO \\\"%s\\\"; CREATE SCHEMA IF NOT EXISTS \\\"%s\\\" AUTHORIZATION \\\"%s\\\"\" operation:\"create database schema\"" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=info msg="doing:creating database schema schemaName:\"a2schema1\" schemaOwner:\"a2db_a2schema1_owner\" dnOwner:\"a2db_owner\" databaseName:\"a2db\" statement:\"SET ROLE TO \\\"%s\\\"; CREATE SCHEMA IF NOT EXISTS \\\"%s\\\" AUTHORIZATION \\\"%s\\\"\" operation:\"create database schema\"" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=info msg="Opened preparedDbName: a3db" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=info msg="Working on preparedDbName: a3db" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=info msg="Opened preparedDbName: a4db" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=info msg="Working on preparedDbName: a4db" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=info msg="Opened preparedDbName: a1db" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=info msg="Working on preparedDbName: a1db" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=info msg="doing:creating database schema schemaName:\"a1schema1\" schemaOwner:\"a1db_a1schema1_owner\" dnOwner:\"a1db_owner\" databaseName:\"a1db\" statement:\"SET ROLE TO \\\"%s\\\"; CREATE SCHEMA IF NOT EXISTS \\\"%s\\\" AUTHORIZATION \\\"%s\\\"\" operation:\"create database schema\"" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=debug msg="closing database connection" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=info msg="Closed preparedDbName: a1db" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=warning msg="attempted to close an empty db connection object" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=info msg="Closed preparedDbName: a1db" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=warning msg="attempted to close an empty db connection object" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=info msg="Closed preparedDbName: a1db" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=warning msg="attempted to close an empty db connection object" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=info msg="Closed preparedDbName: a1db" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=error msg="could not sync prepared databases: could not execute create database schema: pq: permission denied for database a2db" cluster-name=kafka-fix/postgres-sebpg3 pkg=cluster
time="2020-09-11T13:08:17Z" level=info msg="cluster has been updated" cluster-name=kafka-fix/postgres-sebpg3 pkg=controller worker=3
``` 
