### PR TITLE
fix helm install

### DIFF
--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -25,11 +25,11 @@ configGeneral:
   # update only the statefulsets without immediately doing the rolling update
   enable_lazy_spilo_upgrade: "false"
   # set the PGVERSION env var instead of providing the version via postgresql.bin_dir in SPILO_CONFIGURATION
-  enable_pgversion_env_var: "true"
+  enable_pgversion_env_var: true
   # start any new database pod without limitations on shm memory
   enable_shm_volume: "true"
   # enables backwards compatible path between Spilo 12 and Spilo 13 images
-  enable_spilo_wal_path_compat: "false"
+  enable_spilo_wal_path_compat: false
   # etcd connection string for Patroni. Empty uses K8s-native DCS.
   etcd_host: ""
   # Select if setup uses endpoints (default), or configmaps to manage leader (DCS=k8s)
@@ -217,7 +217,7 @@ configAwsOrGcp:
   aws_region: eu-central-1
 
   # enable automatic migration on AWS from gp2 to gp3 volumes
-  enable_ebs_gp3_migration: "false"
+  enable_ebs_gp3_migration false
   # defines maximum volume size in GB until which auto migration happens
   # enable_ebs_gp3_migration_max_size: "1000"
 
@@ -269,7 +269,7 @@ configTeamsApi:
   # enable_admin_role_for_users: "true"
 
   # operator watches for PostgresTeam CRs to assign additional teams and members to clusters
-  enable_postgres_team_crd: "false"
+  enable_postgres_team_crd: false
   # toogle to create additional superuser teams from PostgresTeam CRs
   # enable_postgres_team_crd_superusers: "false"
 


### PR DESCRIPTION
When installing the postgres operator version 1.6.0 through helm I get the following error message:

```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(OperatorConfiguration.configuration.aws_or_gcp.enable_ebs_gp3_migration): invalid type for do.zalan.acid.v1.OperatorConfiguration.configuration.aws_or_gcp.enable_ebs_gp3_migration: got "string", expected "boolean", ValidationError(OperatorConfiguration.configuration.enable_pgversion_env_var): invalid type for do.zalan.acid.v1.OperatorConfiguration.configuration.enable_pgversion_env_var: got "string", expected "boolean", ValidationError(OperatorConfiguration.configuration.enable_spilo_wal_path_compat): invalid type for do.zalan.acid.v1.OperatorConfiguration.configuration.enable_spilo_wal_path_compat: got "string", expected "boolean", ValidationError(OperatorConfiguration.configuration.teams_api.enable_postgres_team_crd): invalid type for do.zalan.acid.v1.OperatorConfiguration.configuration.teams_api.enable_postgres_team_crd: got "string", expected "boolean"]
```

The patch below fixes this behavior.