### PR TITLE
Truncate cronjob name at 52 characters

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2079,7 +2079,7 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 
 // getLogicalBackupJobName returns the name; the job itself may not exists
 func (c *Cluster) getLogicalBackupJobName() (jobName string) {
-	return c.OpConfig.LogicalBackupJobPrefix + c.clusterName().Name
+	return trimCronjobName(c.OpConfig.LogicalBackupJobPrefix + c.clusterName().Name)
 }
 
 // Return an array of ownerReferences to make an arbitraty object dependent on

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -576,3 +576,12 @@ func mergeContainers(containers ...[]v1.Container) ([]v1.Container, []string) {
 	}
 	return result, conflicts
 }
+
+func trimCronjobName(name string) string {
+	maxLength := 52
+	if len(name) > maxLength {
+		name = name[0:maxLength]
+		name = strings.TrimRight(name, "-")
+	}
+	return name
+}

--- a/pkg/cluster/util_test.go
+++ b/pkg/cluster/util_test.go
@@ -139,3 +139,43 @@ func TestInheritedAnnotations(t *testing.T) {
 	}
 
 }
+
+func Test_trimCronjobName(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "short name",
+			args: args{
+				name: "short-name",
+			},
+			want: "short-name",
+		},
+		{
+			name: "long name",
+			args: args{
+				name: "very-very-very-very-very-very-very-very-very-long-db-name",
+			},
+			want: "very-very-very-very-very-very-very-very-very-long-db",
+		},
+		{
+			name: "long name should not end with dash",
+			args: args{
+				name: "very-very-very-very-very-very-very-very-very-----------long-db-name",
+			},
+			want: "very-very-very-very-very-very-very-very-very",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := trimCronjobName(tt.args.name); got != tt.want {
+				t.Errorf("trimCronjobName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
K8s cronjobs must be no longer than 52 characters. This fixes the issue of backup cronjobs not being created for DBs with long names.