### PR TITLE
disable PostgresTeam by default

### DIFF
--- a/charts/postgres-operator/values-crd.yaml
+++ b/charts/postgres-operator/values-crd.yaml
@@ -257,7 +257,7 @@ configTeamsApi:
   # enable_admin_role_for_users: true
 
   # operator watches for PostgresTeam CRs to assign additional teams and members to clusters
-  enable_postgres_team_crd: true
+  enable_postgres_team_crd: false
   # toogle to create additional superuser teams from PostgresTeam CRs
   # enable_postgres_team_crd_superusers: "false"
 

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -1,7 +1,7 @@
 image:
   registry: registry.opensource.zalan.do
   repository: acid/postgres-operator
-  tag: v1.5.0-61-ged2b3239-dirty 
+  tag: v1.5.0-61-ged2b3239-dirty
   pullPolicy: "IfNotPresent"
 
 # Optionally specify an array of imagePullSecrets.
@@ -249,7 +249,7 @@ configTeamsApi:
   # enable_admin_role_for_users: "true"
 
   # operator watches for PostgresTeam CRs to assign additional teams and members to clusters
-  enable_postgres_team_crd: "true"
+  enable_postgres_team_crd: "false"
   # toogle to create additional superuser teams from PostgresTeam CRs
   # enable_postgres_team_crd_superusers: "false"
 

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -1,7 +1,7 @@
 image:
   registry: registry.opensource.zalan.do
   repository: acid/postgres-operator
-  tag: v1.5.0-61-ged2b3239-dirty
+  tag: v1.5.0
   pullPolicy: "IfNotPresent"
 
 # Optionally specify an array of imagePullSecrets.

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -635,7 +635,7 @@ key.
 * **enable_postgres_team_crd**
   toggle to make the operator watch for created or updated `PostgresTeam` CRDs
   and create roles for specified additional teams and members.
-  The default is `true`.
+  The default is `false`.
 
 * **enable_postgres_team_crd_superusers**
   in a `PostgresTeam` CRD additional superuser teams can assigned to teams that

--- a/docs/user.md
+++ b/docs/user.md
@@ -330,6 +330,11 @@ spec:
     - "foo"
 ```
 
+Note, by default the `PostgresTeam` support is disabled in the configuration.
+Switch `enable_postgres_team_crd` flag to `true` and the operator will start to
+watch for this CRD. Make sure, the cluster role is up to date and contains a
+section for [PostgresTeam](../manifests/operator-service-account-rbac.yaml#L30).
+
 ## Prepared databases with roles and default privileges
 
 The `users` section in the manifests only allows for creating database roles

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -41,7 +41,7 @@ data:
   enable_master_load_balancer: "false"
   # enable_pod_antiaffinity: "false"
   # enable_pod_disruption_budget: "true"
-  # enable_postgres_team_crd: "true"
+  # enable_postgres_team_crd: "false"
   # enable_postgres_team_crd_superusers: "false"
   enable_replica_load_balancer: "false"
   # enable_shm_volume: "true"

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -122,7 +122,7 @@ configuration:
     enable_database_access: true
   teams_api:
     # enable_admin_role_for_users: true
-    # enable_postgres_team_crd: true
+    # enable_postgres_team_crd: false
     # enable_postgres_team_crd_superusers: false
     enable_team_superuser: false
     enable_teams_api: false

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -145,7 +145,7 @@ type TeamsAPIConfiguration struct {
 	PamConfiguration                string            `json:"pam_configuration,omitempty"`
 	ProtectedRoles                  []string          `json:"protected_role_names,omitempty"`
 	PostgresSuperuserTeams          []string          `json:"postgres_superuser_teams,omitempty"`
-	EnablePostgresTeamCRD           *bool             `json:"enable_postgres_team_crd,omitempty"`
+	EnablePostgresTeamCRD           bool              `json:"enable_postgres_team_crd,omitempty"`
 	EnablePostgresTeamCRDSuperusers bool              `json:"enable_postgres_team_crd_superusers,omitempty"`
 }
 

--- a/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
@@ -1114,11 +1114,6 @@ func (in *TeamsAPIConfiguration) DeepCopyInto(out *TeamsAPIConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.EnablePostgresTeamCRD != nil {
-		in, out := &in.EnablePostgresTeamCRD, &out.EnablePostgresTeamCRD
-		*out = new(bool)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -329,7 +329,7 @@ func (c *Controller) initController() {
 
 	c.initSharedInformers()
 
-	if c.opConfig.EnablePostgresTeamCRD != nil && *c.opConfig.EnablePostgresTeamCRD {
+	if c.opConfig.EnablePostgresTeamCRD {
 		c.loadPostgresTeams()
 	} else {
 		c.pgTeamMap = teams.PostgresTeamMap{}
@@ -380,7 +380,7 @@ func (c *Controller) initSharedInformers() {
 	})
 
 	// PostgresTeams
-	if c.opConfig.EnablePostgresTeamCRD != nil && *c.opConfig.EnablePostgresTeamCRD {
+	if c.opConfig.EnablePostgresTeamCRD {
 		c.postgresTeamInformer = acidv1informer.NewPostgresTeamInformer(
 			c.KubeClient.AcidV1ClientSet,
 			c.opConfig.WatchedNamespace,
@@ -453,7 +453,7 @@ func (c *Controller) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
 	go c.apiserver.Run(stopCh, wg)
 	go c.kubeNodesInformer(stopCh, wg)
 
-	if c.opConfig.EnablePostgresTeamCRD != nil && *c.opConfig.EnablePostgresTeamCRD {
+	if c.opConfig.EnablePostgresTeamCRD {
 		go c.runPostgresTeamInformer(stopCh, wg)
 	}
 

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -163,7 +163,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.PamConfiguration = util.Coalesce(fromCRD.TeamsAPI.PamConfiguration, "https://info.example.com/oauth2/tokeninfo?access_token= uid realm=/employees")
 	result.ProtectedRoles = util.CoalesceStrArr(fromCRD.TeamsAPI.ProtectedRoles, []string{"admin"})
 	result.PostgresSuperuserTeams = fromCRD.TeamsAPI.PostgresSuperuserTeams
-	result.EnablePostgresTeamCRD = util.CoalesceBool(fromCRD.TeamsAPI.EnablePostgresTeamCRD, util.True())
+	result.EnablePostgresTeamCRD = fromCRD.TeamsAPI.EnablePostgresTeamCRD
 	result.EnablePostgresTeamCRDSuperusers = fromCRD.TeamsAPI.EnablePostgresTeamCRDSuperusers
 
 	// logging REST API config

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -169,7 +169,7 @@ type Config struct {
 	EnableTeamSuperuser                    bool              `name:"enable_team_superuser" default:"false"`
 	TeamAdminRole                          string            `name:"team_admin_role" default:"admin"`
 	EnableAdminRoleForUsers                bool              `name:"enable_admin_role_for_users" default:"true"`
-	EnablePostgresTeamCRD                  *bool             `name:"enable_postgres_team_crd" default:"true"`
+	EnablePostgresTeamCRD                  bool              `name:"enable_postgres_team_crd" default:"false"`
 	EnablePostgresTeamCRDSuperusers        bool              `name:"enable_postgres_team_crd_superusers" default:"false"`
 	EnableMasterLoadBalancer               bool              `name:"enable_master_load_balancer" default:"true"`
 	EnableReplicaLoadBalancer              bool              `name:"enable_replica_load_balancer" default:"false"`


### PR DESCRIPTION
better disable by default to avoid polluting operator logs