### PR TITLE
Support major version upgrade via manifest and global upgrades via min version

### DIFF
--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -74,6 +74,7 @@ data:
   # logical_backup_s3_secret_access_key: ""
   logical_backup_s3_sse: "AES256"
   logical_backup_schedule: "30 00 * * *"
+  major_version_upgrade_mode: "manual"
   master_dns_name_format: "{cluster}.{team}.{hostedzone}"
   # master_pod_move_timeout: 20m
   # max_instances: "-1"

--- a/manifests/minimal-postgres-manifest-12.yaml
+++ b/manifests/minimal-postgres-manifest-12.yaml
@@ -1,0 +1,21 @@
+apiVersion: "acid.zalan.do/v1"
+kind: postgresql
+metadata:
+  name: acid-upgrade-test
+  namespace: default
+spec:
+  teamId: "acid"
+  volume:
+    size: 1Gi
+  numberOfInstances: 2
+  users:
+    zalando:  # database owner
+    - superuser
+    - createdb
+    foo_user: []  # role for application foo
+  databases:
+    foo: zalando  # dbname: owner
+  preparedDatabases:
+    bar: {}
+  postgresql:
+    version: "12"

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -1,0 +1,1 @@
+package mocks

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -1,1 +1,0 @@
-package mocks

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -780,8 +780,12 @@ func (c *Cluster) Update(oldSpec, newSpec *acidv1.Postgresql) error {
 		updateFailed = true
 	}
 
-	if err := c.majorVersionUpgrade(); err != nil {
-		c.logger.Errorf("major version upgrade failed: %v", err)
+	if !updateFailed {
+		// Major version upgrade must only fire after success of earlier operations and should stay last
+		if err := c.majorVersionUpgrade(); err != nil {
+			c.logger.Errorf("major version upgrade failed: %v", err)
+			updateFailed = true
+		}
 	}
 
 	return nil

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -783,7 +783,7 @@ func (c *Cluster) Update(oldSpec, newSpec *acidv1.Postgresql) error {
 	}
 
 	if err := c.majorVersionUpgrade(); err != nil {
-
+		c.logger.Errorf("major version upgrade failed: %v", err)
 	}
 
 	return nil

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -360,7 +360,7 @@ func (c *Cluster) compareStatefulSetWith(statefulSet *appsv1.StatefulSet) *compa
 	}
 	if !reflect.DeepEqual(c.Statefulset.Annotations, statefulSet.Annotations) {
 		match = false
-		reasons = append(reasons, "new statefulset's annotations does not match the current one")
+		reasons = append(reasons, "new statefulset's annotations do not match the current one")
 	}
 
 	needsRollUpdate, reasons = c.compareContainers("initContainers", c.Statefulset.Spec.Template.Spec.InitContainers, statefulSet.Spec.Template.Spec.InitContainers, needsRollUpdate, reasons)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -137,7 +137,7 @@ func New(cfg Config, kubeClient k8sutil.KubernetesClient, pgSpec acidv1.Postgres
 	cluster.logger = logger.WithField("pkg", "cluster").WithField("cluster-name", cluster.clusterName())
 	cluster.teamsAPIClient = teams.NewTeamsAPI(cfg.OpConfig.TeamsAPIUrl, logger)
 	cluster.oauthTokenGetter = newSecretOauthTokenGetter(&kubeClient, cfg.OpConfig.OAuthTokenSecretName)
-	cluster.patroni = patroni.New(cluster.logger)
+	cluster.patroni = patroni.New(cluster.logger, nil)
 	cluster.eventRecorder = eventRecorder
 
 	cluster.EBSVolumes = make(map[string]volumes.VolumeProperties)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -129,10 +129,11 @@ func New(cfg Config, kubeClient k8sutil.KubernetesClient, pgSpec acidv1.Postgres
 			Secrets:   make(map[types.UID]*v1.Secret),
 			Services:  make(map[PostgresRole]*v1.Service),
 			Endpoints: make(map[PostgresRole]*v1.Endpoints)},
-		userSyncStrategy: users.DefaultUserSyncStrategy{PasswordEncryption: passwordEncryption},
-		deleteOptions:    metav1.DeleteOptions{PropagationPolicy: &deletePropagationPolicy},
-		podEventsQueue:   podEventsQueue,
-		KubeClient:       kubeClient,
+		userSyncStrategy:    users.DefaultUserSyncStrategy{PasswordEncryption: passwordEncryption},
+		deleteOptions:       metav1.DeleteOptions{PropagationPolicy: &deletePropagationPolicy},
+		podEventsQueue:      podEventsQueue,
+		KubeClient:          kubeClient,
+		currentMajorVersion: 0,
 	}
 	cluster.logger = logger.WithField("pkg", "cluster").WithField("cluster-name", cluster.clusterName())
 	cluster.teamsAPIClient = teams.NewTeamsAPI(cfg.OpConfig.TeamsAPIUrl, logger)

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -731,7 +731,7 @@ func (c *Cluster) generateSpiloPodEnvVars(uid types.UID, spiloConfiguration stri
 		},
 	}
 	if c.OpConfig.EnablePgVersionEnvVar {
-		envVars = append(envVars, v1.EnvVar{Name: "PGVERSION", Value: c.Spec.PgVersion})
+		envVars = append(envVars, v1.EnvVar{Name: "PGVERSION", Value: c.GetDesiredMajorVersion()})
 	}
 	// Spilo expects cluster labels as JSON
 	if clusterLabels, err := json.Marshal(labels.Set(c.OpConfig.ClusterLabels)); err != nil {

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -1,8 +1,6 @@
 package cluster
 
 import (
-	"fmt"
-
 	"github.com/zalando/postgres-operator/pkg/spec"
 	v1 "k8s.io/api/core/v1"
 )
@@ -80,8 +78,7 @@ func (c *Cluster) majorVersionUpgrade() error {
 		if c.currentMajorVersion < desiredVersion {
 			podName := &spec.NamespacedName{Namespace: masterPod.Namespace, Name: masterPod.Name}
 			c.logger.Infof("triggering major version upgrade on pod %s of %d pods", masterPod.Name, numberOfPods)
-			command := fmt.Sprintf("/bin/su postgres -c \"/usr/bin/python3 /scripts/inplace_upgrade.py %d 2>&1 | tee last_upgrade.log\"", numberOfPods)
-			_, err := c.ExecCommand(podName, command)
+			_, err := c.ExecCommand(podName, "/bin/su", "postgres", "-c", "\"/usr/bin/python3 /scripts/inplace_upgrade.py %d 2>&1 | tee last_upgrade.log\"")
 			if err != nil {
 				return err
 			}

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -55,7 +55,11 @@ func (c *Cluster) majorVersionUpgrade() error {
 		return nil
 	}
 
-	pods, _ := c.listPods()
+	pods, err := c.listPods()
+	if err != nil {
+		return err
+	}
+
 	allRunning := true
 
 	var masterPod *v1.Pod

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -74,7 +74,7 @@ func (c *Cluster) majorVersionUpgrade() error {
 		if c.currentMajorVersion < desiredVersion {
 			podName := &spec.NamespacedName{Namespace: masterPod.Namespace, Name: masterPod.Name}
 			c.logger.Infof("triggering major version upgrade on pod %s", masterPod.Name)
-			command := fmt.Sprintf("su postgres -c \"python3 /scripts/inplace_upgrade.py %d 2>&1 | tee last_upgrade.log\"", numberOfPods)
+			command := fmt.Sprintf("su postgres -c \"/usr/bin/python3 /scripts/inplace_upgrade.py %d 2>&1 | tee last_upgrade.log\"", numberOfPods)
 			c.logger.Infof("executing: %s", command)
 			_, err := c.ExecCommand(podName, command)
 			if err != nil {

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -1,0 +1,82 @@
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/zalando/postgres-operator/pkg/spec"
+	v1 "k8s.io/api/core/v1"
+)
+
+// VersionMap Map of version numbers
+var VersionMap = map[string]int{
+	"9.5": 9500,
+	"9.6": 9600,
+	"10":  10000,
+	"11":  11000,
+	"12":  12000,
+	"13":  13000,
+}
+
+// IsBiggerPostgresVersion Compare two Postgres version numbers
+func IsBiggerPostgresVersion(old string, new string) bool {
+	oldN, _ := VersionMap[old]
+	newN, _ := VersionMap[new]
+	return newN > oldN
+}
+
+// GetDesiredMajorVersionAsInt Convert string to comparable integer of PG version
+func (c *Cluster) GetDesiredMajorVersionAsInt() int {
+	return VersionMap[c.GetDesiredMajorVersion()]
+}
+
+// GetDesiredMajorVersion returns major version to use, incl. potential auto upgrade
+func (c *Cluster) GetDesiredMajorVersion() string {
+
+	if c.Config.OpConfig.MajorVersionUpgradeMode == "full" {
+		if IsBiggerPostgresVersion(c.Spec.PgVersion, c.Config.OpConfig.TargetMajorVersion) {
+			c.logger.Infof("Overwriting configured major version %s to %s", c.Spec.PgVersion, c.Config.OpConfig.TargetMajorVersion)
+			return c.Config.OpConfig.TargetMajorVersion
+		}
+	}
+
+	return c.Spec.PgVersion
+}
+
+func (c *Cluster) majorVersionUpgrade() error {
+
+	if c.OpConfig.MajorVersionUpgradeMode == "off" {
+		return nil
+	}
+
+	pods, _ := c.listPods()
+	allRunning := true
+
+	var masterPod *v1.Pod
+
+	for _, pod := range pods {
+		ps, _ := c.patroni.GetMemberData(&pod)
+
+		if ps.State != "running" {
+			allRunning = false
+		}
+
+		if ps.Role == "master" {
+			masterPod = &pod
+			c.currentMajorVersion = ps.ServerVersion
+		}
+	}
+
+	numberOfPods := len(pods)
+	if allRunning && masterPod != nil {
+		if c.currentMajorVersion < c.GetDesiredMajorVersionAsInt() {
+			podName := &spec.NamespacedName{Namespace: masterPod.Namespace, Name: masterPod.Name}
+			c.ExecCommand(podName, fmt.Sprintf("python3 /scripts/inplace_upgrade.py %d", numberOfPods))
+		}
+	}
+
+	return nil
+}
+
+func (c *Cluster) getCurrentMajorVersion() error {
+	return nil
+}

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -9,8 +9,8 @@ import (
 
 // VersionMap Map of version numbers
 var VersionMap = map[string]int{
-	"9.5": 95000,
-	"9.6": 96000,
+	"9.5": 90500,
+	"9.6": 90600,
 	"10":  100000,
 	"11":  110000,
 	"12":  120000,

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -1,6 +1,8 @@
 package cluster
 
 import (
+	"fmt"
+
 	"github.com/zalando/postgres-operator/pkg/spec"
 	v1 "k8s.io/api/core/v1"
 )
@@ -78,8 +80,8 @@ func (c *Cluster) majorVersionUpgrade() error {
 		if c.currentMajorVersion < desiredVersion {
 			podName := &spec.NamespacedName{Namespace: masterPod.Namespace, Name: masterPod.Name}
 			c.logger.Infof("triggering major version upgrade on pod %s of %d pods", masterPod.Name, numberOfPods)
-			//result, err := c.ExecCommand(podName, "/bin/su", "postgres", "-c", "whoami")
-			_, err := c.ExecCommand(podName, "/bin/su", "postgres", "-c", "/usr/bin/python3 /scripts/inplace_upgrade.py %d 2>&1 | tee last_upgrade.log")
+			upgradeCommand := fmt.Sprintf("/usr/bin/python3 /scripts/inplace_upgrade.py %d 2>&1 | tee last_upgrade.log", numberOfPods)
+			_, err := c.ExecCommand(podName, "/bin/su", "postgres", "-c", upgradeCommand)
 			if err != nil {
 				return err
 			}

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -9,12 +9,12 @@ import (
 
 // VersionMap Map of version numbers
 var VersionMap = map[string]int{
-	"9.5": 9500,
-	"9.6": 9600,
-	"10":  10000,
-	"11":  11000,
-	"12":  12000,
-	"13":  13000,
+	"9.5": 95000,
+	"9.6": 96000,
+	"10":  100000,
+	"11":  110000,
+	"12":  120000,
+	"13":  130000,
 }
 
 // IsBiggerPostgresVersion Compare two Postgres version numbers
@@ -69,10 +69,10 @@ func (c *Cluster) majorVersionUpgrade() error {
 	numberOfPods := len(pods)
 	if allRunning && masterPod != nil {
 		desiredVersion := c.GetDesiredMajorVersionAsInt()
-		c.logger.Infof("Cluster healthy with version: %d desired: %d", c.currentMajorVersion, desiredVersion)
+		c.logger.Infof("cluster healthy with version: %d desired: %d", c.currentMajorVersion, desiredVersion)
 		if c.currentMajorVersion < desiredVersion {
 			podName := &spec.NamespacedName{Namespace: masterPod.Namespace, Name: masterPod.Name}
-			c.logger.Infof("Triggering major version upgrade on pod %s", masterPod.Name)
+			c.logger.Infof("triggering major version upgrade on pod %s", masterPod.Name)
 			c.ExecCommand(podName, fmt.Sprintf("python3 /scripts/inplace_upgrade.py %d", numberOfPods))
 		}
 	}

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -68,8 +68,11 @@ func (c *Cluster) majorVersionUpgrade() error {
 
 	numberOfPods := len(pods)
 	if allRunning && masterPod != nil {
-		if c.currentMajorVersion < c.GetDesiredMajorVersionAsInt() {
+		desiredVersion := c.GetDesiredMajorVersionAsInt()
+		c.logger.Infof("Cluster healthy with version: %d desired: %d", c.currentMajorVersion, desiredVersion)
+		if c.currentMajorVersion < desiredVersion {
 			podName := &spec.NamespacedName{Namespace: masterPod.Namespace, Name: masterPod.Name}
+			c.logger.Infof("Triggering major version upgrade on pod %s", masterPod.Name)
 			c.ExecCommand(podName, fmt.Sprintf("python3 /scripts/inplace_upgrade.py %d", numberOfPods))
 		}
 	}

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -75,7 +75,7 @@ func (c *Cluster) majorVersionUpgrade() error {
 			podName := &spec.NamespacedName{Namespace: masterPod.Namespace, Name: masterPod.Name}
 			c.logger.Infof("triggering major version upgrade on pod %s", masterPod.Name)
 			command := fmt.Sprintf("su postgres -c \"python3 /scripts/inplace_upgrade.py %d 2>&1 | tee last_upgrade.log\"", numberOfPods)
-			c.logger.Info("executing: %s", command)
+			c.logger.Infof("executing: %s", command)
 			_, err := c.ExecCommand(podName, command)
 			if err != nil {
 				return err

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -34,7 +34,7 @@ func (c *Cluster) GetDesiredMajorVersion() string {
 
 	if c.Config.OpConfig.MajorVersionUpgradeMode == "full" {
 		if IsBiggerPostgresVersion(c.Spec.PgVersion, c.Config.OpConfig.TargetMajorVersion) {
-			c.logger.Infof("Overwriting configured major version %s to %s", c.Spec.PgVersion, c.Config.OpConfig.TargetMajorVersion)
+			c.logger.Infof("overwriting configured major version %s to %s", c.Spec.PgVersion, c.Config.OpConfig.TargetMajorVersion)
 			return c.Config.OpConfig.TargetMajorVersion
 		}
 	}
@@ -88,9 +88,5 @@ func (c *Cluster) majorVersionUpgrade() error {
 		}
 	}
 
-	return nil
-}
-
-func (c *Cluster) getCurrentMajorVersion() error {
 	return nil
 }

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -78,7 +78,8 @@ func (c *Cluster) majorVersionUpgrade() error {
 		if c.currentMajorVersion < desiredVersion {
 			podName := &spec.NamespacedName{Namespace: masterPod.Namespace, Name: masterPod.Name}
 			c.logger.Infof("triggering major version upgrade on pod %s of %d pods", masterPod.Name, numberOfPods)
-			_, err := c.ExecCommand(podName, "/bin/su", "postgres", "-c", "\"/usr/bin/python3 /scripts/inplace_upgrade.py %d 2>&1 | tee last_upgrade.log\"")
+			//result, err := c.ExecCommand(podName, "/bin/su", "postgres", "-c", "whoami")
+			_, err := c.ExecCommand(podName, "/bin/su", "postgres", "-c", "/usr/bin/python3 /scripts/inplace_upgrade.py %d 2>&1 | tee last_upgrade.log")
 			if err != nil {
 				return err
 			}

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -73,7 +73,7 @@ func (c *Cluster) majorVersionUpgrade() error {
 		if c.currentMajorVersion < desiredVersion {
 			podName := &spec.NamespacedName{Namespace: masterPod.Namespace, Name: masterPod.Name}
 			c.logger.Infof("triggering major version upgrade on pod %s", masterPod.Name)
-			_, err := c.ExecCommand(podName, fmt.Sprintf("python3 /scripts/inplace_upgrade.py %d | tee last_upgrade.log", numberOfPods))
+			_, err := c.ExecCommand(podName, fmt.Sprintf("su postgres -c \"python3 /scripts/inplace_upgrade.py %d 2>&1 | tee last_upgrade.log\"", numberOfPods))
 			if err != nil {
 				return err
 			}

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -33,7 +33,8 @@ func (c *Cluster) GetDesiredMajorVersionAsInt() int {
 func (c *Cluster) GetDesiredMajorVersion() string {
 
 	if c.Config.OpConfig.MajorVersionUpgradeMode == "full" {
-		if IsBiggerPostgresVersion(c.Spec.PgVersion, c.Config.OpConfig.TargetMajorVersion) {
+		// current is 9.5, minimal is 11 allowing 11 to 13 clusters, everything below is upgraded
+		if IsBiggerPostgresVersion(c.Spec.PgVersion, c.Config.OpConfig.MinimalMajorVersion) {
 			c.logger.Infof("overwriting configured major version %s to %s", c.Spec.PgVersion, c.Config.OpConfig.TargetMajorVersion)
 			return c.Config.OpConfig.TargetMajorVersion
 		}

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -73,7 +73,10 @@ func (c *Cluster) majorVersionUpgrade() error {
 		if c.currentMajorVersion < desiredVersion {
 			podName := &spec.NamespacedName{Namespace: masterPod.Namespace, Name: masterPod.Name}
 			c.logger.Infof("triggering major version upgrade on pod %s", masterPod.Name)
-			c.ExecCommand(podName, fmt.Sprintf("python3 /scripts/inplace_upgrade.py %d", numberOfPods))
+			_, err := c.ExecCommand(podName, fmt.Sprintf("python3 /scripts/inplace_upgrade.py %d | tee last_upgrade.log", numberOfPods))
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -118,6 +118,10 @@ func (c *Cluster) Sync(newSpec *acidv1.Postgresql) error {
 		return fmt.Errorf("could not sync connection pooler: %v", err)
 	}
 
+	if err := c.majorVersionUpgrade(); err != nil {
+		c.logger.Errorf("major version upgrade failed: %v", err)
+	}
+
 	return err
 }
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -475,7 +475,7 @@ func (c *Cluster) syncSecrets() error {
 	for secretUsername, secretSpec := range secrets {
 		if secret, err = c.KubeClient.Secrets(secretSpec.Namespace).Create(context.TODO(), secretSpec, metav1.CreateOptions{}); err == nil {
 			c.Secrets[secret.UID] = secret
-			c.logger.Debugf("created new secret %q, uid: %q", util.NameFromMeta(secret.ObjectMeta), secret.UID)
+			c.logger.Debugf("created new secret %s, uid: %s", util.NameFromMeta(secret.ObjectMeta), secret.UID)
 			continue
 		}
 		if k8sutil.ResourceAlreadyExists(err) {
@@ -484,7 +484,7 @@ func (c *Cluster) syncSecrets() error {
 				return fmt.Errorf("could not get current secret: %v", err)
 			}
 			if secretUsername != string(secret.Data["username"]) {
-				c.logger.Errorf("secret %s does not contain the role %q", secretSpec.Name, secretUsername)
+				c.logger.Errorf("secret %s does not contain the role %s", secretSpec.Name, secretUsername)
 				continue
 			}
 			c.Secrets[secret.UID] = secret
@@ -503,7 +503,7 @@ func (c *Cluster) syncSecrets() error {
 			if pwdUser.Password != string(secret.Data["password"]) &&
 				pwdUser.Origin == spec.RoleOriginInfrastructure {
 
-				c.logger.Debugf("updating the secret %q from the infrastructure roles", secretSpec.Name)
+				c.logger.Debugf("updating the secret %s from the infrastructure roles", secretSpec.Name)
 				if _, err = c.KubeClient.Secrets(secretSpec.Namespace).Update(context.TODO(), secretSpec, metav1.UpdateOptions{}); err != nil {
 					return fmt.Errorf("could not update infrastructure role secret for role %q: %v", secretUsername, err)
 				}
@@ -513,7 +513,7 @@ func (c *Cluster) syncSecrets() error {
 				userMap[secretUsername] = pwdUser
 			}
 		} else {
-			return fmt.Errorf("could not create secret for user %q: %v", secretUsername, err)
+			return fmt.Errorf("could not create secret for user %s: %v", secretUsername, err)
 		}
 	}
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -118,6 +118,7 @@ func (c *Cluster) Sync(newSpec *acidv1.Postgresql) error {
 		return fmt.Errorf("could not sync connection pooler: %v", err)
 	}
 
+	// Major version upgrade must only run after success of all earlier operations, must remain last item in sync
 	if err := c.majorVersionUpgrade(); err != nil {
 		c.logger.Errorf("major version upgrade failed: %v", err)
 	}

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -199,10 +199,10 @@ func (c *Controller) processEvent(event ClusterEvent) {
 	if event.EventType == EventRepair {
 		runRepair, lastOperationStatus := cl.NeedsRepair()
 		if !runRepair {
-			lg.Debugf("Observed cluster status %s, repair is not required", lastOperationStatus)
+			lg.Debugf("observed cluster status %s, repair is not required", lastOperationStatus)
 			return
 		}
-		lg.Debugf("Observed cluster status %s, running sync scan to repair the cluster", lastOperationStatus)
+		lg.Debugf("observed cluster status %s, running sync scan to repair the cluster", lastOperationStatus)
 		event.EventType = EventSync
 	}
 
@@ -217,7 +217,7 @@ func (c *Controller) processEvent(event ClusterEvent) {
 		}
 
 		if err := c.submitRBACCredentials(event); err != nil {
-			c.logger.Warnf("Pods and/or Patroni may misfunction due to the lack of permissions: %v", err)
+			c.logger.Warnf("pods and/or Patroni may misfunction due to the lack of permissions: %v", err)
 		}
 
 	}
@@ -225,7 +225,7 @@ func (c *Controller) processEvent(event ClusterEvent) {
 	switch event.EventType {
 	case EventAdd:
 		if clusterFound {
-			lg.Infof("Recieved add event for already existing Postgres cluster")
+			lg.Infof("recieved add event for already existing Postgres cluster")
 			return
 		}
 
@@ -348,11 +348,11 @@ func (c *Controller) processClusterEventsQueue(idx int, stopCh <-chan struct{}, 
 func (c *Controller) warnOnDeprecatedPostgreSQLSpecParameters(spec *acidv1.PostgresSpec) {
 
 	deprecate := func(deprecated, replacement string) {
-		c.logger.Warningf("Parameter %q is deprecated. Consider setting %q instead", deprecated, replacement)
+		c.logger.Warningf("parameter %q is deprecated. Consider setting %q instead", deprecated, replacement)
 	}
 
 	noeffect := func(param string, explanation string) {
-		c.logger.Warningf("Parameter %q takes no effect. %s", param, explanation)
+		c.logger.Warningf("parameter %q takes no effect. %s", param, explanation)
 	}
 
 	if spec.UseLoadBalancer != nil {
@@ -368,7 +368,7 @@ func (c *Controller) warnOnDeprecatedPostgreSQLSpecParameters(spec *acidv1.Postg
 
 	if (spec.UseLoadBalancer != nil || spec.ReplicaLoadBalancer != nil) &&
 		(spec.EnableReplicaLoadBalancer != nil || spec.EnableMasterLoadBalancer != nil) {
-		c.logger.Warnf("Both old and new load balancer parameters are present in the manifest, ignoring old ones")
+		c.logger.Warnf("both old and new load balancer parameters are present in the manifest, ignoring old ones")
 	}
 }
 

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -480,3 +480,45 @@ func TestInfrastructureRoleDefinitions(t *testing.T) {
 		}
 	}
 }
+
+type SubConfig struct {
+	teammap map[string]string
+}
+
+type SuperConfig struct {
+	sub SubConfig
+}
+
+func TestUnderstandingMapsAndReferences(t *testing.T) {
+	teams := map[string]string{"acid": "Felix"}
+
+	sc := SubConfig{
+		teammap: teams,
+	}
+
+	ssc := SuperConfig{
+		sub: sc,
+	}
+
+	teams["24x7"] = "alex"
+
+	if len(ssc.sub.teammap) != 2 {
+		t.Errorf("Team Map does not contain 2 elements")
+	}
+
+	ssc.sub.teammap["teapot"] = "Mikkel"
+
+	if len(teams) != 3 {
+		t.Errorf("Team Map does not contain 3 elements")
+	}
+
+	teams = make(map[string]string)
+
+	if len(ssc.sub.teammap) != 3 {
+		t.Errorf("Team Map does not contain 0 elements")
+	}
+
+	if &teams == &(ssc.sub.teammap) {
+		t.Errorf("Identical maps")
+	}
+}

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -206,6 +206,10 @@ type Config struct {
 	EnableLazySpiloUpgrade                 bool              `name:"enable_lazy_spilo_upgrade" default:"false"`
 	EnablePgVersionEnvVar                  bool              `name:"enable_pgversion_env_var" default:"true"`
 	EnableSpiloWalPathCompat               bool              `name:"enable_spilo_wal_path_compat" default:"false"`
+	MajorVersionUpgradeMode                string            `name:"major_version_upgrade_mode" default:"off"` // off - no actions, manual - manifest triggers action, full - manifest and minimal version violation trigger upgrade
+	MinimalMajorVersion                    string            `name:"minimal_major_version" default:"9.5"`
+	TargetMajorVersion                     string            `name:"target_major_version" default:"13"`
+	AllowedMajorUpgradeVersions            []string          `name:"allowed_major_upgrade_versions" default:"12,13"`
 }
 
 // MustMarshal marshals the config or panics

--- a/pkg/util/httpclient/httpclient.go
+++ b/pkg/util/httpclient/httpclient.go
@@ -1,0 +1,11 @@
+package httpclient
+
+//go:generate mockgen -package mocks -destination=$PWD/mocks/$GOFILE -source=$GOFILE -build_flags=-mod=vendor
+
+import "net/http"
+
+// HTTPClient interface
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+	Get(url string) (resp *http.Response, err error)
+}

--- a/pkg/util/patroni/patroni.go
+++ b/pkg/util/patroni/patroni.go
@@ -1,7 +1,5 @@
 package patroni
 
-//go:generate mockgen -package mocks -destination=$PWD/mocks/$GOFILE -source=$GOFILE -build_flags=-mod=vendor
-
 import (
 	"bytes"
 	"encoding/json"

--- a/pkg/util/patroni/patroni.go
+++ b/pkg/util/patroni/patroni.go
@@ -40,10 +40,10 @@ type Patroni struct {
 func New(logger *logrus.Entry, client httpclient.HTTPClient) *Patroni {
 	if client == nil {
 
-	} else {
 		client = &http.Client{
 			Timeout: timeout,
 		}
+
 	}
 
 	return &Patroni{
@@ -133,17 +133,16 @@ func (p *Patroni) SetPostgresParameters(server *v1.Pod, parameters map[string]st
 
 // MemberDataPatroni child element
 type MemberDataPatroni struct {
-	Version string
-	Scope   string
+	Version string `json:"version"`
+	Scope   string `json:"scope"`
 }
 
 // MemberData Patroni member data from Patroni API
 type MemberData struct {
-	State          string
-	Role           string
-	ServerVersion  int
-	Patroni        MemberDataPatroni
-	PatroniVersion string
+	State         string            `json:"state"`
+	Role          string            `json:"role"`
+	ServerVersion int               `json:"server_version"`
+	Patroni       MemberDataPatroni `json:"patroni"`
 }
 
 // GetMemberData read member data from patroni API

--- a/pkg/util/patroni/patroni.go
+++ b/pkg/util/patroni/patroni.go
@@ -144,7 +144,7 @@ type MemberData struct {
 	State           string            `json:"state"`
 	Role            string            `json:"role"`
 	ServerVersion   int               `json:"server_version"`
-	PendingRestart  string            `json:"pending_restart"`
+	PendingRestart  bool              `json:"pending_restart"`
 	ClusterUnlocked bool              `json:"cluster_unlocked"`
 	Patroni         MemberDataPatroni `json:"patroni"`
 }

--- a/pkg/util/patroni/patroni.go
+++ b/pkg/util/patroni/patroni.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"time"
 
+	httpclient "github.com/zalando/postgres-operator/pkg/util/httpclient"
+
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 )
@@ -31,20 +33,14 @@ type Interface interface {
 	GetMemberData(server *v1.Pod) (MemberData, error)
 }
 
-// HTTPClient interface
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
-	Get(url string) (resp *http.Response, err error)
-}
-
 // Patroni API client
 type Patroni struct {
-	httpClient HTTPClient
+	httpClient httpclient.HTTPClient
 	logger     *logrus.Entry
 }
 
 // New create patroni
-func New(logger *logrus.Entry, client HTTPClient) *Patroni {
+func New(logger *logrus.Entry, client httpclient.HTTPClient) *Patroni {
 	if client == nil {
 
 	} else {

--- a/pkg/util/patroni/patroni.go
+++ b/pkg/util/patroni/patroni.go
@@ -73,7 +73,9 @@ func (p *Patroni) httpPostOrPatch(method string, url string, body *bytes.Buffer)
 		return fmt.Errorf("could not create request: %v", err)
 	}
 
-	p.logger.Debugf("making %s http request: %s", method, request.URL.String())
+	if p.logger != nil {
+		p.logger.Debugf("making %s http request: %s", method, request.URL.String())
+	}
 
 	resp, err := p.httpClient.Do(request)
 	if err != nil {
@@ -139,10 +141,12 @@ type MemberDataPatroni struct {
 
 // MemberData Patroni member data from Patroni API
 type MemberData struct {
-	State         string            `json:"state"`
-	Role          string            `json:"role"`
-	ServerVersion int               `json:"server_version"`
-	Patroni       MemberDataPatroni `json:"patroni"`
+	State           string            `json:"state"`
+	Role            string            `json:"role"`
+	ServerVersion   int               `json:"server_version"`
+	PendingRestart  string            `json:"pending_restart"`
+	ClusterUnlocked bool              `json:"cluster_unlocked"`
+	Patroni         MemberDataPatroni `json:"patroni"`
 }
 
 // GetMemberData read member data from patroni API

--- a/pkg/util/patroni/patroni_test.go
+++ b/pkg/util/patroni/patroni_test.go
@@ -84,7 +84,7 @@ func TestPatroniAPI(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	json := `{"name":"Test Name","full_name":"test full name","owner":{"login": "octocat"}}`
+	json := `{"state": "running", "postmaster_start_time": "2021-02-19 14:31:50.053 CET", "role": "master", "server_version": 90621, "cluster_unlocked": false, "xlog": {"location": 55978296057856}, "timeline": 6, "database_system_identifier": "6462555844314089962", "pending_restart": true, "patroni": {"version": "2.0.1", "scope": "acid-rest92-standby"}}`
 	r := ioutil.NopCloser(bytes.NewReader([]byte(json)))
 
 	response := http.Response{

--- a/pkg/util/patroni/patroni_test.go
+++ b/pkg/util/patroni/patroni_test.go
@@ -94,4 +94,12 @@ func TestPatroniAPI(t *testing.T) {
 
 	mockClient := mocks.NewMockHTTPClient(ctrl)
 	mockClient.EXPECT().Get(gomock.Any()).Return(&response)
+
+	p := New(nil, mockClient)
+
+	_, err := p.GetMemberData(nil)
+
+	if err != nil {
+		t.Errorf("Could not read Patroni data")
+	}
 }

--- a/pkg/util/patroni/patroni_test.go
+++ b/pkg/util/patroni/patroni_test.go
@@ -93,13 +93,18 @@ func TestPatroniAPI(t *testing.T) {
 	}
 
 	mockClient := mocks.NewMockHTTPClient(ctrl)
-	mockClient.EXPECT().Get(gomock.Any()).Return(&response)
+	mockClient.EXPECT().Get(gomock.Any()).Return(&response, nil)
 
 	p := New(nil, mockClient)
 
-	_, err := p.GetMemberData(nil)
+	pod := v1.Pod{
+		Status: v1.PodStatus{
+			PodIP: "192.168.100.1",
+		},
+	}
+	_, err := p.GetMemberData(&pod)
 
 	if err != nil {
-		t.Errorf("Could not read Patroni data")
+		t.Errorf("Could not read Patroni data: %v", err)
 	}
 }

--- a/pkg/util/patroni/patroni_test.go
+++ b/pkg/util/patroni/patroni_test.go
@@ -94,5 +94,4 @@ func TestPatroniAPI(t *testing.T) {
 
 	mockClient := mocks.NewMockHTTPClient(ctrl)
 	mockClient.EXPECT().Get(gomock.Any()).Return(&response)
-
 }

--- a/pkg/util/patroni/patroni_test.go
+++ b/pkg/util/patroni/patroni_test.go
@@ -1,10 +1,17 @@
 package patroni
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
-	"k8s.io/api/core/v1"
+	"io/ioutil"
+	"net/http"
 	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/zalando/postgres-operator/mocks"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 func newMockPod(ip string) *v1.Pod {
@@ -71,4 +78,21 @@ func TestApiURL(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestPatroniAPI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	json := `{"name":"Test Name","full_name":"test full name","owner":{"login": "octocat"}}`
+	r := ioutil.NopCloser(bytes.NewReader([]byte(json)))
+
+	response := http.Response{
+		Status: "200",
+		Body:   r,
+	}
+
+	mockClient := mocks.NewMockHTTPClient(ctrl)
+	mockClient.EXPECT().Get(gomock.Any()).Return(&response)
+
 }


### PR DESCRIPTION
This PR introduces support to upgrade major version via manifest for a healthy cluster.

This PR also introduces the ability to configure a minimum and desired Postgres major version for all clusters. Clusters with smaller versions will automatically be upgraded to the respective target version, which is 13 for the time being.