### PR TITLE
set AllowPrivilegeEscalation on container securityContext

### DIFF
--- a/charts/postgres-operator/templates/clusterrole-postgres-pod.yaml
+++ b/charts/postgres-operator/templates/clusterrole-postgres-pod.yaml
@@ -63,6 +63,7 @@ rules:
   - services
   verbs:
   - create
+{{- if toString .Values.configKubernetes.spilo_privileged | eq "true" }}
 # to run privileged pods
 - apiGroups:
   - extensions
@@ -72,4 +73,5 @@ rules:
   - privileged
   verbs:
   - use
+{{- end }}
 {{ end }}

--- a/charts/postgres-operator/templates/clusterrole.yaml
+++ b/charts/postgres-operator/templates/clusterrole.yaml
@@ -228,7 +228,8 @@ rules:
   verbs:
   - get
   - create
-# to grant privilege to run privileged pods
+{{- if toString .Values.configKubernetes.spilo_privileged | eq "true" }}
+# to run privileged pods
 - apiGroups:
   - extensions
   resources:
@@ -237,4 +238,5 @@ rules:
   - privileged
   verbs:
   - use
+{{- end }}
 {{ end }}

--- a/manifests/operator-service-account-rbac.yaml
+++ b/manifests/operator-service-account-rbac.yaml
@@ -203,15 +203,15 @@ rules:
   verbs:
   - get
   - create
-# to grant privilege to run privileged pods
-- apiGroups:
-  - extensions
-  resources:
-  - podsecuritypolicies
-  resourceNames:
-  - privileged
-  verbs:
-  - use
+# to grant privilege to run privileged pods (not needed by default)
+#- apiGroups:
+#  - extensions
+#  resources:
+#  - podsecuritypolicies
+#  resourceNames:
+#  - privileged
+#  verbs:
+#  - use
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -265,12 +265,12 @@ rules:
   - services
   verbs:
   - create
-# to run privileged pods
-- apiGroups:
-  - extensions
-  resources:
-  - podsecuritypolicies
-  resourceNames:
-  - privileged
-  verbs:
-  - use
+# to grant privilege to run privileged pods (not needed by default)
+#- apiGroups:
+#  - extensions
+#  resources:
+#  - podsecuritypolicies
+#  resourceNames:
+#  - privileged
+#  verbs:
+#  - use

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -453,8 +453,9 @@ func generateContainer(
 		VolumeMounts: volumeMounts,
 		Env:          envVars,
 		SecurityContext: &v1.SecurityContext{
-			Privileged:             &privilegedMode,
-			ReadOnlyRootFilesystem: util.False(),
+			AllowPrivilegeEscalation: &privilegedMode,
+			Privileged:               &privilegedMode,
+			ReadOnlyRootFilesystem:   util.False(),
 		},
 	}
 }


### PR DESCRIPTION
in the process of switching all pods to non-privileged pods the `use` privilege for a `privileged` PodSecurityPolicy is obsolete. However, Pods holding this privilege before might still escalate to such a PSP and will then face issues when the psp privilege is missing in the RBAC. Setting `AllowPrivilegeEscalation: false` on the container's securityContext should prevent this. The value will be based on what's configured for `spilo_privileged`.