### PR TITLE
update deprecated MAINTAINER field

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine
-MAINTAINER Team ACID @ Zalando <team-acid@zalando.de>
+LABEL maintainer="Team ACID @ Zalando <team-acid@zalando.de>"
 
 # We need root certificates to deal with teams api over https
 RUN apk --no-cache add curl


### PR DESCRIPTION
The MAINTAINER field has been deprecated for dockerfiles. https://docs.docker.com/engine/reference/builder/#maintainer-deprecated 

This PR updates to use the recommended LABEL field