### PR TITLE
Fix CI Pipeline

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Unit tests and coverage
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
           go-version: "^1.15.6"


### PR DESCRIPTION
This commit attempts to fix the CI issues by upgrading the checkout
action to v2. This fix is documented by the coverallsapp upstream.