### PR TITLE
Added imagePullSecrets option for spilo pod

### DIFF
--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -191,6 +191,17 @@ spec:
                 # Note: usernames specified here as database owners must be declared in the users key of the spec key.
               dockerImage:
                 type: string
+              imagePullSecrets:
+                type: array
+                nullable: true
+                description: "Optionally specify an array of imagePullSecrets for the spilo pod"
+                items:
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
               enableConnectionPooler:
                 type: boolean
               enableReplicaConnectionPooler:

--- a/charts/postgres-operator/values-crd.yaml
+++ b/charts/postgres-operator/values-crd.yaml
@@ -33,6 +33,11 @@ configGeneral:
   # kubernetes_use_configmaps: false
   # Spilo docker image
   docker_image: registry.opensource.zalan.do/acid/spilo-13:2.0-p2
+  # Optionally specify an array of imagePullSecrets for the spilo pod.
+  # Secrets must be manually created in the namespace.
+  # ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+  # image_pull_secrets:
+  # - name: myRegistryKeySecretName
   # max number of instances in Postgres cluster. -1 = no limit
   min_instances: -1
   # min number of instances in Postgres cluster. -1 = no limit

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -36,6 +36,9 @@ configGeneral:
   # kubernetes_use_configmaps: "false"
   # Spilo docker image
   docker_image: registry.opensource.zalan.do/acid/spilo-13:2.0-p2
+  # Optionally specify an array of imagePullSecrets for the spilo pod
+  # image_pull_secrets:
+  # - myRegistryKeySecretName
   # max number of instances in Postgres cluster. -1 = no limit
   min_instances: "-1"
   # min number of instances in Postgres cluster. -1 = no limit

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -65,6 +65,10 @@ These parameters are grouped directly under  the `spec` key in the manifest.
   custom Docker image that overrides the **docker_image** operator parameter.
   It should be a [Spilo](https://github.com/zalando/spilo) image. Optional.
 
+* **imagePullSecrets**
+  Specify an array of imagePullSecrets to pull the spilo image (if you want
+  to pull your own spilo image from a private registry). Optional.
+
 * **schedulerName**
   specifies the scheduling profile for database pods. If no value is provided
   K8s' `default-scheduler` will be used. Optional.

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -102,6 +102,10 @@ Those are top-level keys, containing both leaf keys and groups.
   your own Spilo image from the [github
   repository](https://github.com/zalando/spilo).
 
+* **image_pull_secrets**
+  Specify an array of imagePullSecrets to pull the spilo image (if you
+  want to pull your own spilo image from a private registry). Optional.
+
 * **sidecar_docker_images**
   *deprecated*: use **sidecars** instead. A map of sidecar names to Docker
   images to run with Spilo. In case of the name conflict with the definition in

--- a/manifests/complete-postgres-manifest.yaml
+++ b/manifests/complete-postgres-manifest.yaml
@@ -10,6 +10,8 @@ metadata:
 #    "delete-clustername": "acid-test-cluster"  # can only be deleted when name matches if "delete-clustername" key is configured
 spec:
   dockerImage: registry.opensource.zalan.do/acid/spilo-13:2.0-p2
+  # imagePullSecrets:
+  # - name: myRegistryKeySecretName
   teamId: "acid"
   numberOfInstances: 2
   users:  # Application/Robot users

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -32,6 +32,7 @@ data:
   # delete_annotation_date_key: delete-date
   # delete_annotation_name_key: delete-clustername
   docker_image: registry.opensource.zalan.do/acid/spilo-13:2.0-p2
+  # image_pull_secrets: "myRegistryKeySecretName,myOtherRegistryKeySecretName"
   # downscaler_annotations: "deployment-time,downscaler/*"
   # enable_admin_role_for_users: "true"
   # enable_crd_validation: "true"

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -62,6 +62,16 @@ spec:
               docker_image:
                 type: string
                 default: "registry.opensource.zalan.do/acid/spilo-13:2.0-p2"
+              image_pull_secrets:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
               enable_crd_validation:
                 type: boolean
                 default: true

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -4,6 +4,8 @@ metadata:
   name: postgresql-operator-default-configuration
 configuration:
   docker_image: registry.opensource.zalan.do/acid/spilo-13:2.0-p2
+  # image_pull_secrets:
+  # - name: myRegistryKeySecretName
   # enable_crd_validation: true
   # enable_lazy_spilo_upgrade: false
   enable_pgversion_env_var: true

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -187,6 +187,17 @@ spec:
                 # Note: usernames specified here as database owners must be declared in the users key of the spec key.
               dockerImage:
                 type: string
+              imagePullSecrets:
+                type: array
+                nullable: true
+                description: "Optionally specify an array of imagePullSecrets for the spilo pod"
+                items:
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
               enableConnectionPooler:
                 type: boolean
               enableReplicaConnectionPooler:

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -291,6 +291,22 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 					"dockerImage": {
 						Type: "string",
 					},
+					"imagePullSecrets": {
+						Type:        "array",
+						Description: "Optionally specify an array of imagePullSecrets for the spilo pod",
+						Nullable:    true,
+						Items: &apiextv1.JSONSchemaPropsOrArray{
+							Schema: &apiextv1.JSONSchemaProps{
+								Type:     "object",
+								Required: []string{"name"},
+								Properties: map[string]apiextv1.JSONSchemaProps{
+									"name": {
+										Type: "string",
+									},
+								},
+							},
+						},
+					},
 					"enableConnectionPooler": {
 						Type: "boolean",
 					},

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -208,6 +208,7 @@ type OperatorConfigurationData struct {
 	EtcdHost                   string                             `json:"etcd_host,omitempty"`
 	KubernetesUseConfigMaps    bool                               `json:"kubernetes_use_configmaps,omitempty"`
 	DockerImage                string                             `json:"docker_image,omitempty"`
+	ImagePullSecrets           []string                           `json:"image_pull_secrets,omitempty"`
 	Workers                    uint32                             `json:"workers,omitempty"`
 	MinInstances               int32                              `json:"min_instances,omitempty"`
 	MaxInstances               int32                              `json:"max_instances,omitempty"`

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -33,8 +33,9 @@ type PostgresSpec struct {
 	EnableReplicaConnectionPooler *bool             `json:"enableReplicaConnectionPooler,omitempty"`
 	ConnectionPooler              *ConnectionPooler `json:"connectionPooler,omitempty"`
 
-	TeamID      string `json:"teamId"`
-	DockerImage string `json:"dockerImage,omitempty"`
+	TeamID           string                    `json:"teamId"`
+	DockerImage      string                    `json:"dockerImage,omitempty"`
+	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	SpiloRunAsUser  *int64 `json:"spiloRunAsUser,omitempty"`
 	SpiloRunAsGroup *int64 `json:"spiloRunAsGroup,omitempty"`

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -569,6 +569,7 @@ func (c *Cluster) generatePodTemplate(
 	additionalSecretMount string,
 	additionalSecretMountPath string,
 	additionalVolumes []acidv1.AdditionalVolume,
+	imagePullSecrets []v1.LocalObjectReference,
 ) (*v1.PodTemplateSpec, error) {
 
 	terminateGracePeriodSeconds := terminateGracePeriod
@@ -595,6 +596,10 @@ func (c *Cluster) generatePodTemplate(
 		InitContainers:                initContainers,
 		Tolerations:                   *tolerationsSpec,
 		SecurityContext:               &securityContext,
+	}
+
+	if imagePullSecrets != nil {
+		podSpec.ImagePullSecrets = imagePullSecrets
 	}
 
 	if schedulerName != nil {
@@ -1064,6 +1069,12 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 	// pickup the docker image for the spilo container
 	effectiveDockerImage := util.Coalesce(spec.DockerImage, c.OpConfig.DockerImage)
 
+	// get ImagePullSecrets for spilo pod
+	effectiveImagePullSecrets := c.OpConfig.ImagePullSecrets
+	if spec.ImagePullSecrets != nil {
+		effectiveImagePullSecrets = spec.ImagePullSecrets
+	}
+
 	// determine the User, Group and FSGroup for the spilo pod
 	effectiveRunAsUser := c.OpConfig.Resources.SpiloRunAsUser
 	if spec.SpiloRunAsUser != nil {
@@ -1234,7 +1245,8 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 		c.OpConfig.PodAntiAffinityTopologyKey,
 		c.OpConfig.AdditionalSecretMount,
 		c.OpConfig.AdditionalSecretMountPath,
-		additionalVolumes)
+		additionalVolumes,
+		effectiveImagePullSecrets)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not generate pod template: %v", err)
@@ -1939,7 +1951,8 @@ func (c *Cluster) generateLogicalBackupJob() (*batchv1beta1.CronJob, error) {
 		"",
 		c.OpConfig.AdditionalSecretMount,
 		c.OpConfig.AdditionalSecretMountPath,
-		[]acidv1.AdditionalVolume{}); err != nil {
+		[]acidv1.AdditionalVolume{},
+		nil); err != nil {
 		return nil, fmt.Errorf("could not generate pod template for logical backup pod: %v", err)
 	}
 

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -40,6 +40,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.EtcdHost = fromCRD.EtcdHost
 	result.KubernetesUseConfigMaps = fromCRD.KubernetesUseConfigMaps
 	result.DockerImage = util.Coalesce(fromCRD.DockerImage, "registry.opensource.zalan.do/acid/spilo-13:2.0-p2")
+	result.ImagePullSecrets = util.StrArrToLocalObjectReferenceArr(fromCRD.ImagePullSecrets)
 	result.Workers = util.CoalesceUInt32(fromCRD.Workers, 8)
 	result.MinInstances = fromCRD.MinInstances
 	result.MaxInstances = fromCRD.MaxInstances

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -147,13 +147,14 @@ type Config struct {
 	LogicalBackup
 	ConnectionPooler
 
-	WatchedNamespace        string            `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
-	KubernetesUseConfigMaps bool              `name:"kubernetes_use_configmaps" default:"false"`
-	EtcdHost                string            `name:"etcd_host" default:""` // special values: the empty string "" means Patroni will use K8s as a DCS
-	DockerImage             string            `name:"docker_image" default:"registry.opensource.zalan.do/acid/spilo-13:2.0-p2"`
-	SidecarImages           map[string]string `name:"sidecar_docker_images"` // deprecated in favour of SidecarContainers
-	SidecarContainers       []v1.Container    `name:"sidecars"`
-	PodServiceAccountName   string            `name:"pod_service_account_name" default:"postgres-pod"`
+	WatchedNamespace        string                    `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
+	KubernetesUseConfigMaps bool                      `name:"kubernetes_use_configmaps" default:"false"`
+	EtcdHost                string                    `name:"etcd_host" default:""` // special values: the empty string "" means Patroni will use K8s as a DCS
+	DockerImage             string                    `name:"docker_image" default:"registry.opensource.zalan.do/acid/spilo-13:2.0-p2"`
+	ImagePullSecrets        []v1.LocalObjectReference `name:"image_pull_secrets"`
+	SidecarImages           map[string]string         `name:"sidecar_docker_images"` // deprecated in favour of SidecarContainers
+	SidecarContainers       []v1.Container            `name:"sidecars"`
+	PodServiceAccountName   string                    `name:"pod_service_account_name" default:"postgres-pod"`
 	// value of this string must be valid JSON or YAML; see initPodServiceAccount
 	PodServiceAccountDefinition            string            `name:"pod_service_account_definition" default:""`
 	PodServiceAccountRoleBindingDefinition string            `name:"pod_service_account_role_binding_definition" default:""`

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/motomux/pretty"
+	corev1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -339,4 +340,13 @@ func IsSmallerQuantity(requestStr, limitStr string) (bool, error) {
 	}
 
 	return request.Cmp(limit) == -1, nil
+}
+
+// StrArrToLocalObjectReferenceArr : Converts an array of strings into an array of v1.LocalObjectReference
+func StrArrToLocalObjectReferenceArr(arr []string) []corev1.LocalObjectReference {
+	ret := make([]corev1.LocalObjectReference, len(arr))
+	for k, v := range arr {
+		ret[k] = corev1.LocalObjectReference{Name: v}
+	}
+	return ret
 }


### PR DESCRIPTION
I wanted to deploy my own spilo image in a cluster, the image is hosted in a private registry. Therefore i added an option to specify imagePullSecrets for the pods running spilo. It can be specified in the operator configuration as well as in the cluster manifest (in CRDs and/or ConfigMap).
I have built the operator image and ran it in my cluster, it works fine there (tested with and without imagePullSecrets). The change should be backwards compatible. A bit of documentation and examples are added as well.