### PR TITLE
diff SecurityContext of containers

### DIFF
--- a/kubectl-pg/cmd/util.go
+++ b/kubectl-pg/cmd/util.go
@@ -25,6 +25,13 @@ package cmd
 import (
 	"flag"
 	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
 	PostgresqlLister "github.com/zalando/postgres-operator/pkg/generated/clientset/versioned/typed/acid.zalan.do/v1"
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,12 +39,6 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
-	"log"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strconv"
-	"strings"
 )
 
 const (
@@ -88,7 +89,7 @@ func confirmAction(clusterName string, namespace string) {
 		}
 		clusterDetails := strings.Split(confirmClusterDetails, "/")
 		if clusterDetails[0] != namespace || clusterDetails[1] != clusterName {
-			fmt.Printf("cluster name or namespace doesn't match. Please re-enter %s/%s\nHint: Press (ctrl+c) to exit\n", namespace, clusterName)
+			fmt.Printf("cluster name or namespace does not match. Please re-enter %s/%s\nHint: Press (ctrl+c) to exit\n", namespace, clusterName)
 		} else {
 			return
 		}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -248,7 +248,7 @@ func (c *Cluster) Create() error {
 		}
 		if role == Master {
 			// replica endpoint will be created by the replica service. Master endpoint needs to be created by us,
-			// since the corresponding master service doesn't define any selectors.
+			// since the corresponding master service does not define any selectors.
 			ep, err = c.createEndpoint(role)
 			if err != nil {
 				return fmt.Errorf("could not create %s endpoint: %v", role, err)
@@ -412,7 +412,7 @@ func (c *Cluster) compareStatefulSetWith(statefulSet *appsv1.StatefulSet) *compa
 		match = false
 		needsReplace = true
 		needsRollUpdate = true
-		reasons = append(reasons, "new statefulset's pod template metadata annotations doesn't match the current one")
+		reasons = append(reasons, "new statefulset's pod template metadata annotations does not match the current one")
 	}
 	if !reflect.DeepEqual(c.Statefulset.Spec.Template.Spec.SecurityContext, statefulSet.Spec.Template.Spec.SecurityContext) {
 		match = false
@@ -488,20 +488,22 @@ func (c *Cluster) compareContainers(description string, setA, setB []v1.Containe
 	}
 
 	checks := []containerCheck{
-		newCheck("new statefulset %s's %s (index %d) name doesn't match the current one",
+		newCheck("new statefulset %s's %s (index %d) name does not match the current one",
 			func(a, b v1.Container) bool { return a.Name != b.Name }),
-		newCheck("new statefulset %s's %s (index %d) ports don't match the current one",
+		newCheck("new statefulset %s's %s (index %d) ports do not match the current one",
 			func(a, b v1.Container) bool { return !reflect.DeepEqual(a.Ports, b.Ports) }),
-		newCheck("new statefulset %s's %s (index %d) resources don't match the current ones",
+		newCheck("new statefulset %s's %s (index %d) resources do not match the current ones",
 			func(a, b v1.Container) bool { return !compareResources(&a.Resources, &b.Resources) }),
-		newCheck("new statefulset %s's %s (index %d) environment doesn't match the current one",
+		newCheck("new statefulset %s's %s (index %d) environment does not match the current one",
 			func(a, b v1.Container) bool { return !reflect.DeepEqual(a.Env, b.Env) }),
-		newCheck("new statefulset %s's %s (index %d) environment sources don't match the current one",
+		newCheck("new statefulset %s's %s (index %d) environment sources do not match the current one",
 			func(a, b v1.Container) bool { return !reflect.DeepEqual(a.EnvFrom, b.EnvFrom) }),
+		newCheck("new statefulset %s's %s (index %d) security context does not match the current one",
+			func(a, b v1.Container) bool { return !reflect.DeepEqual(a.SecurityContext, b.SecurityContext) }),
 	}
 
 	if !c.OpConfig.EnableLazySpiloUpgrade {
-		checks = append(checks, newCheck("new statefulset %s's %s (index %d) image doesn't match the current one",
+		checks = append(checks, newCheck("new statefulset %s's %s (index %d) image does not match the current one",
 			func(a, b v1.Container) bool { return a.Image != b.Image }))
 	}
 

--- a/pkg/cluster/connection_pooler_test.go
+++ b/pkg/cluster/connection_pooler_test.go
@@ -810,25 +810,25 @@ func TestConnectionPoolerDeploymentSpec(t *testing.T) {
 func testResources(cluster *Cluster, podSpec *v1.PodTemplateSpec, role PostgresRole) error {
 	cpuReq := podSpec.Spec.Containers[0].Resources.Requests["cpu"]
 	if cpuReq.String() != cluster.OpConfig.ConnectionPooler.ConnectionPoolerDefaultCPURequest {
-		return fmt.Errorf("CPU request doesn't match, got %s, expected %s",
+		return fmt.Errorf("CPU request does not match, got %s, expected %s",
 			cpuReq.String(), cluster.OpConfig.ConnectionPooler.ConnectionPoolerDefaultCPURequest)
 	}
 
 	memReq := podSpec.Spec.Containers[0].Resources.Requests["memory"]
 	if memReq.String() != cluster.OpConfig.ConnectionPooler.ConnectionPoolerDefaultMemoryRequest {
-		return fmt.Errorf("Memory request doesn't match, got %s, expected %s",
+		return fmt.Errorf("Memory request does not match, got %s, expected %s",
 			memReq.String(), cluster.OpConfig.ConnectionPooler.ConnectionPoolerDefaultMemoryRequest)
 	}
 
 	cpuLim := podSpec.Spec.Containers[0].Resources.Limits["cpu"]
 	if cpuLim.String() != cluster.OpConfig.ConnectionPooler.ConnectionPoolerDefaultCPULimit {
-		return fmt.Errorf("CPU limit doesn't match, got %s, expected %s",
+		return fmt.Errorf("CPU limit does not match, got %s, expected %s",
 			cpuLim.String(), cluster.OpConfig.ConnectionPooler.ConnectionPoolerDefaultCPULimit)
 	}
 
 	memLim := podSpec.Spec.Containers[0].Resources.Limits["memory"]
 	if memLim.String() != cluster.OpConfig.ConnectionPooler.ConnectionPoolerDefaultMemoryLimit {
-		return fmt.Errorf("Memory limit doesn't match, got %s, expected %s",
+		return fmt.Errorf("Memory limit does not match, got %s, expected %s",
 			memLim.String(), cluster.OpConfig.ConnectionPooler.ConnectionPoolerDefaultMemoryLimit)
 	}
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -599,7 +599,7 @@ func (c *Cluster) syncVolumeClaims() error {
 		return fmt.Errorf("could not compare size of the volume claims: %v", err)
 	}
 	if !act {
-		c.logger.Infof("volume claims don't require changes")
+		c.logger.Infof("volume claims do not require changes")
 		return nil
 	}
 	if err := c.resizeVolumeClaims(c.Spec.Volume); err != nil {

--- a/pkg/controller/node_test.go
+++ b/pkg/controller/node_test.go
@@ -88,7 +88,7 @@ func TestNodeIsReady(t *testing.T) {
 	for _, tt := range testTable {
 		nodeTestController.opConfig.NodeReadinessLabel = tt.readinessLabel
 		if isReady := nodeTestController.nodeIsReady(tt.in); isReady != tt.out {
-			t.Errorf("%s: expected response %t doesn't match the actual %t for the node %#v",
+			t.Errorf("%s: expected response %t does not match the actual %t for the node %#v",
 				testName, tt.out, isReady, tt.in)
 		}
 	}

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -201,7 +201,7 @@ func (client *KubernetesClient) SetPostgresCRDStatus(clusterName spec.Namespaced
 func SameService(cur, new *v1.Service) (match bool, reason string) {
 	//TODO: improve comparison
 	if cur.Spec.Type != new.Spec.Type {
-		return false, fmt.Sprintf("new service's type %q doesn't match the current one %q",
+		return false, fmt.Sprintf("new service's type %q does not match the current one %q",
 			new.Spec.Type, cur.Spec.Type)
 	}
 
@@ -211,13 +211,13 @@ func SameService(cur, new *v1.Service) (match bool, reason string) {
 	/* work around Kubernetes 1.6 serializing [] as nil. See https://github.com/kubernetes/kubernetes/issues/43203 */
 	if (len(oldSourceRanges) != 0) || (len(newSourceRanges) != 0) {
 		if !reflect.DeepEqual(oldSourceRanges, newSourceRanges) {
-			return false, "new service's LoadBalancerSourceRange doesn't match the current one"
+			return false, "new service's LoadBalancerSourceRange does not match the current one"
 		}
 	}
 
 	match = true
 
-	reasonPrefix := "new service's annotations doesn't match the current one:"
+	reasonPrefix := "new service's annotations does not match the current one:"
 	for ann := range cur.Annotations {
 		if _, ok := new.Annotations[ann]; !ok {
 			match = false
@@ -253,7 +253,7 @@ func SamePDB(cur, new *policybeta1.PodDisruptionBudget) (match bool, reason stri
 	//TODO: improve comparison
 	match = reflect.DeepEqual(new.Spec, cur.Spec)
 	if !match {
-		reason = "new PDB spec doesn't match the current one"
+		reason = "new PDB spec does not match the current one"
 	}
 
 	return
@@ -267,14 +267,14 @@ func getJobImage(cronJob *batchv1beta1.CronJob) string {
 func SameLogicalBackupJob(cur, new *batchv1beta1.CronJob) (match bool, reason string) {
 
 	if cur.Spec.Schedule != new.Spec.Schedule {
-		return false, fmt.Sprintf("new job's schedule %q doesn't match the current one %q",
+		return false, fmt.Sprintf("new job's schedule %q does not match the current one %q",
 			new.Spec.Schedule, cur.Spec.Schedule)
 	}
 
 	newImage := getJobImage(new)
 	curImage := getJobImage(cur)
 	if newImage != curImage {
-		return false, fmt.Sprintf("new job's image %q doesn't match the current one %q",
+		return false, fmt.Sprintf("new job's image %q does not match the current one %q",
 			newImage, curImage)
 	}
 

--- a/pkg/util/k8sutil/k8sutil_test.go
+++ b/pkg/util/k8sutil/k8sutil_test.go
@@ -63,7 +63,7 @@ func TestSameService(t *testing.T) {
 				v1.ServiceTypeLoadBalancer,
 				[]string{"128.141.0.0/16", "137.138.0.0/16"}),
 			match:  false,
-			reason: `new service's type "LoadBalancer" doesn't match the current one "ClusterIP"`,
+			reason: `new service's type "LoadBalancer" does not match the current one "ClusterIP"`,
 		},
 		{
 			about: "services differ on lb source ranges",
@@ -82,7 +82,7 @@ func TestSameService(t *testing.T) {
 				v1.ServiceTypeLoadBalancer,
 				[]string{"185.249.56.0/22"}),
 			match:  false,
-			reason: `new service's LoadBalancerSourceRange doesn't match the current one`,
+			reason: `new service's LoadBalancerSourceRange does not match the current one`,
 		},
 		{
 			about: "new service doesn't have lb source ranges",
@@ -101,7 +101,7 @@ func TestSameService(t *testing.T) {
 				v1.ServiceTypeLoadBalancer,
 				[]string{}),
 			match:  false,
-			reason: `new service's LoadBalancerSourceRange doesn't match the current one`,
+			reason: `new service's LoadBalancerSourceRange does not match the current one`,
 		},
 		{
 			about: "services differ on DNS annotation",
@@ -120,7 +120,7 @@ func TestSameService(t *testing.T) {
 				v1.ServiceTypeLoadBalancer,
 				[]string{"128.141.0.0/16", "137.138.0.0/16"}),
 			match:  false,
-			reason: `new service's annotations doesn't match the current one: 'external-dns.alpha.kubernetes.io/hostname' changed from 'clstr.acid.zalan.do' to 'new_clstr.acid.zalan.do'.`,
+			reason: `new service's annotations does not match the current one: 'external-dns.alpha.kubernetes.io/hostname' changed from 'clstr.acid.zalan.do' to 'new_clstr.acid.zalan.do'.`,
 		},
 		{
 			about: "services differ on AWS ELB annotation",
@@ -139,7 +139,7 @@ func TestSameService(t *testing.T) {
 				v1.ServiceTypeLoadBalancer,
 				[]string{"128.141.0.0/16", "137.138.0.0/16"}),
 			match:  false,
-			reason: `new service's annotations doesn't match the current one: 'service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout' changed from '3600' to '1800'.`,
+			reason: `new service's annotations does not match the current one: 'service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout' changed from '3600' to '1800'.`,
 		},
 		{
 			about: "service changes existing annotation",
@@ -160,7 +160,7 @@ func TestSameService(t *testing.T) {
 				v1.ServiceTypeLoadBalancer,
 				[]string{"128.141.0.0/16", "137.138.0.0/16"}),
 			match:  false,
-			reason: `new service's annotations doesn't match the current one: 'foo' changed from 'bar' to 'baz'.`,
+			reason: `new service's annotations does not match the current one: 'foo' changed from 'bar' to 'baz'.`,
 		},
 		{
 			about: "service changes multiple existing annotations",
@@ -184,7 +184,7 @@ func TestSameService(t *testing.T) {
 				[]string{"128.141.0.0/16", "137.138.0.0/16"}),
 			match: false,
 			// Test just the prefix to avoid flakiness and map sorting
-			reason: `new service's annotations doesn't match the current one:`,
+			reason: `new service's annotations does not match the current one:`,
 		},
 		{
 			about: "service adds a new custom annotation",
@@ -204,7 +204,7 @@ func TestSameService(t *testing.T) {
 				v1.ServiceTypeLoadBalancer,
 				[]string{"128.141.0.0/16", "137.138.0.0/16"}),
 			match:  false,
-			reason: `new service's annotations doesn't match the current one: Added 'foo' with value 'bar'.`,
+			reason: `new service's annotations does not match the current one: Added 'foo' with value 'bar'.`,
 		},
 		{
 			about: "service removes a custom annotation",
@@ -224,7 +224,7 @@ func TestSameService(t *testing.T) {
 				v1.ServiceTypeLoadBalancer,
 				[]string{"128.141.0.0/16", "137.138.0.0/16"}),
 			match:  false,
-			reason: `new service's annotations doesn't match the current one: Removed 'foo'.`,
+			reason: `new service's annotations does not match the current one: Removed 'foo'.`,
 		},
 		{
 			about: "service removes a custom annotation and adds a new one",
@@ -245,7 +245,7 @@ func TestSameService(t *testing.T) {
 				v1.ServiceTypeLoadBalancer,
 				[]string{"128.141.0.0/16", "137.138.0.0/16"}),
 			match:  false,
-			reason: `new service's annotations doesn't match the current one: Removed 'foo'. Added 'bar' with value 'foo'.`,
+			reason: `new service's annotations does not match the current one: Removed 'foo'. Added 'bar' with value 'foo'.`,
 		},
 		{
 			about: "service removes a custom annotation, adds a new one and change another",
@@ -269,7 +269,7 @@ func TestSameService(t *testing.T) {
 				[]string{"128.141.0.0/16", "137.138.0.0/16"}),
 			match: false,
 			// Test just the prefix to avoid flakiness and map sorting
-			reason: `new service's annotations doesn't match the current one: Removed 'foo'.`,
+			reason: `new service's annotations does not match the current one: Removed 'foo'.`,
 		},
 		{
 			about: "service add annotations",
@@ -286,7 +286,7 @@ func TestSameService(t *testing.T) {
 				[]string{"128.141.0.0/16", "137.138.0.0/16"}),
 			match: false,
 			// Test just the prefix to avoid flakiness and map sorting
-			reason: `new service's annotations doesn't match the current one: Added `,
+			reason: `new service's annotations does not match the current one: Added `,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
trigger rolling update if `SecurityContext` of container change, e.g. switching `spilo_privieleged` config option

this PR updates some log messages as well