### PR TITLE
code optimization for generateCapabilities

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -321,16 +321,13 @@ func getLocalAndBoostrapPostgreSQLParameters(parameters map[string]string) (loca
 }
 
 func generateCapabilities(capabilities []string) v1.Capabilities {
-	if len(capabilities) > 0 {
-		additionalCapabilities := []v1.Capability{}
-		for _, capability := range capabilities {
-			additionalCapabilities = append(additionalCapabilities, v1.Capability(strings.ToUpper(capability)))
-		}
-		return v1.Capabilities{
-			Add: additionalCapabilities,
-		}
+	additionalCapabilities := make([]v1.Capability, 0, len(capabilities))
+	for _, capability := range capabilities {
+		additionalCapabilities = append(additionalCapabilities, v1.Capability(strings.ToUpper(capability)))
 	}
-	return v1.Capabilities{}
+	return v1.Capabilities{
+		Add: additionalCapabilities,
+	}
 }
 
 func nodeAffinity(nodeReadinessLabel map[string]string, nodeAffinity *v1.NodeAffinity) *v1.Affinity {

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -1502,13 +1502,13 @@ func TestGenerateCapabilities(t *testing.T) {
 		{
 			subTest:      "no capabilities",
 			configured:   nil,
-			capabilities: v1.Capabilities{},
+			capabilities: v1.Capabilities{Add: []v1.Capability{}},
 			err:          fmt.Errorf("could not parse capabilities configuration of nil"),
 		},
 		{
 			subTest:      "empty capabilities",
 			configured:   []string{},
-			capabilities: v1.Capabilities{},
+			capabilities: v1.Capabilities{Add: []v1.Capability{}},
 			err:          fmt.Errorf("could not parse empty capabilities configuration"),
 		},
 		{


### PR DESCRIPTION
* pre-allocate cap for slice structure
* if clause is no needed because access slice with range, and kubelet also use range
  method to get each capability so there is no side-effect

Signed-off-by: Jeff Zvier <zvier20@gmail.com>