### PR TITLE
Corrected default value for SpiloAllowPrivilegeEscalation

### DIFF
--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -34,7 +34,7 @@ type Resources struct {
 	PodPriorityClassName      string              `name:"pod_priority_class_name"`
 	ClusterDomain             string              `name:"cluster_domain" default:"cluster.local"`
 	SpiloPrivileged           bool                `name:"spilo_privileged" default:"false"`
-	SpiloAllowPrivilegeEscalation bool            `name:"spilo_allow_privilege_escalation" default:"false"`
+	SpiloAllowPrivilegeEscalation bool            `name:"spilo_allow_privilege_escalation" default:"true"`
 	AdditionalPodCapabilities []string            `name:"additional_pod_capabilities" default:""`
 	ClusterLabels             map[string]string   `name:"cluster_labels" default:"application:spilo"`
 	InheritedLabels           []string            `name:"inherited_labels" default:""`


### PR DESCRIPTION
Corrected default value for `SpiloAllowPrivilegeEscalation` from `false` to `true`
This is to align it with the rest of the files, including documentation, manifests, etc