### PR TITLE
[UI] on read_pods filter only spilo pods

### DIFF
--- a/ui/operator_ui/spiloutils.py
+++ b/ui/operator_ui/spiloutils.py
@@ -107,6 +107,12 @@ def encode_labels(label_selector):
     ])
 
 
+def cluster_labels(spilo_cluster):
+    labels = COMMON_CLUSTER_LABEL
+    labels[OPERATOR_CLUSTER_NAME_LABEL] = spilo_cluster
+    return labels
+
+
 def kubernetes_url(
     resource_type,
     namespace='default',
@@ -151,7 +157,7 @@ def read_pods(cluster, namespace, spilo_cluster):
         cluster=cluster,
         resource_type='pods',
         namespace=namespace,
-        label_selector={OPERATOR_CLUSTER_NAME_LABEL: spilo_cluster},
+        label_selector=cluster_labels(spilo_cluster),
     )
 
 


### PR DESCRIPTION
Pods from enabled connection pooler also receive the `spilo-role=master` label. Therefore, only fetching pods by the cluster name would return too many labeled masters hence showing in the UI that the master isn't ready.