### PR TITLE
making pgTeamMap a pointer

### DIFF
--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -750,6 +750,7 @@ class EndToEndTestCase(unittest.TestCase):
             return r
 
         self.eventuallyTrue(verify_pod_limits, "Pod limits where not adjusted")
+        print('Operator log: {}'.format(k8s.get_operator_log()))
 
     @classmethod
     def setUp(cls):

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -749,8 +749,8 @@ class EndToEndTestCase(unittest.TestCase):
             r = r and pods[1].spec.containers[0].resources.limits['cpu'] == minCPULimit
             return r
 
-        self.eventuallyTrue(verify_pod_limits, "Pod limits where not adjusted")
         print('Operator log: {}'.format(k8s.get_operator_log()))
+        self.eventuallyTrue(verify_pod_limits, "Pod limits where not adjusted")
 
     @classmethod
     def setUp(cls):

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -989,7 +989,6 @@ class EndToEndTestCase(unittest.TestCase):
         # verify we are in good state from potential previous tests
         self.eventuallyEqual(lambda: k8s.count_running_pods(), 2, "No 2 pods running")
         self.eventuallyEqual(lambda: len(k8s.get_patroni_running_members("acid-minimal-cluster-0")), 2, "Postgres status did not enter running")
-        self.eventuallyEqual(lambda: self.k8s.get_operator_state(), {"0": "idle"}, "Operator does not get in sync")
 
         # get nodes of master and replica(s)
         master_node, replica_nodes = k8s.get_pg_nodes(cluster_label)
@@ -1074,6 +1073,9 @@ class EndToEndTestCase(unittest.TestCase):
                 name="acid-minimal-cluster",
                 body=patch_node_remove_affinity_config)
             self.eventuallyEqual(lambda: self.k8s.get_operator_state(), {"0": "idle"}, "Operator does not get in sync")
+
+            self.eventuallyEqual(lambda: k8s.count_running_pods(), 2, "No 2 pods running")
+            self.eventuallyEqual(lambda: len(k8s.get_patroni_running_members("acid-minimal-cluster-0")), 2, "Postgres status did not enter running")
 
             # remove node affinity to move replica away from master node
             nm, new_replica_nodes = k8s.get_cluster_nodes()

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -1040,7 +1040,6 @@ class EndToEndTestCase(unittest.TestCase):
                 plural="postgresqls",
                 name="acid-minimal-cluster",
                 body=patch_node_affinity_config)
-            self.eventuallyEqual(lambda: self.k8s.get_operator_state(), {"0": "idle"}, "Operator does not get in sync")
 
             # node affinity change should cause replica to relocate from replica node to master node due to node affinity requirement
             k8s.wait_for_pod_failover(master_node, 'spilo-role=replica,' + cluster_label)

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -1040,6 +1040,7 @@ class EndToEndTestCase(unittest.TestCase):
                 plural="postgresqls",
                 name="acid-minimal-cluster",
                 body=patch_node_affinity_config)
+            self.eventuallyEqual(lambda: self.k8s.get_operator_state(), {"0": "idle"}, "Operator does not get in sync")
 
             # node affinity change should cause replica to relocate from replica node to master node due to node affinity requirement
             k8s.wait_for_pod_failover(master_node, 'spilo-role=replica,' + cluster_label)

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -126,6 +126,7 @@ class EndToEndTestCase(unittest.TestCase):
                          "api-service.yaml",
                          "infrastructure-roles.yaml",
                          "infrastructure-roles-new.yaml",
+                         "custom-team-membership.yaml",
                          "e2e-storage-class.yaml"]:
             result = k8s.create_with_kubectl("manifests/" + filename)
             print("stdout: {}, stderr: {}".format(result.stdout, result.stderr))
@@ -173,6 +174,63 @@ class EndToEndTestCase(unittest.TestCase):
         
         self.eventuallyEqual(lambda: self.k8s.count_pods_with_container_capabilities(capabilities, cluster_label),
                              2, "Container capabilities not updated")
+
+    @timeout_decorator.timeout(TEST_TIMEOUT_SEC)
+    def test_additional_teams_and_members(self):
+        '''
+           Test PostgresTeam CRD with extra teams and members
+        '''
+        # enable PostgresTeam CRD and lower resync
+        enable_postgres_team_crd = {
+            "data": {
+                "enable_postgres_team_crd": "true",
+                "resync_period": "15s",
+            },
+        }
+        self.k8s.update_config(enable_postgres_team_crd)
+        self.eventuallyEqual(lambda: self.k8s.get_operator_state(), {"0": "idle"},
+                             "Operator does not get in sync")
+        
+        self.k8s.api.custom_objects_api.patch_namespaced_custom_object(
+        'acid.zalan.do', 'v1', 'default',
+        'postgresteams', 'custom-team-membership',
+        {
+            'spec': {
+                'additionalTeams': {
+                    'acid': [
+                        'e2e'
+                    ]
+                },
+                'additionalMembers': {
+                    'e2e': [
+                        'kind'
+                    ]
+                }
+            }
+        })
+
+        # make sure we let one sync pass and the new user being added
+        time.sleep(15)
+
+        leader = self.k8s.get_cluster_leader_pod('acid-minimal-cluster')
+        user_query = """
+            SELECT usename
+              FROM pg_catalog.pg_user
+             WHERE usename IN ('elephant', 'kind');
+        """
+        users = self.query_database(leader.metadata.name, "postgres", user_query)
+        self.eventuallyEqual(lambda: len(users), 2, 
+            "Not all additional users found in database: {}".format(users))
+
+        # revert config change
+        revert_resync = {
+            "data": {
+                "resync_period": "30m",
+            },
+        }
+        self.k8s.update_config(revert_resync)
+        self.eventuallyEqual(lambda: self.k8s.get_operator_state(), {"0": "idle"},
+                             "Operator does not get in sync")
 
     @timeout_decorator.timeout(TEST_TIMEOUT_SEC)
     def test_overwrite_pooler_deployment(self):
@@ -332,54 +390,19 @@ class EndToEndTestCase(unittest.TestCase):
         # Verify that all the databases have pooler schema installed.
         # Do this via psql, since otherwise we need to deal with
         # credentials.
-        dbList = []
+        db_list = []
 
         leader = k8s.get_cluster_leader_pod('acid-minimal-cluster')
-        dbListQuery = "select datname from pg_database"
-        schemasQuery = """
+        schemas_query = """
             select schema_name
             from information_schema.schemata
             where schema_name = 'pooler'
         """
-        exec_query = r"psql -tAq -c \"{}\" -d {}"
 
-        if leader:
-            try:
-                q = exec_query.format(dbListQuery, "postgres")
-                q = "su postgres -c \"{}\"".format(q)
-                print('Get databases: {}'.format(q))
-                result = k8s.exec_with_kubectl(leader.metadata.name, q)
-                dbList = clean_list(result.stdout.split(b'\n'))
-                print('dbList: {}, stdout: {}, stderr {}'.format(
-                    dbList, result.stdout, result.stderr
-                ))
-            except Exception as ex:
-                print('Could not get databases: {}'.format(ex))
-                print('Stdout: {}'.format(result.stdout))
-                print('Stderr: {}'.format(result.stderr))
-
-            for db in dbList:
-                if db in ('template0', 'template1'):
-                    continue
-
-                schemas = []
-                try:
-                    q = exec_query.format(schemasQuery, db)
-                    q = "su postgres -c \"{}\"".format(q)
-                    print('Get schemas: {}'.format(q))
-                    result = k8s.exec_with_kubectl(leader.metadata.name, q)
-                    schemas = clean_list(result.stdout.split(b'\n'))
-                    print('schemas: {}, stdout: {}, stderr {}'.format(
-                        schemas, result.stdout, result.stderr
-                    ))
-                except Exception as ex:
-                    print('Could not get databases: {}'.format(ex))
-                    print('Stdout: {}'.format(result.stdout))
-                    print('Stderr: {}'.format(result.stderr))
-
-                self.assertNotEqual(len(schemas), 0)
-        else:
-            print('Could not find leader pod')
+        db_list = self.list_databases(leader.metadata.name)
+        for db in db_list:
+            self.eventuallyNotEqual(lambda: len(self.query_database(leader.metadata.name, db, schemas_query)), 0, 
+                "Pooler schema not found in database {}".format(db))
 
         # remove config section to make test work next time
         k8s.api.custom_objects_api.patch_namespaced_custom_object(
@@ -1219,6 +1242,60 @@ class EndToEndTestCase(unittest.TestCase):
         k8s.wait_for_pod_start('spilo-role=replica')
         return True
 
+    def list_databases(self, pod_name):
+        '''
+           Get list of databases we might want to iterate over
+        '''
+        k8s = self.k8s
+        result_set = []
+        db_list = []
+        db_list_query = "select datname from pg_database"
+        exec_query = r"psql -tAq -c \"{}\" -d {}"
+
+        try:
+            q = exec_query.format(db_list_query, "postgres")
+            q = "su postgres -c \"{}\"".format(q)
+            print('Get databases: {}'.format(q))
+            result = k8s.exec_with_kubectl(pod_name, q)
+            db_list = clean_list(result.stdout.split(b'\n'))
+            print('db_list: {}, stdout: {}, stderr {}'.format(
+                db_list, result.stdout, result.stderr
+            ))
+        except Exception as ex:
+            print('Could not get databases: {}'.format(ex))
+            print('Stdout: {}'.format(result.stdout))
+            print('Stderr: {}'.format(result.stderr))
+
+        for db in db_list:
+            if db in ('template0', 'template1'):
+                continue
+            result_set.append(db)
+
+        return result_set
+
+    def query_database(self, pod_name, db_name, query):
+        '''
+           Query database and return result as a list
+        '''
+        k8s = self.k8s
+        result_set = []
+        exec_query = r"psql -tAq -c \"{}\" -d {}"
+
+        try:
+            q = exec_query.format(query, db_name)
+            q = "su postgres -c \"{}\"".format(q)
+            print('Send query: {}'.format(q))
+            result = k8s.exec_with_kubectl(pod_name, q)
+            result_set = clean_list(result.stdout.split(b'\n'))
+            print('result: {}, stdout: {}, stderr {}'.format(
+                result_set, result.stdout, result.stderr
+            ))
+        except Exception as ex:
+            print('Error on query execution: {}'.format(ex))
+            print('Stdout: {}'.format(result.stdout))
+            print('Stderr: {}'.format(result.stderr))
+
+        return result_set
 
 if __name__ == '__main__':
     unittest.main()

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1143,7 +1143,7 @@ func (c *Cluster) initHumanUsers() error {
 	var clusterIsOwnedBySuperuserTeam bool
 	superuserTeams := []string{}
 
-	if c.OpConfig.EnablePostgresTeamCRDSuperusers {
+	if c.OpConfig.EnablePostgresTeamCRD && c.OpConfig.EnablePostgresTeamCRDSuperusers && c.Config.PgTeamMap != nil {
 		superuserTeams = c.Config.PgTeamMap.GetAdditionalSuperuserTeams(c.Spec.TeamID, true)
 	}
 
@@ -1163,7 +1163,7 @@ func (c *Cluster) initHumanUsers() error {
 		}
 	}
 
-	if c.Config.PgTeamMap != nil {
+	if c.OpConfig.EnablePostgresTeamCRD && c.Config.PgTeamMap != nil {
 		additionalTeams := c.Config.PgTeamMap.GetAdditionalTeams(c.Spec.TeamID, true)
 		for _, additionalTeam := range additionalTeams {
 			if !(util.SliceContains(superuserTeams, additionalTeam)) {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1144,7 +1144,7 @@ func (c *Cluster) initHumanUsers() error {
 	superuserTeams := []string{}
 
 	if c.OpConfig.EnablePostgresTeamCRDSuperusers {
-		superuserTeams = c.PgTeamMap.GetAdditionalSuperuserTeams(c.Spec.TeamID, true)
+		superuserTeams = c.Config.PgTeamMap.GetAdditionalSuperuserTeams(c.Spec.TeamID, true)
 	}
 
 	for _, postgresSuperuserTeam := range c.OpConfig.PostgresSuperuserTeams {
@@ -1163,7 +1163,7 @@ func (c *Cluster) initHumanUsers() error {
 		}
 	}
 
-	additionalTeams := c.PgTeamMap.GetAdditionalTeams(c.Spec.TeamID, true)
+	additionalTeams := c.Config.PgTeamMap.GetAdditionalTeams(c.Spec.TeamID, true)
 	for _, additionalTeam := range additionalTeams {
 		if !(util.SliceContains(superuserTeams, additionalTeam)) {
 			err := c.initTeamMembers(additionalTeam, false)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -49,7 +49,7 @@ var (
 type Config struct {
 	OpConfig                     config.Config
 	RestConfig                   *rest.Config
-	PgTeamMap                    pgteams.PostgresTeamMap
+	PgTeamMap                    *pgteams.PostgresTeamMap
 	InfrastructureRoles          map[string]spec.PgUser // inherited from the controller
 	PodServiceAccount            *v1.ServiceAccount
 	PodServiceAccountRoleBinding *rbacv1.RoleBinding

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1163,12 +1163,14 @@ func (c *Cluster) initHumanUsers() error {
 		}
 	}
 
-	additionalTeams := c.Config.PgTeamMap.GetAdditionalTeams(c.Spec.TeamID, true)
-	for _, additionalTeam := range additionalTeams {
-		if !(util.SliceContains(superuserTeams, additionalTeam)) {
-			err := c.initTeamMembers(additionalTeam, false)
-			if err != nil {
-				return fmt.Errorf("Cannot initialize members for additional team %q for cluster owned by %q: %v", additionalTeam, c.Spec.TeamID, err)
+	if c.Config.PgTeamMap != nil {
+		additionalTeams := c.Config.PgTeamMap.GetAdditionalTeams(c.Spec.TeamID, true)
+		for _, additionalTeam := range additionalTeams {
+			if !(util.SliceContains(superuserTeams, additionalTeam)) {
+				err := c.initTeamMembers(additionalTeam, false)
+				if err != nil {
+					return fmt.Errorf("Cannot initialize members for additional team %q for cluster owned by %q: %v", additionalTeam, c.Spec.TeamID, err)
+				}
 			}
 		}
 	}

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sirupsen/logrus"
 	acidv1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
 	"github.com/zalando/postgres-operator/pkg/spec"
-	pgteams "github.com/zalando/postgres-operator/pkg/teams"
 	"github.com/zalando/postgres-operator/pkg/util/config"
 	"github.com/zalando/postgres-operator/pkg/util/constants"
 	"github.com/zalando/postgres-operator/pkg/util/k8sutil"
@@ -24,7 +23,6 @@ const (
 
 var logger = logrus.New().WithField("test", "cluster")
 var eventRecorder = record.NewFakeRecorder(1)
-var teamMap = make(pgteams.PostgresTeamMap, 0)
 
 var cl = New(
 	Config{
@@ -39,7 +37,6 @@ var cl = New(
 				DownscalerAnnotations: []string{"downscaler/*"},
 			},
 		},
-		PgTeamMap: &teamMap,
 	},
 	k8sutil.NewMockKubernetesClient(),
 	acidv1.Postgresql{ObjectMeta: metav1.ObjectMeta{Name: "acid-test", Namespace: "test", Annotations: map[string]string{"downscaler/downtime_replicas": "0"}}},

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -24,6 +24,7 @@ const (
 
 var logger = logrus.New().WithField("test", "cluster")
 var eventRecorder = record.NewFakeRecorder(1)
+var teamMap = make(pgteams.PostgresTeamMap, 0)
 
 var cl = New(
 	Config{
@@ -38,7 +39,7 @@ var cl = New(
 				DownscalerAnnotations: []string{"downscaler/*"},
 			},
 		},
-		PgTeamMap: new(pgteams.PostgresTeamMap),
+		PgTeamMap: &teamMap,
 	},
 	k8sutil.NewMockKubernetesClient(),
 	acidv1.Postgresql{ObjectMeta: metav1.ObjectMeta{Name: "acid-test", Namespace: "test", Annotations: map[string]string{"downscaler/downtime_replicas": "0"}}},

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	acidv1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
 	"github.com/zalando/postgres-operator/pkg/spec"
+	pgteams "github.com/zalando/postgres-operator/pkg/teams"
 	"github.com/zalando/postgres-operator/pkg/util/config"
 	"github.com/zalando/postgres-operator/pkg/util/constants"
 	"github.com/zalando/postgres-operator/pkg/util/k8sutil"
@@ -37,6 +38,7 @@ var cl = New(
 				DownscalerAnnotations: []string{"downscaler/*"},
 			},
 		},
+		PgTeamMap: new(pgteams.PostgresTeamMap),
 	},
 	k8sutil.NewMockKubernetesClient(),
 	acidv1.Postgresql{ObjectMeta: metav1.ObjectMeta{Name: "acid-test", Namespace: "test", Annotations: map[string]string{"downscaler/downtime_replicas": "0"}}},

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -240,7 +240,14 @@ func (c *Cluster) getTeamMembers(teamID string) ([]string, error) {
 
 	c.logger.Debugf("fetching possible additional team members for team %q", teamID)
 	members := []string{}
-	additionalMembers := c.PgTeamMap[teamID].AdditionalMembers
+	additionalMembers := []string{}
+
+	for team, membership := range *c.PgTeamMap {
+		if team == teamID {
+			additionalMembers = membership.AdditionalMembers
+		}
+	}
+
 	for _, member := range additionalMembers {
 		members = append(members, member)
 	}

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -242,9 +242,11 @@ func (c *Cluster) getTeamMembers(teamID string) ([]string, error) {
 	members := []string{}
 	additionalMembers := []string{}
 
-	for team, membership := range *c.Config.PgTeamMap {
-		if team == teamID {
-			additionalMembers = membership.AdditionalMembers
+	if c.Config.PgTeamMap != nil {
+		for team, membership := range *c.Config.PgTeamMap {
+			if team == teamID {
+				additionalMembers = membership.AdditionalMembers
+			}
 		}
 	}
 

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -240,9 +240,10 @@ func (c *Cluster) getTeamMembers(teamID string) ([]string, error) {
 
 	c.logger.Debugf("fetching possible additional team members for team %q", teamID)
 	members := []string{}
-	additionalMembers := []string{}
 
 	if c.OpConfig.EnablePostgresTeamCRD && c.Config.PgTeamMap != nil {
+		additionalMembers := []string{}
+
 		for team, membership := range *c.Config.PgTeamMap {
 			if team == teamID {
 				additionalMembers = membership.AdditionalMembers

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -242,21 +242,21 @@ func (c *Cluster) getTeamMembers(teamID string) ([]string, error) {
 	members := []string{}
 	additionalMembers := []string{}
 
-	if c.Config.PgTeamMap != nil {
+	if c.OpConfig.EnablePostgresTeamCRD && c.Config.PgTeamMap != nil {
 		for team, membership := range *c.Config.PgTeamMap {
 			if team == teamID {
 				additionalMembers = membership.AdditionalMembers
 			}
 		}
-	}
 
-	for _, member := range additionalMembers {
-		members = append(members, member)
-	}
+		for _, member := range additionalMembers {
+			members = append(members, member)
+		}
 
-	if !c.OpConfig.EnableTeamsAPI {
-		c.logger.Debugf("team API is disabled, only returning %d members for team %q", len(members), teamID)
-		return members, nil
+		if !c.OpConfig.EnableTeamsAPI {
+			c.logger.Debugf("team API is disabled, only returning %d members for team %q", len(members), teamID)
+			return members, nil
+		}
 	}
 
 	token, err := c.oauthTokenGetter.getOAuthToken()

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -238,26 +238,27 @@ func (c *Cluster) getTeamMembers(teamID string) ([]string, error) {
 		return nil, fmt.Errorf("no teamId specified")
 	}
 
-	c.logger.Debugf("fetching possible additional team members for team %q", teamID)
 	members := []string{}
 
 	if c.OpConfig.EnablePostgresTeamCRD && c.Config.PgTeamMap != nil {
+		c.logger.Debugf("fetching possible additional team members for team %q", teamID)
 		additionalMembers := []string{}
 
 		for team, membership := range *c.Config.PgTeamMap {
 			if team == teamID {
 				additionalMembers = membership.AdditionalMembers
+				c.logger.Debugf("found %d additional members for team %q", len(members), teamID)
 			}
 		}
 
 		for _, member := range additionalMembers {
 			members = append(members, member)
 		}
+	}
 
-		if !c.OpConfig.EnableTeamsAPI {
-			c.logger.Debugf("team API is disabled, only returning %d members for team %q", len(members), teamID)
-			return members, nil
-		}
+	if !c.OpConfig.EnableTeamsAPI {
+		c.logger.Debugf("team API is disabled")
+		return members, nil
 	}
 
 	token, err := c.oauthTokenGetter.getOAuthToken()

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -242,7 +242,7 @@ func (c *Cluster) getTeamMembers(teamID string) ([]string, error) {
 	members := []string{}
 	additionalMembers := []string{}
 
-	for team, membership := range *c.PgTeamMap {
+	for team, membership := range *c.Config.PgTeamMap {
 		if team == teamID {
 			additionalMembers = membership.AdditionalMembers
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -329,10 +329,9 @@ func (c *Controller) initController() {
 
 	c.initSharedInformers()
 
+	c.pgTeamMap = teams.PostgresTeamMap{}
 	if c.opConfig.EnablePostgresTeamCRD {
 		c.loadPostgresTeams()
-	} else {
-		c.pgTeamMap = teams.PostgresTeamMap{}
 	}
 
 	if c.opConfig.DebugLogging {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -332,7 +332,7 @@ func (c *Controller) initController() {
 	if c.opConfig.EnablePostgresTeamCRD {
 		c.loadPostgresTeams()
 	} else {
-		c.pgTeamMap.Reset()
+		c.pgTeamMap = teams.PostgresTeamMap{}
 	}
 
 	if c.opConfig.DebugLogging {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -332,7 +332,8 @@ func (c *Controller) initController() {
 	if c.opConfig.EnablePostgresTeamCRD {
 		c.loadPostgresTeams()
 	} else {
-		c.pgTeamMap = new(teams.PostgresTeamMap)
+		teamMap := make(teams.PostgresTeamMap, 0)
+		c.pgTeamMap = &teamMap
 	}
 
 	if c.opConfig.DebugLogging {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -37,7 +37,7 @@ import (
 type Controller struct {
 	config    spec.ControllerConfig
 	opConfig  *config.Config
-	pgTeamMap *teams.PostgresTeamMap
+	pgTeamMap teams.PostgresTeamMap
 
 	logger     *logrus.Entry
 	KubeClient k8sutil.KubernetesClient

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -37,7 +37,7 @@ import (
 type Controller struct {
 	config    spec.ControllerConfig
 	opConfig  *config.Config
-	pgTeamMap teams.PostgresTeamMap
+	pgTeamMap *teams.PostgresTeamMap
 
 	logger     *logrus.Entry
 	KubeClient k8sutil.KubernetesClient
@@ -332,7 +332,7 @@ func (c *Controller) initController() {
 	if c.opConfig.EnablePostgresTeamCRD {
 		c.loadPostgresTeams()
 	} else {
-		c.pgTeamMap = teams.PostgresTeamMap{}
+		c.pgTeamMap = new(teams.PostgresTeamMap)
 	}
 
 	if c.opConfig.DebugLogging {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -332,8 +332,7 @@ func (c *Controller) initController() {
 	if c.opConfig.EnablePostgresTeamCRD {
 		c.loadPostgresTeams()
 	} else {
-		teamMap := make(teams.PostgresTeamMap, 0)
-		c.pgTeamMap = &teamMap
+		c.pgTeamMap.Reset()
 	}
 
 	if c.opConfig.DebugLogging {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -400,6 +400,7 @@ func (c *Controller) loadPostgresTeams() {
 	}
 
 	c.pgTeamMap.Load(pgTeams)
+	c.logger.Debugf("Internal Postgres Team Cache: %#v", c.pgTeamMap)
 }
 
 func (c *Controller) postgresTeamAdd(obj interface{}) {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -15,6 +15,7 @@ import (
 	acidv1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
 	"github.com/zalando/postgres-operator/pkg/cluster"
 	"github.com/zalando/postgres-operator/pkg/spec"
+	"github.com/zalando/postgres-operator/pkg/teams"
 	"github.com/zalando/postgres-operator/pkg/util"
 	"github.com/zalando/postgres-operator/pkg/util/config"
 	"github.com/zalando/postgres-operator/pkg/util/k8sutil"
@@ -30,7 +31,7 @@ func (c *Controller) makeClusterConfig() cluster.Config {
 	return cluster.Config{
 		RestConfig:          c.config.RestConfig,
 		OpConfig:            config.Copy(c.opConfig),
-		PgTeamMap:           c.pgTeamMap,
+		PgTeamMap:           &c.pgTeamMap,
 		InfrastructureRoles: infrastructureRoles,
 		PodServiceAccount:   c.PodServiceAccount,
 	}
@@ -395,7 +396,7 @@ func (c *Controller) getInfrastructureRole(
 
 func (c *Controller) loadPostgresTeams() {
 	// reset team map
-	c.pgTeamMap.Reset()
+	c.pgTeamMap = teams.PostgresTeamMap{}
 
 	pgTeams, err := c.KubeClient.PostgresTeamsGetter.PostgresTeams(c.opConfig.WatchedNamespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -15,7 +15,6 @@ import (
 	acidv1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
 	"github.com/zalando/postgres-operator/pkg/cluster"
 	"github.com/zalando/postgres-operator/pkg/spec"
-	"github.com/zalando/postgres-operator/pkg/teams"
 	"github.com/zalando/postgres-operator/pkg/util"
 	"github.com/zalando/postgres-operator/pkg/util/config"
 	"github.com/zalando/postgres-operator/pkg/util/k8sutil"
@@ -396,8 +395,7 @@ func (c *Controller) getInfrastructureRole(
 
 func (c *Controller) loadPostgresTeams() {
 	// reset team map
-	teamMap := make(teams.PostgresTeamMap, 0)
-	c.pgTeamMap = &teamMap
+	c.pgTeamMap.Reset()
 
 	pgTeams, err := c.KubeClient.PostgresTeamsGetter.PostgresTeams(c.opConfig.WatchedNamespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -400,7 +400,6 @@ func (c *Controller) loadPostgresTeams() {
 	}
 
 	c.pgTeamMap.Load(pgTeams)
-	c.logger.Debugf("Internal Postgres Team Cache: %#v", c.pgTeamMap)
 }
 
 func (c *Controller) postgresTeamAdd(obj interface{}) {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -396,7 +396,7 @@ func (c *Controller) getInfrastructureRole(
 
 func (c *Controller) loadPostgresTeams() {
 	// reset team map
-	c.pgTeamMap = teams.PostgresTeamMap{}
+	c.pgTeamMap = new(teams.PostgresTeamMap)
 
 	pgTeams, err := c.KubeClient.PostgresTeamsGetter.PostgresTeams(c.opConfig.WatchedNamespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -396,7 +396,8 @@ func (c *Controller) getInfrastructureRole(
 
 func (c *Controller) loadPostgresTeams() {
 	// reset team map
-	c.pgTeamMap = new(teams.PostgresTeamMap)
+	teamMap := make(teams.PostgresTeamMap, 0)
+	c.pgTeamMap = &teamMap
 
 	pgTeams, err := c.KubeClient.PostgresTeamsGetter.PostgresTeams(c.opConfig.WatchedNamespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -15,7 +15,6 @@ import (
 	acidv1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
 	"github.com/zalando/postgres-operator/pkg/cluster"
 	"github.com/zalando/postgres-operator/pkg/spec"
-	"github.com/zalando/postgres-operator/pkg/teams"
 	"github.com/zalando/postgres-operator/pkg/util"
 	"github.com/zalando/postgres-operator/pkg/util/config"
 	"github.com/zalando/postgres-operator/pkg/util/k8sutil"
@@ -395,9 +394,6 @@ func (c *Controller) getInfrastructureRole(
 }
 
 func (c *Controller) loadPostgresTeams() {
-	// reset team map
-	c.pgTeamMap = teams.PostgresTeamMap{}
-
 	pgTeams, err := c.KubeClient.PostgresTeamsGetter.PostgresTeams(c.opConfig.WatchedNamespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		c.logger.Errorf("could not list postgres team objects: %v", err)

--- a/pkg/teams/postgres_team.go
+++ b/pkg/teams/postgres_team.go
@@ -95,8 +95,7 @@ func (ptm *PostgresTeamMap) GetAdditionalSuperuserTeams(team string, transitive 
 // Load function to import data from PostgresTeam CRD
 func (ptm *PostgresTeamMap) Load(pgTeams *acidv1.PostgresTeamList) {
 	// reset the team map
-	var emptyTeamMap = make(PostgresTeamMap, 0)
-	*ptm = emptyTeamMap
+	*ptm = make(PostgresTeamMap, 0)
 
 	superuserTeamSet := teamHashSet{}
 	teamSet := teamHashSet{}

--- a/pkg/teams/postgres_team.go
+++ b/pkg/teams/postgres_team.go
@@ -6,7 +6,7 @@ import (
 )
 
 // PostgresTeamMap is the operator's internal representation of all PostgresTeam CRDs
-type PostgresTeamMap map[string]*postgresTeamMembership
+type PostgresTeamMap map[string]postgresTeamMembership
 
 type postgresTeamMembership struct {
 	AdditionalSuperuserTeams []string
@@ -113,7 +113,7 @@ func (ptm *PostgresTeamMap) Load(pgTeams *acidv1.PostgresTeamList) {
 	fetchTeams(&teamIDs, teamMemberSet)
 
 	for teamID := range teamIDs {
-		(*ptm)[teamID] = &postgresTeamMembership{
+		(*ptm)[teamID] = postgresTeamMembership{
 			AdditionalSuperuserTeams: util.CoalesceStrArr(superuserTeamSet.toMap()[teamID], []string{}),
 			AdditionalTeams:          util.CoalesceStrArr(teamSet.toMap()[teamID], []string{}),
 			AdditionalMembers:        util.CoalesceStrArr(teamMemberSet.toMap()[teamID], []string{}),

--- a/pkg/teams/postgres_team.go
+++ b/pkg/teams/postgres_team.go
@@ -8,8 +8,6 @@ import (
 // PostgresTeamMap is the operator's internal representation of all PostgresTeam CRDs
 type PostgresTeamMap map[string]*postgresTeamMembership
 
-var emptyTeamMap = make(PostgresTeamMap, 0)
-
 type postgresTeamMembership struct {
 	AdditionalSuperuserTeams []string
 	AdditionalTeams          []string
@@ -96,9 +94,8 @@ func (ptm *PostgresTeamMap) GetAdditionalSuperuserTeams(team string, transitive 
 
 // Load function to import data from PostgresTeam CRD
 func (ptm *PostgresTeamMap) Load(pgTeams *acidv1.PostgresTeamList) {
-	if ptm == nil {
-		ptm = &emptyTeamMap
-	}
+	var emptyTeamMap = make(PostgresTeamMap, 0)
+	*ptm = emptyTeamMap
 
 	superuserTeamSet := teamHashSet{}
 	teamSet := teamHashSet{}

--- a/pkg/teams/postgres_team.go
+++ b/pkg/teams/postgres_team.go
@@ -125,7 +125,5 @@ func (ptm *PostgresTeamMap) Load(pgTeams *acidv1.PostgresTeamList) {
 
 // Reset a PostgresTeamMap
 func (ptm *PostgresTeamMap) Reset() {
-	if ptm != nil {
-		*ptm = emptyTeamMap
-	}
+	*ptm = emptyTeamMap
 }

--- a/pkg/teams/postgres_team.go
+++ b/pkg/teams/postgres_team.go
@@ -6,11 +6,11 @@ import (
 )
 
 // PostgresTeamMap is the operator's internal representation of all PostgresTeam CRDs
-type PostgresTeamMap map[string]*PostgresTeamMembership
+type PostgresTeamMap map[string]*postgresTeamMembership
 
 var emptyTeamMap = make(PostgresTeamMap, 0)
 
-type PostgresTeamMembership struct {
+type postgresTeamMembership struct {
 	AdditionalSuperuserTeams []string
 	AdditionalTeams          []string
 	AdditionalMembers        []string
@@ -115,15 +115,10 @@ func (ptm *PostgresTeamMap) Load(pgTeams *acidv1.PostgresTeamList) {
 	fetchTeams(&teamIDs, teamMemberSet)
 
 	for teamID := range teamIDs {
-		(*ptm)[teamID] = &PostgresTeamMembership{
+		(*ptm)[teamID] = &postgresTeamMembership{
 			AdditionalSuperuserTeams: util.CoalesceStrArr(superuserTeamSet.toMap()[teamID], []string{}),
 			AdditionalTeams:          util.CoalesceStrArr(teamSet.toMap()[teamID], []string{}),
 			AdditionalMembers:        util.CoalesceStrArr(teamMemberSet.toMap()[teamID], []string{}),
 		}
 	}
-}
-
-// Reset a PostgresTeamMap
-func (ptm *PostgresTeamMap) Reset() {
-	*ptm = emptyTeamMap
 }

--- a/pkg/teams/postgres_team.go
+++ b/pkg/teams/postgres_team.go
@@ -94,6 +94,7 @@ func (ptm *PostgresTeamMap) GetAdditionalSuperuserTeams(team string, transitive 
 
 // Load function to import data from PostgresTeam CRD
 func (ptm *PostgresTeamMap) Load(pgTeams *acidv1.PostgresTeamList) {
+	// reset the team map
 	var emptyTeamMap = make(PostgresTeamMap, 0)
 	*ptm = emptyTeamMap
 

--- a/pkg/teams/postgres_team_test.go
+++ b/pkg/teams/postgres_team_test.go
@@ -3,6 +3,7 @@ package teams
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	acidv1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
 	"github.com/zalando/postgres-operator/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,9 +47,36 @@ var (
 			},
 		},
 	}
+	pgTeamMap = PostgresTeamMap{
+		"teamA": {
+			AdditionalSuperuserTeams: []string{"teamB", "team24x7"},
+			AdditionalTeams:          []string{"teamC"},
+			AdditionalMembers:        []string{},
+		},
+		"teamB": {
+			AdditionalSuperuserTeams: []string{"teamA", "teamC", "team24x7"},
+			AdditionalTeams:          []string{},
+			AdditionalMembers:        []string{"drno"},
+		},
+		"teamC": {
+			AdditionalSuperuserTeams: []string{"team24x7"},
+			AdditionalTeams:          []string{"teamA", "teamB", "acid"},
+			AdditionalMembers:        []string{},
+		},
+		"team24x7": {
+			AdditionalSuperuserTeams: []string{},
+			AdditionalTeams:          []string{},
+			AdditionalMembers:        []string{"optimusprime"},
+		},
+		"acid": {
+			AdditionalSuperuserTeams: []string{},
+			AdditionalTeams:          []string{},
+			AdditionalMembers:        []string{"batman"},
+		},
+	}
 )
 
-// PostgresTeamMap is the operator's internal representation of all PostgresTeam CRDs
+// TestLoadingPostgresTeamCRD PostgresTeamMap is the operator's internal representation of all PostgresTeam CRDs
 func TestLoadingPostgresTeamCRD(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -59,33 +87,7 @@ func TestLoadingPostgresTeamCRD(t *testing.T) {
 		{
 			"Check that CRD is imported correctly into the internal format",
 			pgTeamList,
-			PostgresTeamMap{
-				"teamA": {
-					AdditionalSuperuserTeams: []string{"teamB", "team24x7"},
-					AdditionalTeams:          []string{"teamC"},
-					AdditionalMembers:        []string{},
-				},
-				"teamB": {
-					AdditionalSuperuserTeams: []string{"teamA", "teamC", "team24x7"},
-					AdditionalTeams:          []string{},
-					AdditionalMembers:        []string{"drno"},
-				},
-				"teamC": {
-					AdditionalSuperuserTeams: []string{"team24x7"},
-					AdditionalTeams:          []string{"teamA", "teamB", "acid"},
-					AdditionalMembers:        []string{},
-				},
-				"team24x7": {
-					AdditionalSuperuserTeams: []string{},
-					AdditionalTeams:          []string{},
-					AdditionalMembers:        []string{"optimusprime"},
-				},
-				"acid": {
-					AdditionalSuperuserTeams: []string{},
-					AdditionalTeams:          []string{},
-					AdditionalMembers:        []string{"batman"},
-				},
-			},
+			pgTeamMap,
 			"Mismatch between PostgresTeam CRD and internal map",
 		},
 	}
@@ -105,6 +107,14 @@ func TestLoadingPostgresTeamCRD(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestLoadingPostgresTeamCRD PostgresTeamMap is the operator's internal representation of all PostgresTeam CRDs
+func TestResetPostgresTeamCRD(t *testing.T) {
+	teamMap := &pgTeamMap
+	teamMap.Reset()
+
+	assert.Equal(t, teamMap, &PostgresTeamMap{})
 }
 
 // TestGetAdditionalTeams if returns teams with and without transitive dependencies

--- a/pkg/teams/postgres_team_test.go
+++ b/pkg/teams/postgres_team_test.go
@@ -3,7 +3,6 @@ package teams
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	acidv1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
 	"github.com/zalando/postgres-operator/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -107,14 +106,6 @@ func TestLoadingPostgresTeamCRD(t *testing.T) {
 			}
 		}
 	}
-}
-
-// TestLoadingPostgresTeamCRD PostgresTeamMap is the operator's internal representation of all PostgresTeam CRDs
-func TestResetPostgresTeamCRD(t *testing.T) {
-	teamMap := &pgTeamMap
-	teamMap.Reset()
-
-	assert.Equal(t, teamMap, &PostgresTeamMap{})
 }
 
 // TestGetAdditionalTeams if returns teams with and without transitive dependencies


### PR DESCRIPTION
when a PostgresTeam map is updated with more teams/users, it's immediately reflected in the controller's pgTeamMap (can be seen from logs). However, `initUsers` function do not seem to pick them up. Only after the operator is restarted, it seems to work.

Essential change 1: Make cluster's PgTeamMap a pointer:
```
--- PgTeamMap                    pgteams.PostgresTeamMap
+++ PgTeamMap                    *pgteams.PostgresTeamMap
```

Essential change 2: Additional teams and members are only fetched if the feature is enabled and the PgTeamMap is not `nil`