### PR TITLE
allow additional members from other teams

### DIFF
--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -240,7 +240,7 @@ func (c *Cluster) getTeamMembers(teamID string) ([]string, error) {
 
 	c.logger.Debugf("fetching possible additional team members for team %q", teamID)
 	members := []string{}
-	additionalMembers := c.PgTeamMap[c.Spec.TeamID].AdditionalMembers
+	additionalMembers := c.PgTeamMap[teamID].AdditionalMembers
 	for _, member := range additionalMembers {
 		members = append(members, member)
 	}


### PR DESCRIPTION
`getTeamMembers` should also work for other teams associated to a cluster, e.g. superusers, additional teams etc.