### PR TITLE
CRD: preserve unknown fields and add to all category

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -15,6 +15,8 @@ spec:
     singular: operatorconfiguration
     shortNames:
     - opconfig
+    categories:
+    - all
   scope: Namespaced
   versions:
   - name: v1
@@ -45,6 +47,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-preserve-unknown-fields: true
         required:
           - kind
           - apiVersion

--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -15,6 +15,8 @@ spec:
     singular: postgresql
     shortNames:
     - pg
+    categories:
+    - all
   scope: Namespaced
   versions:
   - name: v1
@@ -57,6 +59,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-preserve-unknown-fields: true
         required:
           - kind
           - apiVersion

--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -323,6 +323,7 @@ spec:
                         - "10"
                         - "11"
                         - "12"
+                        - "13"
                     parameters:
                       type: object
                       additionalProperties:

--- a/charts/postgres-operator/crds/postgresteams.yaml
+++ b/charts/postgres-operator/crds/postgresteams.yaml
@@ -15,6 +15,8 @@ spec:
     singular: postgresteam
     shortNames:
     - pgteam
+    categories:
+    - all
   scope: Namespaced
   versions:
   - name: v1
@@ -25,6 +27,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-preserve-unknown-fields: true
         required:
           - kind
           - apiVersion

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -11,6 +11,8 @@ spec:
     singular: operatorconfiguration
     shortNames:
     - opconfig
+    categories:
+    - all
   scope: Namespaced
   versions:
   - name: v1
@@ -41,6 +43,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-preserve-unknown-fields: true
         required:
           - kind
           - apiVersion

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -11,6 +11,8 @@ spec:
     singular: postgresql
     shortNames:
     - pg
+    categories:
+    - all
   scope: Namespaced
   versions:
   - name: v1
@@ -53,6 +55,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-preserve-unknown-fields: true
         required:
           - kind
           - apiVersion

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -319,6 +319,7 @@ spec:
                         - "10"
                         - "11"
                         - "12"
+                        - "13"
                     parameters:
                       type: object
                       additionalProperties:

--- a/manifests/postgresteam.crd.yaml
+++ b/manifests/postgresteam.crd.yaml
@@ -11,6 +11,8 @@ spec:
     singular: postgresteam
     shortNames:
     - pgteam
+    categories:
+    - all
   scope: Namespaced
   versions:
   - name: v1
@@ -21,6 +23,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        x-preserve-unknown-fields: true
         required:
           - kind
           - apiVersion

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -414,6 +414,9 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 									{
 										Raw: []byte(`"12"`),
 									},
+									{
+										Raw: []byte(`"13"`),
+									},
 								},
 							},
 							"parameters": {

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	acidzalando "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do"
+	"github.com/zalando/postgres-operator/pkg/util"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -111,8 +112,9 @@ var minDisable = -1.0
 // PostgresCRDResourceValidation to check applied manifest parameters
 var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 	OpenAPIV3Schema: &apiextv1.JSONSchemaProps{
-		Type:     "object",
-		Required: []string{"kind", "apiVersion", "spec"},
+		Type:                   "object",
+		XPreserveUnknownFields: util.True(),
+		Required:               []string{"kind", "apiVersion", "spec"},
 		Properties: map[string]apiextv1.JSONSchemaProps{
 			"kind": {
 				Type: "string",
@@ -779,8 +781,9 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 // OperatorConfigCRDResourceValidation to check applied manifest parameters
 var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 	OpenAPIV3Schema: &apiextv1.JSONSchemaProps{
-		Type:     "object",
-		Required: []string{"kind", "apiVersion", "configuration"},
+		Type:                   "object",
+		XPreserveUnknownFields: util.True(),
+		Required:               []string{"kind", "apiVersion", "configuration"},
 		Properties: map[string]apiextv1.JSONSchemaProps{
 			"kind": {
 				Type: "string",
@@ -1394,6 +1397,7 @@ func buildCRD(name, kind, plural, short string, columns []apiextv1.CustomResourc
 				Plural:     plural,
 				ShortNames: []string{short},
 				Kind:       kind,
+				Categories: []string{"all"},
 			},
 			Scope: apiextv1.NamespaceScoped,
 			Versions: []apiextv1.CustomResourceDefinitionVersion{


### PR DESCRIPTION
With #746 we switched the CRDs to `v1`. It seems that this api version does require to explicitly enable preserving unknown fields (e.g. whenever we allow full specs). Plus, the toggle moved from `crd.spec` to the schema.

This PR will also register the Postgres Operator CRDs in the `all` category, so that they are listed when `kubectl get all` is executed.

fixes #1206 