### PR TITLE
fix issue with soft node affinity CRD

### DIFF
--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -604,7 +604,7 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 								Items: &apiextv1.JSONSchemaPropsOrArray{
 									Schema: &apiextv1.JSONSchemaProps{
 										Type:     "object",
-										Required: []string{"preference, weight"},
+										Required: []string{"preference", "weight"},
 										Properties: map[string]apiextv1.JSONSchemaProps{
 											"preference": {
 												Type: "object",


### PR DESCRIPTION
This fixes the following error:

`error: error validating "test-manifest.yaml": error validating data: ValidationError(postgresql.spec.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0]): missing required field "preference, weight" in do.zalan.acid.v1.postgresql.spec.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution; if you choose to ignore these errors, turn validation off with --validate=false
`

where `test-manifest.yaml` is:

```yaml
apiVersion: "acid.zalan.do/v1"
kind: postgresql
metadata:
  name: test-manifest-cluster
  namespace: default
spec:
  teamId: "test"
  volume:
    size: 10Gi
  numberOfInstances: 1
  users:
    test: []
  databases:
    test: test
  nodeAffinity:
    preferredDuringSchedulingIgnoredDuringExecution:
    - weight: 1
      preference:
        matchExpressions:
        - key: kubernetes.io/hostname
          operator: In
          values: [ helios ]
  postgresql:
    version: "12"
```