### PR TITLE
add maxLength constraint for CRD

### DIFF
--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -75,7 +75,7 @@ spec:
           properties:
             name:
               type: string
-              maxLength: 50
+              maxLength: 53
         spec:
           type: object
           required:

--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -57,6 +57,7 @@ spec:
       required:
         - kind
         - apiVersion
+        - metadata
         - spec
       properties:
         kind:
@@ -67,6 +68,14 @@ spec:
           type: string
           enum:
             - acid.zalan.do/v1
+        metadata:
+          type: object
+          required:
+            - name
+          properties:
+            name:
+              type: string
+              maxLength: 50
         spec:
           type: object
           required:

--- a/docs/user.md
+++ b/docs/user.md
@@ -49,7 +49,7 @@ Note, that the name of the cluster must start with the `teamId` and `-`. At
 Zalando we use team IDs (nicknames) to lower the chance of duplicate cluster
 names and colliding entities. The team ID would also be used to query an API to
 get all members of a team and create [database roles](#teams-api-roles) for
-them.
+them. Besides, the maximum cluster name length is 53 characters.
 
 ## Watch pods being created
 

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -53,6 +53,7 @@ spec:
       required:
         - kind
         - apiVersion
+        - metadata
         - spec
       properties:
         kind:
@@ -63,6 +64,14 @@ spec:
           type: string
           enum:
             - acid.zalan.do/v1
+        metadata:
+          type: object
+          required:
+            - name
+          properties:
+            name:
+              type: string
+              maxLength: 50
         spec:
           type: object
           required:

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -71,7 +71,7 @@ spec:
           properties:
             name:
               type: string
-              maxLength: 50
+              maxLength: 53
         spec:
           type: object
           required:

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -107,7 +107,7 @@ var min0 = 0.0
 var min1 = 1.0
 var min2 = 2.0
 var minDisable = -1.0
-var maxLength = int64(50)
+var maxLength = int64(53)
 
 // PostgresCRDResourceValidation to check applied manifest parameters
 var PostgresCRDResourceValidation = apiextv1beta1.CustomResourceValidation{

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -107,12 +107,13 @@ var min0 = 0.0
 var min1 = 1.0
 var min2 = 2.0
 var minDisable = -1.0
+var maxLength = int64(50)
 
 // PostgresCRDResourceValidation to check applied manifest parameters
 var PostgresCRDResourceValidation = apiextv1beta1.CustomResourceValidation{
 	OpenAPIV3Schema: &apiextv1beta1.JSONSchemaProps{
 		Type:     "object",
-		Required: []string{"kind", "apiVersion", "spec"},
+		Required: []string{"kind", "apiVersion", "metadata", "spec"},
 		Properties: map[string]apiextv1beta1.JSONSchemaProps{
 			"kind": {
 				Type: "string",
@@ -127,6 +128,16 @@ var PostgresCRDResourceValidation = apiextv1beta1.CustomResourceValidation{
 				Enum: []apiextv1beta1.JSON{
 					{
 						Raw: []byte(`"acid.zalan.do/v1"`),
+					},
+				},
+			},
+			"metadata": {
+				Type:     "object",
+				Required: []string{"name"},
+				Properties: map[string]apiextv1beta1.JSONSchemaProps{
+					"name": {
+						Type:      "string",
+						MaxLength: &maxLength,
 					},
 				},
 			},


### PR DESCRIPTION
Because otherwise cluster creation will silently fail when label length is exceeded (e.g. cluster name + random revision value)