### PR TITLE
Lookup function installation

### DIFF
--- a/e2e/exec.sh
+++ b/e2e/exec.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-kubectl exec -it $1 -- sh -c "$2"
+kubectl exec -i $1 -- sh -c "$2"

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -15,6 +15,14 @@ def to_selector(labels):
     return ",".join(["=".join(l) for l in labels.items()])
 
 
+def clean_list(values):
+    # value is not stripped bytes, strip and convert to a string
+    clean = lambda v: v.strip().decode()
+    notNone = lambda v: v
+
+    return list(filter(notNone, map(clean, values)))
+
+
 class EndToEndTestCase(unittest.TestCase):
     '''
     Test interaction of the operator with multiple K8s components.
@@ -140,6 +148,58 @@ class EndToEndTestCase(unittest.TestCase):
 
             k8s.wait_for_running_pods(pod_selector, 2)
 
+            # Verify that all the databases have pooler schema installed.
+            # Do this via psql, since otherwise we need to deal with
+            # credentials.
+            dbList = []
+
+            leader = k8s.get_cluster_leader_pod('acid-minimal-cluster')
+            dbListQuery = "select datname from pg_database"
+            schemasQuery = """
+                select schema_name
+                from information_schema.schemata
+                where schema_name = 'pooler'
+            """
+            exec_query = r"psql -tAq -c \"{}\" -d {}"
+
+            if leader:
+                try:
+                    q = exec_query.format(dbListQuery, "postgres")
+                    q = "su postgres -c \"{}\"".format(q)
+                    print('Get databases: {}'.format(q))
+                    result = k8s.exec_with_kubectl(leader.metadata.name, q)
+                    dbList = clean_list(result.stdout.split(b'\n'))
+                    print('dbList: {}, stdout: {}, stderr {}'.format(
+                        dbList, result.stdout, result.stderr
+                    ))
+                except Exception as ex:
+                    print('Could not get databases: {}'.format(ex))
+                    print('Stdout: {}'.format(result.stdout))
+                    print('Stderr: {}'.format(result.stderr))
+
+                for db in dbList:
+                    if db in ('template0', 'template1'):
+                        continue
+
+                    schemas = []
+                    try:
+                        q = exec_query.format(schemasQuery, db)
+                        q = "su postgres -c \"{}\"".format(q)
+                        print('Get schemas: {}'.format(q))
+                        result = k8s.exec_with_kubectl(leader.metadata.name, q)
+                        schemas = clean_list(result.stdout.split(b'\n'))
+                        print('schemas: {}, stdout: {}, stderr {}'.format(
+                            schemas, result.stdout, result.stderr
+                        ))
+                    except Exception as ex:
+                        print('Could not get databases: {}'.format(ex))
+                        print('Stdout: {}'.format(result.stdout))
+                        print('Stderr: {}'.format(result.stderr))
+
+                    self.assertNotEqual(len(schemas), 0)
+            else:
+                print('Could not find leader pod')
+
             # turn it off, keeping configuration section
             k8s.api.custom_objects_api.patch_namespaced_custom_object(
                 'acid.zalan.do', 'v1', 'default',
@@ -235,7 +295,10 @@ class EndToEndTestCase(unittest.TestCase):
             # operator configuration via API
             operator_pod = k8s.get_operator_pod()
             get_config_cmd = "wget --quiet -O - localhost:8080/config"
-            result = k8s.exec_with_kubectl(operator_pod.metadata.name, get_config_cmd)
+            result = k8s.exec_with_kubectl(
+                operator_pod.metadata.name,
+                get_config_cmd,
+            )
             roles_dict = (json.loads(result.stdout)
                           .get("controller", {})
                           .get("InfrastructureRoles"))
@@ -861,6 +924,19 @@ class K8s:
                 replica_pod_nodes.append(pod.spec.node_name)
 
         return master_pod_node, replica_pod_nodes
+
+    def get_cluster_leader_pod(self, pg_cluster_name, namespace='default'):
+        labels = {
+            'application': 'spilo',
+            'cluster-name': pg_cluster_name,
+            'spilo-role': 'master',
+        }
+
+        pods = self.api.core_v1.list_namespaced_pod(
+                namespace, label_selector=to_selector(labels)).items
+
+        if pods:
+            return pods[0]
 
     def wait_for_operator_pod_start(self):
         self. wait_for_pod_start("name=postgres-operator")

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -780,7 +780,13 @@ func (c *Cluster) Update(oldSpec, newSpec *acidv1.Postgresql) error {
 		}
 	}
 
-	// sync connection pooler
+	// Sync connection pooler. Before actually doing sync reset lookup
+	// installation flag, since manifest updates could add another db which we
+	// need to process. In the future we may want to do this more careful and
+	// check which databases we need to process, but even repeating the whole
+	// installation process should be good enough.
+	c.ConnectionPooler.LookupFunction = false
+
 	if _, err := c.syncConnectionPooler(oldSpec, newSpec,
 		c.installLookupFunction); err != nil {
 		c.logger.Errorf("could not sync connection pooler: %v", err)

--- a/pkg/cluster/database.go
+++ b/pkg/cluster/database.go
@@ -151,7 +151,9 @@ func (c *Cluster) initDbConnWithName(dbname string) error {
 	conn.SetMaxIdleConns(-1)
 
 	if c.pgDb != nil {
-		c.logger.Warningf("Overwriting connection %v", c.pgDb)
+		msg := "Closing an existing connection before opening a new one to %s"
+		c.logger.Warningf(msg, dbname)
+		c.closeDbConn()
 	}
 
 	c.pgDb = conn

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -847,7 +847,9 @@ func (c *Cluster) syncConnectionPooler(oldSpec,
 	var err error
 
 	if c.ConnectionPooler == nil {
-		c.ConnectionPooler = &ConnectionPoolerObjects{}
+		c.ConnectionPooler = &ConnectionPoolerObjects{
+			LookupFunction: false,
+		}
 	}
 
 	newNeedConnectionPooler := c.needConnectionPoolerWorker(&newSpec.Spec)
@@ -885,6 +887,11 @@ func (c *Cluster) syncConnectionPooler(oldSpec,
 			if err = lookup(schema, user); err != nil {
 				return NoSync, err
 			}
+		} else {
+			// Lookup function installation seems to be a fragile point, so
+			// let's log for debugging if we skip it
+			msg := "Skip lookup function installation, old: %d, already installed %d"
+			c.logger.Debug(msg, oldNeedConnectionPooler, c.ConnectionPooler.LookupFunction)
 		}
 
 		if reason, err = c.syncConnectionPoolerWorker(oldSpec, newSpec); err != nil {


### PR DESCRIPTION
Apparently lookup function installation process is somewhat fragile right now.
It seems that it happens because a connection to an original db could be
somehow reused when we iterate over available databases, and the required
pooler appliance is installed into a wrong db (does it happen due to some
golang optimization reshuffling the code?). To prevent that and make the
implementation more robust, put more debug logging about installation process,
close connection before opening a new one and check to which database we
actually connected to. One more minor fix is to reset stmtBytes, as it was
accumulating stuff in between (which does not lead to any issues, as appliance
queries are idempotent, but still).

Fixes #1060 