### PR TITLE
Changes to support separate bucket per pg cluster (#1209)

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -741,7 +741,6 @@ func (c *Cluster) generateSpiloPodEnvVars(uid types.UID, spiloConfiguration stri
 	}
 
 	if c.OpConfig.WALES3Bucket != "" {
-		envVars = append(envVars, v1.EnvVar{Name: "WAL_S3_BUCKET", Value: c.OpConfig.WALES3Bucket})
 		envVars = append(envVars, v1.EnvVar{Name: "WAL_BUCKET_SCOPE_SUFFIX", Value: getBucketScopeSuffix(string(uid))})
 		envVars = append(envVars, v1.EnvVar{Name: "WAL_BUCKET_SCOPE_PREFIX", Value: ""})
 	}
@@ -760,6 +759,13 @@ func (c *Cluster) generateSpiloPodEnvVars(uid types.UID, spiloConfiguration stri
 		envVars = append(envVars, v1.EnvVar{Name: "LOG_S3_BUCKET", Value: c.OpConfig.LogS3Bucket})
 		envVars = append(envVars, v1.EnvVar{Name: "LOG_BUCKET_SCOPE_SUFFIX", Value: getBucketScopeSuffix(string(uid))})
 		envVars = append(envVars, v1.EnvVar{Name: "LOG_BUCKET_SCOPE_PREFIX", Value: ""})
+	}
+
+	// Get WAL_S3_BUCKET env var from customPodEnvVarsList, if present. Priority to be given to customPodEnvVarsList
+	if getEnvValue("WAL_S3_BUCKET", customPodEnvVarsList) != "" {
+		envVars = append(envVars, v1.EnvVar{Name: "WAL_S3_BUCKET", Value: getEnvValue("WAL_S3_BUCKET", customPodEnvVarsList)})
+	} else if c.OpConfig.WALES3Bucket != "" {
+		envVars = append(envVars, v1.EnvVar{Name: "WAL_S3_BUCKET", Value: c.OpConfig.WALES3Bucket})
 	}
 
 	return envVars
@@ -1857,7 +1863,15 @@ func (c *Cluster) generateLogicalBackupJob() (*batchv1beta1.CronJob, error) {
 		return nil, fmt.Errorf("could not generate resource requirements for logical backup pods: %v", err)
 	}
 
-	envVars := c.generateLogicalBackupPodEnvVars()
+	// fetch env vars from custom ConfigMap
+	customPodEnvVarsList, err := c.getPodEnvironmentConfigMapVariables()
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(customPodEnvVarsList,
+		func(i, j int) bool { return customPodEnvVarsList[i].Name < customPodEnvVarsList[j].Name })
+
+	envVars := deduplicateEnvVars(c.generateLogicalBackupPodEnvVars(customPodEnvVarsList), c.containerName(), c.logger)
 	logicalBackupContainer := generateContainer(
 		"logical-backup",
 		&c.OpConfig.LogicalBackup.LogicalBackupDockerImage,
@@ -1952,7 +1966,7 @@ func (c *Cluster) generateLogicalBackupJob() (*batchv1beta1.CronJob, error) {
 	return cronJob, nil
 }
 
-func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
+func (c *Cluster) generateLogicalBackupPodEnvVars(customPodEnvVarsList []v1.EnvVar) []v1.EnvVar {
 
 	envVars := []v1.EnvVar{
 		{
@@ -1973,10 +1987,6 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 			},
 		},
 		// Bucket env vars
-		{
-			Name:  "LOGICAL_BACKUP_S3_BUCKET",
-			Value: c.OpConfig.LogicalBackup.LogicalBackupS3Bucket,
-		},
 		{
 			Name:  "LOGICAL_BACKUP_S3_REGION",
 			Value: c.OpConfig.LogicalBackup.LogicalBackupS3Region,
@@ -2025,6 +2035,13 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 				},
 			},
 		},
+	}
+
+	// Get LOGICAL_BACKUP_S3_BUCKET env var from customPodEnvVarsList, if present. Priority to be given to customPodEnvVarsList
+	if getEnvValue("LOGICAL_BACKUP_S3_BUCKET", customPodEnvVarsList) != "" {
+		envVars = append(envVars, v1.EnvVar{Name: "LOGICAL_BACKUP_S3_BUCKET", Value: getEnvValue("LOGICAL_BACKUP_S3_BUCKET", customPodEnvVarsList)})
+	} else if c.OpConfig.LogicalBackup.LogicalBackupS3Bucket != "" {
+		envVars = append(envVars, v1.EnvVar{Name: "LOGICAL_BACKUP_S3_BUCKET", Value: c.OpConfig.LogicalBackup.LogicalBackupS3Bucket})
 	}
 
 	if c.OpConfig.LogicalBackup.LogicalBackupS3AccessKeyID != "" {

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -549,3 +549,13 @@ func mergeContainers(containers ...[]v1.Container) ([]v1.Container, []string) {
 	}
 	return result, conflicts
 }
+
+// Get env key's value from env list
+func getEnvValue(envKey string, customPodEnvVarsList []v1.EnvVar) string {
+	for _, customEnvVar := range customPodEnvVarsList {
+		if customEnvVar.Name == envKey {
+			return customEnvVar.Value
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Changes Done
---
- `WAL_S3_BUCKET` used in pg configmap will result in the cluster using that bucket for streaming/pushing WAL archives. In case it's not set, the default bucket `wal_s3_bucket` from operator configmap will be used. This bucket should be accessible by the user `AWS_ACCESS_KEY_ID` in pg configmap.
- `LOGICAL_BACKUP_S3_BUCKET` used in pg configmap will result in the cluster using that bucket for pushing logical backups. In case its not set, the default bucket `logical_backup_s3_bucket` from operator configmap will be used. This bucket should be accessible by the user `logical_backup_s3_access_key_id` in operator configmap. Using a custom user for a logical backup bucket is not included in this PR. 

Ideally, we will always use the same bucket for WAL and logical backups.


Tests performed
---
| __Scenario__ | __Result__ |
| ------ | ------ |
| Don't set `WAL_S3_BUCKET` or `LOGICAL_BACKUP_S3_BUCKET`. Create primary | Default bucket from operator used. WAL and backups pushed to default |
| Don't set `WAL_S3_BUCKET` or `LOGICAL_BACKUP_S3_BUCKET`. Create standby | Default bucket from operator used. Only backups pushed to default |
| Set custom `WAL_S3_BUCKET` and `LOGICAL_BACKUP_S3_BUCKET`. Create primary | Custom bucket from configmap used. WAL and backups pushed to custom | 
| Set custom `WAL_S3_BUCKET` and `LOGICAL_BACKUP_S3_BUCKET`. Create standby to stream from default bucket | Custom bucket from configmap used. The cluster starts streaming from the primary in a different bucket. Only backups pushed to custom bucket | 
| Set custom `WAL_S3_BUCKET` and don't set `LOGICAL_BACKUP_S3_BUCKET`. Create primary | Default bucket from operator used to push backups and custom bucket from configmap used to push WALs |
| Set custom `WAL_S3_BUCKET` and `LOGICAL_BACKUP_S3_BUCKET`. Clone from custom bucket | Cluster cloned from the custom bucket. Custom bucket from configmap used. WAL and backups pushed to custom |