### PR TITLE
new env var for backwards compatability between spilo 12 and 13

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -73,6 +73,8 @@ spec:
                 type: boolean
               enable_shm_volume:
                 type: boolean
+              enable_spilo_wal_path_compat:
+                type: boolean
               etcd_host:
                 type: string
               kubernetes_use_configmaps:

--- a/charts/postgres-operator/values-crd.yaml
+++ b/charts/postgres-operator/values-crd.yaml
@@ -25,6 +25,8 @@ configGeneral:
   enable_pgversion_env_var: false
   # start any new database pod without limitations on shm memory
   enable_shm_volume: true
+  # enables backwards compatible path between Spilo 12 and Spilo 13 images
+  enable_spilo_wal_path_compat: false
   # etcd connection string for Patroni. Empty uses K8s-native DCS.
   etcd_host: ""
   # Select if setup uses endpoints (default), or configmaps to manage leader (DCS=k8s)

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -28,6 +28,8 @@ configGeneral:
   enable_pgversion_env_var: "false"
   # start any new database pod without limitations on shm memory
   enable_shm_volume: "true"
+  # enables backwards compatible path between Spilo 12 and Spilo 13 images
+  enable_spilo_wal_path_compat: "false"
   # etcd connection string for Patroni. Empty uses K8s-native DCS.
   etcd_host: ""
   # Select if setup uses endpoints (default), or configmaps to manage leader (DCS=k8s)

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -79,6 +79,12 @@ Those are top-level keys, containing both leaf keys and groups.
   Instruct operator to update only the statefulsets with new images (Spilo and InitContainers) without immediately doing the rolling update. The assumption is pods will be re-started later with new images, for example due to the node rotation.
   The default is `false`.
 
+* **enable_pgversion_env_var**
+  With newer versions of Spilo, it is preferable to use `PGVERSION` pod environment variable instead of the setting `postgresql.bin_dir` in the `SPILO_CONFIGURATION` env variable. When this option is true, the operator sets `PGVERSION` and omits `postgresql.bin_dir` from  `SPILO_CONFIGURATION`. When false, the `postgresql.bin_dir` is set. This setting takes precedence over `PGVERSION`; see PR 222 in Spilo. The default is `false`.
+
+* **enable_spilo_wal_path_compat**
+  enables backwards compatible path between Spilo 12 and Spilo 13 images. The default is `false`.
+
 * **etcd_host**
   Etcd connection string for Patroni defined as `host:port`. Not required when
   Patroni native Kubernetes support is used. The default is empty (use
@@ -117,9 +123,6 @@ Those are top-level keys, containing both leaf keys and groups.
   [docker issue](https://github.com/docker-library/postgres/issues/416)).
   This option is global for an operator object, and can be overwritten by
   `enableShmVolume` parameter from Postgres manifest. The default is `true`.
-
-* **enable_pgversion_env_var**
-  With newer versions of Spilo, it is preferable to use `PGVERSION` pod environment variable instead of the setting `postgresql.bin_dir` in the `SPILO_CONFIGURATION` env variable. When this option is true, the operator sets `PGVERSION` and omits `postgresql.bin_dir` from  `SPILO_CONFIGURATION`. When false, the `postgresql.bin_dir` is set. This setting takes precedence over `PGVERSION`; see PR 222 in Spilo. The default is `false`.
 
 * **workers**
   number of working routines the operator spawns to process requests to

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -50,6 +50,7 @@ data:
   # enable_shm_volume: "true"
   # enable_pgversion_env_var: "false"
   # enable_sidecars: "true"
+  enable_spilo_wal_path_compat: "false"
   # enable_team_superuser: "false"
   enable_teams_api: "false"
   # etcd_host: ""

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -69,6 +69,8 @@ spec:
                 type: boolean
               enable_shm_volume:
                 type: boolean
+              enable_spilo_wal_path_compat:
+                type: boolean
               etcd_host:
                 type: string
               kubernetes_use_configmaps:

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -8,6 +8,7 @@ configuration:
   # enable_lazy_spilo_upgrade: false
   # enable_pgversion_env_var: false
   # enable_shm_volume: true
+  enable_spilo_wal_path_compat: false
   etcd_host: ""
   # kubernetes_use_configmaps: false
   max_instances: -1

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -815,6 +815,9 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 					"enable_shm_volume": {
 						Type: "boolean",
 					},
+					"enable_spilo_wal_path_compat": {
+						Type: "boolean",
+					},
 					"etcd_host": {
 						Type: "string",
 					},

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -201,6 +201,7 @@ type OperatorConfigurationData struct {
 	EnableCRDValidation        *bool                              `json:"enable_crd_validation,omitempty"`
 	EnableLazySpiloUpgrade     bool                               `json:"enable_lazy_spilo_upgrade,omitempty"`
 	EnablePgVersionEnvVar      bool                               `json:"enable_pgversion_env_var,omitempty"`
+	EnableSpiloWalPathCompat   bool                               `json:"enable_spilo_wal_path_compat,omitempty"`
 	EtcdHost                   string                             `json:"etcd_host,omitempty"`
 	KubernetesUseConfigMaps    bool                               `json:"kubernetes_use_configmaps,omitempty"`
 	DockerImage                string                             `json:"docker_image,omitempty"`

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -824,7 +824,7 @@ func (c *Cluster) getPodEnvironmentConfigMapVariables() ([]v1.EnvVar, error) {
 	return configMapPodEnvVarsList, nil
 }
 
-// Return list of variables the pod recieved from the configured Secret
+// Return list of variables the pod received from the configured Secret
 func (c *Cluster) getPodEnvironmentSecretVariables() ([]v1.EnvVar, error) {
 	secretPodEnvVarsList := make([]v1.EnvVar, 0)
 
@@ -979,6 +979,16 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 		initContainers = spec.InitContainers
 	}
 
+	spiloCompathWalPathList := make([]v1.EnvVar, 0)
+	if c.OpConfig.EnableSpiloWalPathCompat {
+		spiloCompathWalPathList = append(spiloCompathWalPathList,
+			v1.EnvVar{
+				Name:  "ENABLE_WAL_PATH_COMPAT",
+				Value: "true",
+			},
+		)
+	}
+
 	// fetch env vars from custom ConfigMap
 	configMapEnvVarsList, err := c.getPodEnvironmentConfigMapVariables()
 	if err != nil {
@@ -992,7 +1002,8 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 	}
 
 	// concat all custom pod env vars and sort them
-	customPodEnvVarsList := append(configMapEnvVarsList, secretEnvVarsList...)
+	customPodEnvVarsList := append(spiloCompathWalPathList, configMapEnvVarsList...)
+	customPodEnvVarsList = append(customPodEnvVarsList, secretEnvVarsList...)
 	sort.Slice(customPodEnvVarsList,
 		func(i, j int) bool { return customPodEnvVarsList[i].Name < customPodEnvVarsList[j].Name })
 

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -36,6 +36,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.EnableCRDValidation = util.CoalesceBool(fromCRD.EnableCRDValidation, util.True())
 	result.EnableLazySpiloUpgrade = fromCRD.EnableLazySpiloUpgrade
 	result.EnablePgVersionEnvVar = fromCRD.EnablePgVersionEnvVar
+	result.EnableSpiloWalPathCompat = fromCRD.EnableSpiloWalPathCompat
 	result.EtcdHost = fromCRD.EtcdHost
 	result.KubernetesUseConfigMaps = fromCRD.KubernetesUseConfigMaps
 	result.DockerImage = util.Coalesce(fromCRD.DockerImage, "registry.opensource.zalan.do/acid/spilo-12:1.6-p3")

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -201,6 +201,7 @@ type Config struct {
 	SetMemoryRequestToLimit                bool              `name:"set_memory_request_to_limit" default:"false"`
 	EnableLazySpiloUpgrade                 bool              `name:"enable_lazy_spilo_upgrade" default:"false"`
 	EnablePgVersionEnvVar                  bool              `name:"enable_pgversion_env_var" default:"false"`
+	EnableSpiloWalPathCompat               bool              `name:"enable_spilo_wal_path_compat" default:"false"`
 }
 
 // MustMarshal marshals the config or panics


### PR DESCRIPTION
new config option `enable_spilo_wal_path_compat` sets `ENABLE_WAL_PATH_COMPAT` in database pods