### PR TITLE
Fix operator configs runasuser and runasgroup

### DIFF
--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -28,8 +28,8 @@ type Resources struct {
 	PodLabelWaitTimeout       time.Duration       `name:"pod_label_wait_timeout" default:"10m"`
 	PodDeletionWaitTimeout    time.Duration       `name:"pod_deletion_wait_timeout" default:"10m"`
 	PodTerminateGracePeriod   time.Duration       `name:"pod_terminate_grace_period" default:"5m"`
-	SpiloRunAsUser            *int64              `json:"spilo_runasuser,omitempty"`
-	SpiloRunAsGroup           *int64              `json:"spilo_runasgroup,omitempty"`
+	SpiloRunAsUser            *int64              `name:"spilo_runasuser,omitempty"`
+	SpiloRunAsGroup           *int64              `name:"spilo_runasgroup,omitempty"`
 	SpiloFSGroup              *int64              `name:"spilo_fsgroup"`
 	PodPriorityClassName      string              `name:"pod_priority_class_name"`
 	ClusterDomain             string              `name:"cluster_domain" default:"cluster.local"`


### PR DESCRIPTION
This commit fixes a typo in the operator's configuration that would lead to the configs spilo_runasuser and spilo_runasgroup to be ignored.

fixes #1359 