### PR TITLE
add operator ui helm chart value imagePullSecret

### DIFF
--- a/charts/postgres-operator-ui/templates/deployment.yaml
+++ b/charts/postgres-operator-ui/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
         team: "acid" # Parameterize?
     spec:
       serviceAccountName: {{ include "postgres-operator-ui.serviceAccountName" . }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       containers:
         - name: "service"
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/postgres-operator-ui/values.yaml
+++ b/charts/postgres-operator-ui/values.yaml
@@ -11,6 +11,12 @@ image:
   tag: v1.5.0-dirty
   pullPolicy: "IfNotPresent"
 
+# Optionally specify an array of imagePullSecrets.
+# Secrets must be manually created in the namespace.
+# ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+# imagePullSecrets:
+#   - name: 
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
To use the Postgres Operator UI Helm Chart with a private docker registry, I was forced to transfer the imagePullSecret parameter of the Postgres Operator Helm Chart to the Postgres Operator UI Helm Chart.
I have no experience with GITHub yet, but would like to contribute the change.

Related to #1210 
