### PR TITLE
Update aws arguments conditionals in dump.sh

### DIFF
--- a/docker/logical-backup/dump.sh
+++ b/docker/logical-backup/dump.sh
@@ -38,10 +38,10 @@ function aws_upload {
 
     args=()
 
-    [[ ! -z "$EXPECTED_SIZE" ]] && args+=("--expected-size=$EXPECTED_SIZE")
-    [[ ! -z "$LOGICAL_BACKUP_S3_ENDPOINT" ]] && args+=("--endpoint-url=$LOGICAL_BACKUP_S3_ENDPOINT")
-    [[ ! -z "$LOGICAL_BACKUP_S3_REGION" ]] && args+=("--region=$LOGICAL_BACKUP_S3_REGION")
-    [[ ! -z "$LOGICAL_BACKUP_S3_SSE" ]] && args+=("--sse=$LOGICAL_BACKUP_S3_SSE")
+    [[ -n "$EXPECTED_SIZE" ]] && args+=("--expected-size=$EXPECTED_SIZE")
+    [[ -n "$LOGICAL_BACKUP_S3_ENDPOINT" ]] && args+=("--endpoint-url=$LOGICAL_BACKUP_S3_ENDPOINT")
+    [[ -n "$LOGICAL_BACKUP_S3_REGION" ]] && args+=("--region=$LOGICAL_BACKUP_S3_REGION")
+    [[ -n "$LOGICAL_BACKUP_S3_SSE" ]] && args+=("--sse=$LOGICAL_BACKUP_S3_SSE")
 
     aws s3 cp - "$PATH_TO_BACKUP" "${args[@]//\'/}"
 }


### PR DESCRIPTION
This is just a minor change to the conditionals when assinging the aws parameters in the dump.sh script.
Since ` [[ ! -z $str ]] == [[ -n $str ]] == [[ $str ]]` is the same in [bash](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Bash-Conditional-Expressions), I'd say that the second one makes most sense to use.
Feel free to close this if you don't agree :slightly_smiling_face:

Sanity check:
```bash
EXPECTED_SIZE=12345
LOGICAL_BACKUP_S3_REGION=eu-north-1
PATH_TO_BACKUP=s3://hi/spilo/1

args=()
[[ ! -z "$EXPECTED_SIZE" ]] && args+=("--expected-size=$EXPECTED_SIZE")
[[ ! -z "$LOGICAL_BACKUP_S3_ENDPOINT" ]] && args+=("--endpoint-url=$LOGICAL_BACKUP_S3_ENDPOINT")
[[ ! -z "$LOGICAL_BACKUP_S3_REGION" ]] && args+=("--region=$LOGICAL_BACKUP_S3_REGION")
[[ ! -z "$LOGICAL_BACKUP_S3_SSE" ]] && args+=("--sse=$LOGICAL_BACKUP_S3_SSE")
res_old=$(echo aws s3 cp - "$PATH_TO_BACKUP" "${args[@]//\'/}")

args=()
[[ -n "$EXPECTED_SIZE" ]] && args+=("--expected-size=$EXPECTED_SIZE")
[[ -n "$LOGICAL_BACKUP_S3_ENDPOINT" ]] && args+=("--endpoint-url=$LOGICAL_BACKUP_S3_ENDPOINT")
[[ -n "$LOGICAL_BACKUP_S3_REGION" ]] && args+=("--region=$LOGICAL_BACKUP_S3_REGION")
[[ -n "$LOGICAL_BACKUP_S3_SSE" ]] && args+=("--sse=$LOGICAL_BACKUP_S3_SSE")
res_new=$(echo aws s3 cp - "$PATH_TO_BACKUP" "${args[@]//\'/}")

echo "$res_old"; echo "$res_new"
[[ "$res_old" = "$res_new" ]] && echo "Yup they are equal :)"
```