### PR TITLE
Add logic to look for container by name instead of defaulting to to index 0

### DIFF
--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -263,8 +263,21 @@ func (c *Cluster) mustUpdatePodsAfterLazyUpdate(desiredSset *appsv1.StatefulSet)
 
 	for _, pod := range pods {
 
-		effectivePodImage := pod.Spec.Containers[0].Image
-		ssImage := desiredSset.Spec.Template.Spec.Containers[0].Image
+		var (
+			effectivePodImage, ssImage string
+		)
+
+		for i := range pod.Spec.Containers {
+			if pod.Spec.Containers[i].Name == "postgres" {
+				effectivePodImage = pod.Spec.Containers[i].Image
+			}
+		}
+
+		for j := range desiredSset.Spec.Template.Spec.Containers {
+			if desiredSset.Spec.Template.Spec.Containers[j].Name == "postgres" {
+				ssImage = desiredSset.Spec.Template.Spec.Containers[j].Image
+			}
+		}
 
 		if ssImage != effectivePodImage {
 			c.logger.Infof("not all pods were re-started when the lazy upgrade was enabled; forcing the rolling upgrade now")


### PR DESCRIPTION
## Problem description

The postgres pods would restart every 30 minutes due to Postgres-Operator applying a rolling update because the container image name was defaulting to the index 0 and the actual name of the container in index 0 was a different one. 

In our case, we have Istio injecting the sidecar manually, and when injects the sidecar, it injects it to the top of the container images. When the operator is checking if there has been a change, it detects the image name `istio-proxy` different than `postgres` which causes to roll an update every 30 minutes.

## Linked issues


## Checklist

Thanks for submitting a pull request to the Postgres Operator project.
Please, ensure your contribution matches the following items:

- [ ] Your go code is [formatted](https://blog.golang.org/gofmt). Your IDE should do it automatically for you.
- [ ] You have updated [generated code](https://github.com/zalando/postgres-operator/blob/master/docs/developer.md#code-generation) when introducing new fields to the `acid.zalan.do` api package.
- [ ] New [configuration options](https://github.com/zalando/postgres-operator/blob/master/docs/developer.md#introduce-additional-configuration-parameters) are reflected in CRD validation, helm charts and sample manifests.
- [ ] New functionality is covered by [unit](https://github.com/zalando/postgres-operator/blob/master/docs/developer.md#unit-tests) and/or [e2e](https://github.com/zalando/postgres-operator/blob/master/docs/developer.md#end-to-end-tests) tests.
- [ ] You have checked existing open PRs for possible overlay and referenced them.