### PR TITLE
create global default privileges in the appropriate prepared databases

### DIFF
--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -661,6 +661,9 @@ func (c *Cluster) syncDatabases() error {
 
 	// set default privileges for prepared database
 	for _, preparedDatabase := range preparedDatabases {
+		if err := c.initDbConnWithName(preparedDatabase); err != nil {
+			return fmt.Errorf("could not init database connection to %s", preparedDatabase)
+		}
 		if err = c.execAlterGlobalDefaultPrivileges(preparedDatabase+constants.OwnerRoleNameSuffix, preparedDatabase); err != nil {
 			return err
 		}


### PR DESCRIPTION
fixes https://github.com/zalando/postgres-operator/issues/1420
I can see the default privileges now.
I don't see how to easily test this, maybe the preparedDatabases feature needs some e2e tests?
