### PR TITLE
Compare Postgres pod priority on Sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ script:
   - hack/verify-codegen.sh
   - travis_wait 20 go test -race -covermode atomic -coverprofile=profile.cov ./pkg/... -v
   - goveralls -coverprofile=profile.cov -service=travis-ci -v
-  - make e2e
+  - travis_wait 20 make e2e

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -2,6 +2,10 @@ version: "2017-09-20"
 pipeline:
     - id: build-postgres-operator
       type: script
+      vm: large
+      cache:
+        paths:
+          - /go/pkg/mod
       commands:
         - desc: 'Update'
           cmd: |

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -85,6 +85,7 @@ data:
   pod_service_account_name: "postgres-pod"
   # pod_service_account_role_binding_definition: ""
   pod_terminate_grace_period: 5m
+  # pod_priority_class_name: "postgres-pod-priority"
   # postgres_superuser_teams: "postgres_superusers"
   # protected_role_names: "admin"
   ready_wait_interval: 3s

--- a/manifests/postgres-pod-priority-class.yaml
+++ b/manifests/postgres-pod-priority-class.yaml
@@ -1,0 +1,11 @@
+apiVersion: scheduling.k8s.io/v1
+description: 'This priority class must be used only for databases controlled by the
+  Postgres operator'
+kind: PriorityClass
+metadata:
+  labels:
+    application: postgres-operator
+  name: postgres-pod-priority
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+value: 1000000

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -459,18 +459,13 @@ func (c *Cluster) compareStatefulSetWith(statefulSet *appsv1.StatefulSet) *compa
 		}
 	}
 
+	// we assume any change in priority happens by rolling out a new priority class
+	// changing the priority value in an existing class is not supproted
 	if c.Statefulset.Spec.Template.Spec.PriorityClassName != statefulSet.Spec.Template.Spec.PriorityClassName {
 		match = false
 		needsReplace = true
 		needsRollUpdate = true
 		reasons = append(reasons, "new statefulset's pod priority class in spec doesn't match the current one")
-	}
-
-	if c.Statefulset.Spec.Template.Spec.Priority != statefulSet.Spec.Template.Spec.Priority {
-		match = false
-		needsReplace = true
-		needsRollUpdate = true
-		reasons = append(reasons, "new statefulset's pod priority value in spec doesn't match the current one")
 	}
 
 	// lazy Spilo update: modify the image in the statefulset itself but let its pods run with the old image

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -459,6 +459,20 @@ func (c *Cluster) compareStatefulSetWith(statefulSet *appsv1.StatefulSet) *compa
 		}
 	}
 
+	if c.Statefulset.Spec.Template.Spec.PriorityClassName != statefulSet.Spec.Template.Spec.PriorityClassName {
+		match = false
+		needsReplace = true
+		needsRollUpdate = true
+		reasons = append(reasons, "new statefulset's pod priority class in spec doesn't match the current one")
+	}
+
+	if c.Statefulset.Spec.Template.Spec.Priority != statefulSet.Spec.Template.Spec.Priority {
+		match = false
+		needsReplace = true
+		needsRollUpdate = true
+		reasons = append(reasons, "new statefulset's pod priority value in spec doesn't match the current one")
+	}
+
 	// lazy Spilo update: modify the image in the statefulset itself but let its pods run with the old image
 	// until they are re-created for other reasons, for example node rotation
 	if c.OpConfig.EnableLazySpiloUpgrade && !reflect.DeepEqual(c.Statefulset.Spec.Template.Spec.Containers[0].Image, statefulSet.Spec.Template.Spec.Containers[0].Image) {


### PR DESCRIPTION
Priority classes are immutable. One option to change a priority class for existing pods is to delete it and then submit the newly configured class under the same name. We deem this approach as too dangerous because in the meantime no Postgres pod will be able to start.

So we take the alternative approach  and rely on the existing Sync machinery to do the rolling update of existing pods. 