### PR TITLE
fix redundant appending of infrastructure roles

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -341,9 +341,7 @@ func (c *Controller) getInfrastructureRole(
 				util.Coalesce(string(secretData[infraRole.RoleKey]), infraRole.DefaultRoleValue))
 		}
 
-		if roleDescr.Valid() {
-			roles = append(roles, *roleDescr)
-		} else {
+		if !roleDescr.Valid() {
 			msg := "infrastructure role %q is not complete and ignored"
 			c.logger.Warningf(msg, roleDescr)
 


### PR DESCRIPTION
only append once after the roleDescr checks. Should solve the `Conflicting infrastructure roles` error which one could see in the debug logs on operator start up