### PR TITLE
Remove repeated initialization of Pod ServiceAccount

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -295,7 +295,6 @@ func (c *Controller) initController() {
 		c.logger.Fatalf("could not register Postgres CustomResourceDefinition: %v", err)
 	}
 
-	c.initPodServiceAccount()
 	c.initSharedInformers()
 
 	if c.opConfig.DebugLogging {


### PR DESCRIPTION
The function of  initPodServiceAccount() has been invoked at line 289, Remove repeated initialization of Pod ServiceAccount 