### PR TITLE
Fix typo in operatorconfigurations CRD

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -457,7 +457,7 @@ spec:
                       log_statement: all
                   teams_api_url:
                     type: string
-                    defaults: "https://teams.example.com/api/"
+                    default: "https://teams.example.com/api/"
               logging_rest_api:
                 type: object
                 properties:

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -453,7 +453,7 @@ spec:
                       log_statement: all
                   teams_api_url:
                     type: string
-                    defaults: "https://teams.example.com/api/"
+                    default: "https://teams.example.com/api/"
               logging_rest_api:
                 type: object
                 properties:


### PR DESCRIPTION
defaults -> default
Noticed the typo because I got an error while trying to update the CRD in my cluster