### PR TITLE
add to postgresql_type.go omitempty annotation

### DIFF
--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -53,7 +53,7 @@ type PostgresSpec struct {
 	// load balancers' source ranges are the same for master and replica services
 	AllowedSourceRanges []string `json:"allowedSourceRanges"`
 
-	NumberOfInstances     int32                       `json:"numberOfInstances" defaults:"2"`
+	NumberOfInstances     int32                       `json:"numberOfInstances"`
 	Users                 map[string]UserFlags        `json:"users,omitempty"`
 	MaintenanceWindows    []MaintenanceWindow         `json:"maintenanceWindows,omitempty"`
 	Clone                 *CloneDescription           `json:"clone,omitempty"`

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -127,7 +127,7 @@ type AdditionalVolume struct {
 // PostgresqlParam describes PostgreSQL version and pairs of configuration parameter name - values.
 type PostgresqlParam struct {
 	PgVersion  string            `json:"version"`
-	Parameters map[string]string `json:"parameters"`
+	Parameters map[string]string `json:"parameters,omitempty"`
 }
 
 // ResourceDescription describes CPU and memory resources defined for a cluster.
@@ -144,15 +144,15 @@ type Resources struct {
 
 // Patroni contains Patroni-specific configuration
 type Patroni struct {
-	InitDB                map[string]string            `json:"initdb"`
-	PgHba                 []string                     `json:"pg_hba"`
-	TTL                   uint32                       `json:"ttl"`
-	LoopWait              uint32                       `json:"loop_wait"`
-	RetryTimeout          uint32                       `json:"retry_timeout"`
-	MaximumLagOnFailover  float32                      `json:"maximum_lag_on_failover"` // float32 because https://github.com/kubernetes/kubernetes/issues/30213
-	Slots                 map[string]map[string]string `json:"slots"`
-	SynchronousMode       bool                         `json:"synchronous_mode"`
-	SynchronousModeStrict bool                         `json:"synchronous_mode_strict"`
+	InitDB                map[string]string            `json:"initdb,omitempty"`
+	PgHba                 []string                     `json:"pg_hba,omitempty"`
+	TTL                   uint32                       `json:"ttl,omitempty"`
+	LoopWait              uint32                       `json:"loop_wait,omitempty"`
+	RetryTimeout          uint32                       `json:"retry_timeout,omitempty"`
+	MaximumLagOnFailover  float32                      `json:"maximum_lag_on_failover,omitempty"` // float32 because https://github.com/kubernetes/kubernetes/issues/30213
+	Slots                 map[string]map[string]string `json:"slots,omitempty"`
+	SynchronousMode       bool                         `json:"synchronous_mode,omitempty"`
+	SynchronousModeStrict bool                         `json:"synchronous_mode_strict,omitempty"`
 }
 
 //StandbyCluster

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -53,8 +53,8 @@ type PostgresSpec struct {
 	// load balancers' source ranges are the same for master and replica services
 	AllowedSourceRanges []string `json:"allowedSourceRanges"`
 
-	NumberOfInstances     int32                       `json:"numberOfInstances"`
-	Users                 map[string]UserFlags        `json:"users"`
+	NumberOfInstances     int32                       `json:"numberOfInstances" defaults:"2"`
+	Users                 map[string]UserFlags        `json:"users,omitempty"`
 	MaintenanceWindows    []MaintenanceWindow         `json:"maintenanceWindows,omitempty"`
 	Clone                 *CloneDescription           `json:"clone,omitempty"`
 	ClusterName           string                      `json:"-"`
@@ -112,14 +112,14 @@ type MaintenanceWindow struct {
 // Volume describes a single volume in the manifest.
 type Volume struct {
 	Size         string `json:"size"`
-	StorageClass string `json:"storageClass"`
+	StorageClass string `json:"storageClass,omitempty"`
 	SubPath      string `json:"subPath,omitempty"`
 }
 
 type AdditionalVolume struct {
 	Name             string          `json:"name"`
 	MountPath        string          `json:"mountPath"`
-	SubPath          string          `json:"subPath"`
+	SubPath          string          `json:"subPath,omitempty"`
 	TargetContainers []string        `json:"targetContainers"`
 	VolumeSource     v1.VolumeSource `json:"volumeSource"`
 }


### PR DESCRIPTION
I use the PostgreSQL type to configure a struct instance in golang to create the resource in the k8s cluster.

To create the https://github.com/zalando/postgres-operator/blob/master/manifests/minimal-postgres-manifest.yaml in golang it is necessary to add some more `omitempty` annotations to unset values.

Closes #1221 