### PR TITLE
set allowPrivilegeEscalation for deployment templates

### DIFF
--- a/charts/postgres-operator/templates/deployment.yaml
+++ b/charts/postgres-operator/templates/deployment.yaml
@@ -62,6 +62,8 @@ spec:
 {{ toYaml .Values.affinity | indent 8 }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
+      securityContext:
+{{ toYaml .Values.securityContext| indent 8 }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
     {{- if .Values.priorityClassName }}

--- a/charts/postgres-operator/templates/deployment.yaml
+++ b/charts/postgres-operator/templates/deployment.yaml
@@ -54,6 +54,8 @@ spec:
       {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        securityContext:
+{{ toYaml .Values.securityContext| indent 10 }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
@@ -62,8 +64,6 @@ spec:
 {{ toYaml .Values.affinity | indent 8 }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
-      securityContext:
-{{ toYaml .Values.securityContext| indent 8 }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
     {{- if .Values.priorityClassName }}

--- a/charts/postgres-operator/templates/deployment.yaml
+++ b/charts/postgres-operator/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         securityContext:
-{{ toYaml .Values.securityContext| indent 10 }}
+{{ toYaml .Values.securityContext | indent 10 }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/charts/postgres-operator/values-crd.yaml
+++ b/charts/postgres-operator/values-crd.yaml
@@ -359,17 +359,23 @@ resources:
     cpu: 100m
     memory: 250Mi
 
+securityContext:
+  runAsUser: 1000
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+
 # Affinity for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
 
-# Tolerations for pod assignment
-# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: []
-
 # Node labels for pod assignment
 # Ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
+
+# Tolerations for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
 
 controllerID:
   # Specifies whether a controller ID should be defined for the operator

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -354,17 +354,23 @@ resources:
     cpu: 100m
     memory: 250Mi
 
+securityContext:
+  runAsUser: 1000
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+
 # Affinity for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
 
-# Tolerations for pod assignment
-# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: []
-
 # Node labels for pod assignment
 # Ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
+
+# Tolerations for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
 
 controllerID:
   # Specifies whether a controller ID should be defined for the operator

--- a/manifests/complete-postgres-manifest.yaml
+++ b/manifests/complete-postgres-manifest.yaml
@@ -45,7 +45,7 @@ spec:
     size: 1Gi
 #    storageClass: my-sc
 #    iops: 1000  # for EBS gp3
- #   throughput: 250  # in MB/s for EBS gp3
+#    throughput: 250  # in MB/s for EBS gp3
   additionalVolumes:
     - name: empty
       mountPath: /opt/empty

--- a/manifests/postgres-operator.yaml
+++ b/manifests/postgres-operator.yaml
@@ -32,6 +32,7 @@ spec:
           runAsUser: 1000
           runAsNonRoot: true
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
         env:
         # provided additional ENV vars can overwrite individual config map entries
         - name: CONFIG_MAP_NAME

--- a/pkg/cluster/connection_pooler.go
+++ b/pkg/cluster/connection_pooler.go
@@ -280,6 +280,9 @@ func (c *Cluster) generateConnectionPoolerPodTemplate(role PostgresRole) (
 				},
 			},
 		},
+		SecurityContext: &v1.SecurityContext{
+			AllowPrivilegeEscalation: util.False(),
+		},
 	}
 
 	podTemplate := &v1.PodTemplateSpec{

--- a/pkg/cluster/connection_pooler.go
+++ b/pkg/cluster/connection_pooler.go
@@ -292,7 +292,6 @@ func (c *Cluster) generateConnectionPoolerPodTemplate(role PostgresRole) (
 			Annotations: c.annotationsSet(c.generatePodAnnotations(spec)),
 		},
 		Spec: v1.PodSpec{
-			ServiceAccountName:            c.OpConfig.PodServiceAccountName,
 			TerminationGracePeriodSeconds: &gracePeriod,
 			Containers:                    []v1.Container{poolerContainer},
 			// TODO: add tolerations to scheduler pooler on the same node


### PR DESCRIPTION
#1326 has added `allowPrivilegeEscalation` field to postgres containers, but operator and pooler containers might need it, too, since the service account they have used so far holds or has hold the `use` privilege for a `privileged` PSP.

This PR also introduces configuring the operator container's `securityContext` in the helm chart.