### PR TITLE
Cleanup config examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ script:
   - hack/verify-codegen.sh
   - travis_wait 20 go test -race -covermode atomic -coverprofile=profile.cov ./pkg/... -v
   - goveralls -coverprofile=profile.cov -service=travis-ci -v
-  - travis_wait 20 make e2e
+  - make e2e

--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -263,6 +263,11 @@ spec:
                   type: boolean
                 enable_replica_load_balancer:
                   type: boolean
+                external_traffic_policy:
+                  type: string
+                  enum:
+                    - "Cluster"
+                    - "Local"
                 master_dns_name_format:
                   type: string
                 replica_dns_name_format:

--- a/charts/postgres-operator/templates/configmap.yaml
+++ b/charts/postgres-operator/templates/configmap.yaml
@@ -9,6 +9,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 data:
+  {{- if .Values.podPriorityClassName }}
+  pod_priority_class_name: {{ .Values.podPriorityClassName }}
+  {{- end }}
   pod_service_account_name: {{ include "postgres-pod.serviceAccountName" . }}
 {{ toYaml .Values.configGeneral | indent 2 }}
 {{ toYaml .Values.configUsers | indent 2 }}

--- a/charts/postgres-operator/templates/operatorconfiguration.yaml
+++ b/charts/postgres-operator/templates/operatorconfiguration.yaml
@@ -13,6 +13,9 @@ configuration:
   users:
 {{ toYaml .Values.configUsers | indent 4 }}
   kubernetes:
+    {{- if .Values.podPriorityClassName }}
+    pod_priority_class_name: {{ .Values.podPriorityClassName }}
+    {{- end }}
     pod_service_account_name: {{ include "postgres-pod.serviceAccountName" . }}
     oauth_token_secret_name: {{ template "postgres-operator.fullname" . }}
 {{ toYaml .Values.configKubernetes | indent 4 }}

--- a/charts/postgres-operator/templates/postgres-pod-priority-class.yaml
+++ b/charts/postgres-operator/templates/postgres-pod-priority-class.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.priorityClassName }}
+{{- if .Values.podPriorityClassName }}
 apiVersion: scheduling.k8s.io/v1
 description: 'Use only for databases controlled by Postgres operator'
 kind: PriorityClass
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ template "postgres-operator.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-  name: {{ .Values.priorityClassName }}
+  name: {{ .Values.podPriorityClassName }}
 preemptionPolicy: PreemptLowerPriority
 globalDefault: false
 value: 1000000

--- a/charts/postgres-operator/templates/postgres-pod-priority-class.yaml
+++ b/charts/postgres-operator/templates/postgres-pod-priority-class.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.priorityClassName }}
+apiVersion: scheduling.k8s.io/v1
+description: 'Use only for databases controlled by Postgres operator'
+kind: PriorityClass
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
+    helm.sh/chart: {{ template "postgres-operator.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ .Values.priorityClassName }}
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+value: 1000000
+{{- end }}

--- a/charts/postgres-operator/values-crd.yaml
+++ b/charts/postgres-operator/values-crd.yaml
@@ -320,7 +320,11 @@ podServiceAccount:
   # If not set a name is generated using the fullname template and "-pod" suffix
   name: "postgres-pod"
 
+# priority class for operator pod
 priorityClassName: ""
+
+# priority class for database pods
+podPriorityClassName: ""
 
 resources:
   limits:

--- a/charts/postgres-operator/values-crd.yaml
+++ b/charts/postgres-operator/values-crd.yaml
@@ -183,6 +183,8 @@ configLoadBalancer:
   enable_master_load_balancer: false
   # toggles service type load balancer pointing to the replica pod of the cluster
   enable_replica_load_balancer: false
+  # define external traffic policy for the load balancer
+  external_traffic_policy: "Cluster"
   # defines the DNS name string template for the master load balancer cluster
   master_dns_name_format: "{cluster}.{team}.{hostedzone}"
   # defines the DNS name string template for the replica load balancer cluster

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -312,7 +312,11 @@ podServiceAccount:
   # If not set a name is generated using the fullname template and "-pod" suffix
   name: "postgres-pod"
 
+# priority class for operator pod
 priorityClassName: ""
+
+# priority class for database pods
+podPriorityClassName: ""
 
 resources:
   limits:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -172,6 +172,8 @@ configLoadBalancer:
   enable_master_load_balancer: "false"
   # toggles service type load balancer pointing to the replica pod of the cluster
   enable_replica_load_balancer: "false"
+  # define external traffic policy for the load balancer
+  external_traffic_policy: "Cluster"
   # defines the DNS name string template for the master load balancer cluster
   master_dns_name_format: '{cluster}.{team}.{hostedzone}'
   # defines the DNS name string template for the replica load balancer cluster

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -434,6 +434,12 @@ CRD-based configuration.
 Those options affect the behavior of load balancers created by the operator.
 In the CRD-based configuration they are grouped under the `load_balancer` key.
 
+* **custom_service_annotations**
+  This key/value map provides a list of annotations that get attached to each
+  service of a cluster created by the operator. If the annotation key is also
+  provided by the cluster definition, the manifest value is used.
+  Optional.
+
 * **db_hosted_zone**
   DNS zone for the cluster DNS name when the load balancer is configured for
   the cluster. Only used when combined with
@@ -450,11 +456,8 @@ In the CRD-based configuration they are grouped under the `load_balancer` key.
   cluster.  Can be overridden by individual cluster settings. The default is
   `false`.
 
-* **custom_service_annotations**
-  This key/value map provides a list of annotations that get attached to each
-  service of a cluster created by the operator. If the annotation key is also
-  provided by the cluster definition, the manifest value is used.
-  Optional.
+* **external_traffic_policy** defines external traffic policy for load
+  balancers. Allowed values are `Cluster` (default) and `Local`.
 
 * **master_dns_name_format** defines the DNS name string template for the
   master load balancer cluster.  The default is
@@ -469,9 +472,6 @@ In the CRD-based configuration they are grouped under the `load_balancer` key.
   cluster name, `{team}` is replaced with the team name and `{hostedzone}` is
   replaced with the hosted zone (the value of the `db_hosted_zone` parameter).
   No other placeholders are allowed.
-
-* **external_traffic_policy** define external traffic policy for the load
-balancer, it will default to `Cluster` if undefined.
 
 ## AWS or GCP interaction
 

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/tools v0.0.0-20200828161849-5deb26317202 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	golang.org/x/tools v0.0.0-20200928201943-a0ef9b62deab // indirect
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.18.8
 	k8s.io/apiextensions-apiserver v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -287,7 +287,7 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
@@ -333,8 +333,8 @@ golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
-golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
@@ -386,11 +386,10 @@ golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200828161849-5deb26317202 h1:DrWbY9UUFi/sl/3HkNVoBjDbGfIPZZfgoGsGxOL1EU8=
-golang.org/x/tools v0.0.0-20200828161849-5deb26317202/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20200928201943-a0ef9b62deab h1:CyH2SDm5ATQiX9gtbMYfvNNed97A9v+TJFnUX/fTaJY=
+golang.org/x/tools v0.0.0-20200928201943-a0ef9b62deab/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -47,6 +47,7 @@ data:
   # enable_team_superuser: "false"
   enable_teams_api: "false"
   # etcd_host: ""
+  external_traffic_policy: "Cluster"
   # gcp_credentials: ""
   # kubernetes_use_configmaps: "false"
   # infrastructure_roles_secret_name: "postgresql-infrastructure-roles"
@@ -80,12 +81,12 @@ data:
   # pod_environment_secret: "my-custom-secret"
   pod_label_wait_timeout: 10m
   pod_management_policy: "ordered_ready"
+  # pod_priority_class_name: "postgres-pod-priority"
   pod_role_label: spilo-role
   # pod_service_account_definition: ""
   pod_service_account_name: "postgres-pod"
   # pod_service_account_role_binding_definition: ""
   pod_terminate_grace_period: 5m
-  # pod_priority_class_name: "postgres-pod-priority"
   # postgres_superuser_teams: "postgres_superusers"
   # protected_role_names: "admin"
   ready_wait_interval: 3s

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -265,6 +265,11 @@ spec:
                   type: boolean
                 enable_replica_load_balancer:
                   type: boolean
+                external_traffic_policy:
+                  type: string
+                  enum:
+                    - "Cluster"
+                    - "Local"
                 master_dns_name_format:
                   type: string
                 replica_dns_name_format:

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -61,7 +61,7 @@ configuration:
     # pod_environment_configmap: "default/my-custom-config"
     # pod_environment_secret: "my-custom-secret"
     pod_management_policy: "ordered_ready"
-    # pod_priority_class_name: ""
+    # pod_priority_class_name: "postgres-pod-priority"
     pod_role_label: spilo-role
     # pod_service_account_definition: ""
     pod_service_account_name: postgres-pod
@@ -90,12 +90,13 @@ configuration:
     resource_check_interval: 3s
     resource_check_timeout: 10m
   load_balancer:
-    # db_hosted_zone: ""
-    enable_master_load_balancer: false
-    enable_replica_load_balancer: false
     # custom_service_annotations:
     #   keyx: valuex
     #   keyy: valuey
+    # db_hosted_zone: ""
+    enable_master_load_balancer: false
+    enable_replica_load_balancer: false
+    external_traffic_policy: "Cluster"
     master_dns_name_format: "{cluster}.{team}.{hostedzone}"
     replica_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
   aws_or_gcp:

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1135,12 +1135,6 @@ var OperatorConfigCRDResourceValidation = apiextv1beta1.CustomResourceValidation
 							"enable_replica_load_balancer": {
 								Type: "boolean",
 							},
-							"master_dns_name_format": {
-								Type: "string",
-							},
-							"replica_dns_name_format": {
-								Type: "string",
-							},
 							"external_traffic_policy": {
 								Type: "string",
 								Enum: []apiextv1beta1.JSON{
@@ -1151,6 +1145,12 @@ var OperatorConfigCRDResourceValidation = apiextv1beta1.CustomResourceValidation
 										Raw: []byte(`"Local"`),
 									},
 								},
+							},
+							"master_dns_name_format": {
+								Type: "string",
+							},
+							"replica_dns_name_format": {
+								Type: "string",
 							},
 						},
 					},

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -193,20 +193,19 @@ type OperatorLogicalBackupConfiguration struct {
 
 // OperatorConfigurationData defines the operation config
 type OperatorConfigurationData struct {
-	EnableCRDValidation     *bool    `json:"enable_crd_validation,omitempty"`
-	EnableLazySpiloUpgrade  bool     `json:"enable_lazy_spilo_upgrade,omitempty"`
-	EtcdHost                string   `json:"etcd_host,omitempty"`
-	KubernetesUseConfigMaps bool     `json:"kubernetes_use_configmaps,omitempty"`
-	DockerImage             string   `json:"docker_image,omitempty"`
-	Workers                 uint32   `json:"workers,omitempty"`
-	MinInstances            int32    `json:"min_instances,omitempty"`
-	MaxInstances            int32    `json:"max_instances,omitempty"`
-	ResyncPeriod            Duration `json:"resync_period,omitempty"`
-	RepairPeriod            Duration `json:"repair_period,omitempty"`
-	SetMemoryRequestToLimit bool     `json:"set_memory_request_to_limit,omitempty"`
-	ShmVolume               *bool    `json:"enable_shm_volume,omitempty"`
-	// deprecated in favour of SidecarContainers
-	SidecarImages              map[string]string                  `json:"sidecar_docker_images,omitempty"`
+	EnableCRDValidation        *bool                              `json:"enable_crd_validation,omitempty"`
+	EnableLazySpiloUpgrade     bool                               `json:"enable_lazy_spilo_upgrade,omitempty"`
+	EtcdHost                   string                             `json:"etcd_host,omitempty"`
+	KubernetesUseConfigMaps    bool                               `json:"kubernetes_use_configmaps,omitempty"`
+	DockerImage                string                             `json:"docker_image,omitempty"`
+	Workers                    uint32                             `json:"workers,omitempty"`
+	MinInstances               int32                              `json:"min_instances,omitempty"`
+	MaxInstances               int32                              `json:"max_instances,omitempty"`
+	ResyncPeriod               Duration                           `json:"resync_period,omitempty"`
+	RepairPeriod               Duration                           `json:"repair_period,omitempty"`
+	SetMemoryRequestToLimit    bool                               `json:"set_memory_request_to_limit,omitempty"`
+	ShmVolume                  *bool                              `json:"enable_shm_volume,omitempty"`
+	SidecarImages              map[string]string                  `json:"sidecar_docker_images,omitempty"` // deprecated in favour of SidecarContainers
 	SidecarContainers          []v1.Container                     `json:"sidecars,omitempty"`
 	PostgresUsersConfiguration PostgresUsersConfiguration         `json:"users"`
 	Kubernetes                 KubernetesMetaConfiguration        `json:"kubernetes"`

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -143,14 +143,13 @@ type Config struct {
 	LogicalBackup
 	ConnectionPooler
 
-	WatchedNamespace        string `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
-	KubernetesUseConfigMaps bool   `name:"kubernetes_use_configmaps" default:"false"`
-	EtcdHost                string `name:"etcd_host" default:""` // special values: the empty string "" means Patroni will use K8s as a DCS
-	DockerImage             string `name:"docker_image" default:"registry.opensource.zalan.do/acid/spilo-12:1.6-p3"`
-	// deprecated in favour of SidecarContainers
-	SidecarImages         map[string]string `name:"sidecar_docker_images"`
-	SidecarContainers     []v1.Container    `name:"sidecars"`
-	PodServiceAccountName string            `name:"pod_service_account_name" default:"postgres-pod"`
+	WatchedNamespace        string            `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
+	KubernetesUseConfigMaps bool              `name:"kubernetes_use_configmaps" default:"false"`
+	EtcdHost                string            `name:"etcd_host" default:""` // special values: the empty string "" means Patroni will use K8s as a DCS
+	DockerImage             string            `name:"docker_image" default:"registry.opensource.zalan.do/acid/spilo-12:1.6-p3"`
+	SidecarImages           map[string]string `name:"sidecar_docker_images"` // deprecated in favour of SidecarContainers
+	SidecarContainers       []v1.Container    `name:"sidecars"`
+	PodServiceAccountName   string            `name:"pod_service_account_name" default:"postgres-pod"`
 	// value of this string must be valid JSON or YAML; see initPodServiceAccount
 	PodServiceAccountDefinition            string            `name:"pod_service_account_definition" default:""`
 	PodServiceAccountRoleBindingDefinition string            `name:"pod_service_account_role_binding_definition" default:""`
@@ -177,26 +176,25 @@ type Config struct {
 	EnablePodAntiAffinity                  bool              `name:"enable_pod_antiaffinity" default:"false"`
 	PodAntiAffinityTopologyKey             string            `name:"pod_antiaffinity_topology_key" default:"kubernetes.io/hostname"`
 	StorageResizeMode                      string            `name:"storage_resize_mode" default:"ebs"`
-	// deprecated and kept for backward compatibility
-	EnableLoadBalancer        *bool             `name:"enable_load_balancer"`
-	ExternalTrafficPolicy     string            `name:"external_traffic_policy" default:"Cluster"`
-	MasterDNSNameFormat       StringTemplate    `name:"master_dns_name_format" default:"{cluster}.{team}.{hostedzone}"`
-	ReplicaDNSNameFormat      StringTemplate    `name:"replica_dns_name_format" default:"{cluster}-repl.{team}.{hostedzone}"`
-	PDBNameFormat             StringTemplate    `name:"pdb_name_format" default:"postgres-{cluster}-pdb"`
-	EnablePodDisruptionBudget *bool             `name:"enable_pod_disruption_budget" default:"true"`
-	EnableInitContainers      *bool             `name:"enable_init_containers" default:"true"`
-	EnableSidecars            *bool             `name:"enable_sidecars" default:"true"`
-	Workers                   uint32            `name:"workers" default:"8"`
-	APIPort                   int               `name:"api_port" default:"8080"`
-	RingLogLines              int               `name:"ring_log_lines" default:"100"`
-	ClusterHistoryEntries     int               `name:"cluster_history_entries" default:"1000"`
-	TeamAPIRoleConfiguration  map[string]string `name:"team_api_role_configuration" default:"log_statement:all"`
-	PodTerminateGracePeriod   time.Duration     `name:"pod_terminate_grace_period" default:"5m"`
-	PodManagementPolicy       string            `name:"pod_management_policy" default:"ordered_ready"`
-	ProtectedRoles            []string          `name:"protected_role_names" default:"admin"`
-	PostgresSuperuserTeams    []string          `name:"postgres_superuser_teams" default:""`
-	SetMemoryRequestToLimit   bool              `name:"set_memory_request_to_limit" default:"false"`
-	EnableLazySpiloUpgrade    bool              `name:"enable_lazy_spilo_upgrade" default:"false"`
+	EnableLoadBalancer                     *bool             `name:"enable_load_balancer"` // deprecated and kept for backward compatibility
+	ExternalTrafficPolicy                  string            `name:"external_traffic_policy" default:"Cluster"`
+	MasterDNSNameFormat                    StringTemplate    `name:"master_dns_name_format" default:"{cluster}.{team}.{hostedzone}"`
+	ReplicaDNSNameFormat                   StringTemplate    `name:"replica_dns_name_format" default:"{cluster}-repl.{team}.{hostedzone}"`
+	PDBNameFormat                          StringTemplate    `name:"pdb_name_format" default:"postgres-{cluster}-pdb"`
+	EnablePodDisruptionBudget              *bool             `name:"enable_pod_disruption_budget" default:"true"`
+	EnableInitContainers                   *bool             `name:"enable_init_containers" default:"true"`
+	EnableSidecars                         *bool             `name:"enable_sidecars" default:"true"`
+	Workers                                uint32            `name:"workers" default:"8"`
+	APIPort                                int               `name:"api_port" default:"8080"`
+	RingLogLines                           int               `name:"ring_log_lines" default:"100"`
+	ClusterHistoryEntries                  int               `name:"cluster_history_entries" default:"1000"`
+	TeamAPIRoleConfiguration               map[string]string `name:"team_api_role_configuration" default:"log_statement:all"`
+	PodTerminateGracePeriod                time.Duration     `name:"pod_terminate_grace_period" default:"5m"`
+	PodManagementPolicy                    string            `name:"pod_management_policy" default:"ordered_ready"`
+	ProtectedRoles                         []string          `name:"protected_role_names" default:"admin"`
+	PostgresSuperuserTeams                 []string          `name:"postgres_superuser_teams" default:""`
+	SetMemoryRequestToLimit                bool              `name:"set_memory_request_to_limit" default:"false"`
+	EnableLazySpiloUpgrade                 bool              `name:"enable_lazy_spilo_upgrade" default:"false"`
 }
 
 // MustMarshal marshals the config or panics

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -177,10 +177,9 @@ type Config struct {
 	EnablePodAntiAffinity                  bool              `name:"enable_pod_antiaffinity" default:"false"`
 	PodAntiAffinityTopologyKey             string            `name:"pod_antiaffinity_topology_key" default:"kubernetes.io/hostname"`
 	StorageResizeMode                      string            `name:"storage_resize_mode" default:"ebs"`
-	// ExternalTrafficPolicy for load balancer
-	ExternalTrafficPolicy string `name:"external_traffic_policy" default:"Cluster"`
 	// deprecated and kept for backward compatibility
 	EnableLoadBalancer        *bool             `name:"enable_load_balancer"`
+	ExternalTrafficPolicy     string            `name:"external_traffic_policy" default:"Cluster"`
 	MasterDNSNameFormat       StringTemplate    `name:"master_dns_name_format" default:"{cluster}.{team}.{hostedzone}"`
 	ReplicaDNSNameFormat      StringTemplate    `name:"replica_dns_name_format" default:"{cluster}-repl.{team}.{hostedzone}"`
 	PDBNameFormat             StringTemplate    `name:"pdb_name_format" default:"postgres-{cluster}-pdb"`


### PR DESCRIPTION
#1136 was merged but this new config option wasn't covered in sample manifests and helm chart.

This PR also adds examples for pod priority class in helm chart and updates travis and go modules.