### PR TITLE
[WIP] Use MinIO in e2e tests

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -48,6 +48,10 @@ tools:
 	# go get must run outside of a dir with a (module-based) Go project !
 	# otherwise go get updates project's dependencies and/or behaves differently
 	cd "/tmp" && GO111MODULE=on go get sigs.k8s.io/kind@v0.9.0
+	# install helm to be able to deploy MinIO Helm Chart
+	wget -P /tmp https://get.helm.sh/helm-v3.3.4-linux-amd64.tar.gz
+	mkdir /tmp/helm-postgres-operator-e2e-tests
+	tar -C /tmp/helm-postgres-operator-e2e-tests --strip-components 1 -zxvf /tmp/helm-v3.3.4-linux-amd64.tar.gz
 
 e2etest: tools copy clean
 	./run.sh main

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,3 +1,4 @@
 kubernetes==11.0.0
 timeout_decorator==0.4.1
 pyyaml==5.3.1
+minio=6.0.0

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -53,6 +53,7 @@ function set_kind_api_server_ip(){
 
 function deploy_minio(){
  echo "Deploying MinIO object storage..."
+ /tmp/helm-postgres-operator-e2e-tests/helm repo update
  /tmp/helm-postgres-operator-e2e-tests/helm install --generate-name minio/minio
 }
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -53,8 +53,8 @@ function set_kind_api_server_ip(){
 
 function deploy_minio(){
  echo "Deploying MinIO object storage..."
- /tmp/helm-postgres-operator-e2e-tests/helm repo update
  /tmp/helm-postgres-operator-e2e-tests/helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+ /tmp/helm-postgres-operator-e2e-tests/helm repo update
  /tmp/helm-postgres-operator-e2e-tests/helm install --generate-name minio/minio
  kubectl create file manifests/minio-configmap.yaml
 }

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -55,6 +55,7 @@ function deploy_minio(){
  echo "Deploying MinIO object storage..."
  /tmp/helm-postgres-operator-e2e-tests/helm repo update
  /tmp/helm-postgres-operator-e2e-tests/helm install --generate-name minio/minio
+ kubectl create file manifests/minio-configmap.yaml
 }
 
 function run_tests(){

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -54,6 +54,7 @@ function set_kind_api_server_ip(){
 function deploy_minio(){
  echo "Deploying MinIO object storage..."
  /tmp/helm-postgres-operator-e2e-tests/helm repo update
+ /tmp/helm-postgres-operator-e2e-tests/helm repo add stable https://kubernetes-charts.storage.googleapis.com/
  /tmp/helm-postgres-operator-e2e-tests/helm install --generate-name minio/minio
  kubectl create file manifests/minio-configmap.yaml
 }

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -10,6 +10,9 @@ import yaml
 from datetime import datetime
 from kubernetes import client, config
 
+from minio import Minio
+from minio.error import ResponseError
+
 
 def to_selector(labels):
     return ",".join(["=".join(l) for l in labels.items()])
@@ -35,6 +38,18 @@ class EndToEndTestCase(unittest.TestCase):
         next invocation of "make test" will re-create it.
         '''
         print("Test Setup being executed")
+
+        # create Minio bucket to store WAL
+        minioClient = Minio(
+        'play.min.io',
+        access_key=os.environ['ACCESS_KEY'],
+        secret_key=os.environ['SECRET_KEY']
+        )
+
+        try:
+            minioClient.make_bucket("minio/wal", location="us-east-1")
+        except ResponseError as err:
+            raise
 
         # set a single K8s wrapper for all tests
         k8s = cls.k8s = K8s()

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -77,7 +77,7 @@ data:
   pdb_name_format: "postgres-{cluster}-pdb"
   # pod_antiaffinity_topology_key: "kubernetes.io/hostname"
   pod_deletion_wait_timeout: 10m
-  # pod_environment_configmap: "default/my-custom-config"
+  pod_environment_configmap: "default/minio-configmap" # example used in e2e tests
   # pod_environment_secret: "my-custom-secret"
   pod_label_wait_timeout: 10m
   pod_management_policy: "ordered_ready"
@@ -112,6 +112,6 @@ data:
   # teams_api_url: http://fake-teams-api.default.svc.cluster.local
   # toleration: ""
   # wal_gs_bucket: ""
-  # wal_s3_bucket: ""
+  wal_s3_bucket: "minio/wal"
   watched_namespace: "*"  # listen to all namespaces
   workers: "8"

--- a/manifests/minio-configmap.yaml
+++ b/manifests/minio-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: minio-configmap
+data:
+  MINIO_ACCESS_KEY: WU9VUkFDQ0VTU0tFWQo=
+  MINIO_SECRET_KEY: WU9VUlNFQ1JFVEtFWQo=


### PR DESCRIPTION
We need MinIO to be able to store backups/WALs during e2e tests.

That would enable 
1. Testing existing operator capabilities such as cloning a cluster from a backup resting in a storage bucket.
2. Testing upcoming changes in the WAL storage path. Newer Spilo versions  add the support of the major version upgrade but they require the path to contain the PG version number, which was not previously the case. With automated tests we want to ensure the seamless upgrade.

This PR deploys and configures MinIO in the e2e pipeline for future use.

Related #1160 