### PR TITLE
add a prefix for the name of a logical backup job

### DIFF
--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -259,6 +259,8 @@ configLogicalBackup:
   logical_backup_s3_sse: "AES256"
   # backup schedule in the cron format
   logical_backup_schedule: "30 00 * * *"
+  # prefix for the backup job name
+  logical_backup_job_prefix: "logical-backup-"
 
 # automate creation of human users with teams API service
 configTeamsApi:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -242,25 +242,25 @@ configLogicalBackup:
   logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v.1.6.0"
   # path of google cloud service account json file
   # logical_backup_google_application_credentials: ""
-
+  # prefix for the backup job name
+  logical_backup_job_prefix: "logical-backup-"
   # storage provider - either "s3" or "gcs"
   logical_backup_provider: "s3"
   # S3 Access Key ID
   logical_backup_s3_access_key_id: ""
   # S3 bucket to store backup results
   logical_backup_s3_bucket: "my-bucket-url"
-  # S3 region of bucket
-  logical_backup_s3_region: ""
   # S3 endpoint url when not using AWS
   logical_backup_s3_endpoint: ""
+  # S3 region of bucket
+  logical_backup_s3_region: ""
   # S3 Secret Access Key
   logical_backup_s3_secret_access_key: ""
   # S3 server side encryption
   logical_backup_s3_sse: "AES256"
   # backup schedule in the cron format
   logical_backup_schedule: "30 00 * * *"
-  # prefix for the backup job name
-  logical_backup_job_prefix: "logical-backup-"
+
 
 # automate creation of human users with teams API service
 configTeamsApi:

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -571,6 +571,9 @@ grouped under the `logical_backup` key.
   S3 bucket to store backup results. The bucket has to be present and
   accessible by Postgres pods. Default: empty.
 
+* **logical_backup_job_prefix**
+  The prefix to be prepended to the name of a k8s CronJob running the backups. Beware the prefix counts towards the name length restrictions imposed by k8s. Empty string is a legitimate value. Operator does not do the actual renaming: If you change the prefix, you will have to recreate respective CronJobs manually. Default: "logical-backup-".
+
 * **logical_backup_s3_region**
   Specifies the region of the bucket which is required with some non-AWS S3 storage services. The default is empty.
 

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -562,7 +562,7 @@ grouped under the `logical_backup` key.
   Specifies the path of the google cloud service account json file. Default is empty.
 
 * **logical_backup_job_prefix**
-  The prefix to be prepended to the name of a k8s CronJob running the backups. Beware the prefix counts towards the name length restrictions imposed by k8s. Empty string is a legitimate value. Operator does not do the actual renaming: If you change the prefix, you will have to recreate respective CronJobs manually. Default: "logical-backup-".
+  The prefix to be prepended to the name of a k8s CronJob running the backups. Beware the prefix counts towards the name length restrictions imposed by k8s. Empty string is a legitimate value. Operator does not do the actual renaming: It simply creates the job with the new prefix. You will have to delete the old cron job manually. Default: "logical-backup-".
 
 * **logical_backup_provider**
   Specifies the storage provider to which the backup should be uploaded (`s3` or `gcs`).

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -551,11 +551,6 @@ These parameters configure a K8s cron job managed by the operator to produce
 Postgres logical backups. In the CRD-based configuration those parameters are
 grouped under the `logical_backup` key.
 
-* **logical_backup_schedule**
-  Backup schedule in the cron format. Please take the
-  [reference schedule format](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule)
-  into account. Default: "30 00 \* \* \*"
-
 * **logical_backup_docker_image**
   An image for pods of the logical backup job. The [example image](../../docker/logical-backup/Dockerfile)
   runs `pg_dumpall` on a replica if possible and uploads compressed results to
@@ -563,35 +558,40 @@ grouped under the `logical_backup` key.
   The default image is the same image built with the Zalando-internal CI
   pipeline. Default: "registry.opensource.zalan.do/acid/logical-backup"
 
+* **logical_backup_google_application_credentials**
+  Specifies the path of the google cloud service account json file. Default is empty.
+
+* **logical_backup_job_prefix**
+  The prefix to be prepended to the name of a k8s CronJob running the backups. Beware the prefix counts towards the name length restrictions imposed by k8s. Empty string is a legitimate value. Operator does not do the actual renaming: If you change the prefix, you will have to recreate respective CronJobs manually. Default: "logical-backup-".
+
 * **logical_backup_provider**
   Specifies the storage provider to which the backup should be uploaded (`s3` or `gcs`).
   Default: "s3"
+
+* **logical_backup_s3_access_key_id**
+  When set, value will be in AWS_ACCESS_KEY_ID env variable. The Default is empty.
 
 * **logical_backup_s3_bucket**
   S3 bucket to store backup results. The bucket has to be present and
   accessible by Postgres pods. Default: empty.
 
-* **logical_backup_job_prefix**
-  The prefix to be prepended to the name of a k8s CronJob running the backups. Beware the prefix counts towards the name length restrictions imposed by k8s. Empty string is a legitimate value. Operator does not do the actual renaming: If you change the prefix, you will have to recreate respective CronJobs manually. Default: "logical-backup-".
+* **logical_backup_s3_endpoint**
+  When using non-AWS S3 storage, endpoint can be set as a ENV variable. The default is empty.
 
 * **logical_backup_s3_region**
   Specifies the region of the bucket which is required with some non-AWS S3 storage services. The default is empty.
 
-* **logical_backup_s3_endpoint**
-  When using non-AWS S3 storage, endpoint can be set as a ENV variable. The default is empty.
+* **logical_backup_s3_secret_access_key**
+  When set, value will be in AWS_SECRET_ACCESS_KEY env variable. The Default is empty.
 
 * **logical_backup_s3_sse**
   Specify server side encryption that S3 storage is using. If empty string
   is specified, no argument will be passed to `aws s3` command. Default: "AES256".
 
-* **logical_backup_s3_access_key_id**
-  When set, value will be in AWS_ACCESS_KEY_ID env variable. The Default is empty.
-
-* **logical_backup_s3_secret_access_key**
-  When set, value will be in AWS_SECRET_ACCESS_KEY env variable. The Default is empty.
-
-* **logical_backup_google_application_credentials**
-  Specifies the path of the google cloud service account json file. Default is empty.
+* **logical_backup_schedule**
+  Backup schedule in the cron format. Please take the
+  [reference schedule format](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule)
+  into account. Default: "30 00 \* \* \*"
 
 ## Debugging the operator
 

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -334,6 +334,8 @@ spec:
                   logical_backup_schedule:
                     type: string
                     pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
+                  logical_backup_job_prefix:
+                    type: string
               debug:
                 type: object
                 properties:

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -317,6 +317,8 @@ spec:
                     type: string
                   logical_backup_google_application_credentials:
                     type: string
+                  logical_backup_job_prefix:
+                    type: string
                   logical_backup_provider:
                     type: string
                   logical_backup_s3_access_key_id:
@@ -334,8 +336,6 @@ spec:
                   logical_backup_schedule:
                     type: string
                     pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
-                  logical_backup_job_prefix:
-                    type: string
               debug:
                 type: object
                 properties:

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -117,6 +117,7 @@ configuration:
   logical_backup:
     logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v.1.6.0"
     # logical_backup_google_application_credentials: ""
+    logical_backup_job_prefix: "logical-backup-"
     logical_backup_provider: "s3"
     # logical_backup_s3_access_key_id: ""
     logical_backup_s3_bucket: "my-bucket-url"
@@ -125,7 +126,6 @@ configuration:
     # logical_backup_s3_secret_access_key: ""
     logical_backup_s3_sse: "AES256"
     logical_backup_schedule: "30 00 * * *"
-    logical_backup_job_prefix: "logical-backup-"
   debug:
     debug_logging: true
     enable_database_access: true

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -125,6 +125,7 @@ configuration:
     # logical_backup_s3_secret_access_key: ""
     logical_backup_s3_sse: "AES256"
     logical_backup_schedule: "30 00 * * *"
+    logical_backup_job_prefix: "logical-backup-"
   debug:
     debug_logging: true
     enable_database_access: true

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -196,6 +196,7 @@ type OperatorLogicalBackupConfiguration struct {
 	S3SecretAccessKey            string `json:"logical_backup_s3_secret_access_key,omitempty"`
 	S3SSE                        string `json:"logical_backup_s3_sse,omitempty"`
 	GoogleApplicationCredentials string `json:"logical_backup_google_application_credentials,omitempty"`
+	JobPrefix                    string `json:"logical_backup_job_prefix,omitempty"`
 }
 
 // OperatorConfigurationData defines the operation config

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2079,7 +2079,7 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 
 // getLogicalBackupJobName returns the name; the job itself may not exists
 func (c *Cluster) getLogicalBackupJobName() (jobName string) {
-	return "logical-backup-" + c.clusterName().Name
+	return c.OpConfig.LogicalBackupJobPrefix + c.clusterName().Name
 }
 
 // Return an array of ownerReferences to make an arbitraty object dependent on

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -154,6 +154,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.LogicalBackupS3SecretAccessKey = fromCRD.LogicalBackup.S3SecretAccessKey
 	result.LogicalBackupS3SSE = fromCRD.LogicalBackup.S3SSE
 	result.LogicalBackupGoogleApplicationCredentials = fromCRD.LogicalBackup.GoogleApplicationCredentials
+	result.LogicalBackupJobPrefix = fromCRD.LogicalBackup.JobPrefix
 
 	// debug config
 	result.DebugLogging = fromCRD.OperatorDebug.DebugLogging

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -121,6 +121,7 @@ type LogicalBackup struct {
 	LogicalBackupS3SecretAccessKey            string `name:"logical_backup_s3_secret_access_key" default:""`
 	LogicalBackupS3SSE                        string `name:"logical_backup_s3_sse" default:""`
 	LogicalBackupGoogleApplicationCredentials string `name:"logical_backup_google_application_credentials" default:""`
+	LogicalBackupJobPrefix                    string `name:"logical_backup_job_prefix" default:"logical-backup-"`
 }
 
 // Operator options for connection pooler


### PR DESCRIPTION
Operator currently prepends the `logical-backup-` prefix to the name of  a CronJob doing the backup.
The prefix proved to be too long as it counts towards the name length limit imposed by k8s.
This patch makes the prefix configurable.

Automatic job renaming after prefix change is out of scope. Operator will automatically create a new job with the updated  prefix. The old job will stay around and has to be deleted manually. Logical backup jobs for `$CLUSTERNAME` are visible with
```bash
kubectl get cronjobs -l application=spilo,cluster-name=$CLUSTERNAME
``` 
Operator currently does not assign any specific labels to the jobs.

  