### PR TITLE
Add missing configuration

### DIFF
--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -62,6 +62,7 @@ data:
   # inherited_labels: application,environment
   # kube_iam_role: ""
   # log_s3_bucket: ""
+  logical_backup_provider: "s3"
   logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.6.0"
   # logical_backup_s3_access_key_id: ""
   logical_backup_s3_bucket: "my-bucket-url"


### PR DESCRIPTION
_logical_backup_provider_ configuration was added in [PR](https://github.com/zalando/postgres-operator/pull/873) to support GCS. However, it missed the configmap which is still an option when deploying the operator. 

Without it, the users will get the following error:
```
+ case $LOGICAL_BACKUP_PROVIDER in
/dump.sh: line 56: LOGICAL_BACKUP_PROVIDER: unbound variable 
```