### PR TITLE
Support standby replication from GS (GCS)

### DIFF
--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -466,9 +466,9 @@ spec:
                 type: integer
               standby:
                 type: object
-                required:
-                  - s3_wal_path
                 properties:
+                  cluster:
+                    type: string
                   s3_wal_path:
                     type: string
               teamId:

--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -474,6 +474,17 @@ spec:
                   uid:
                     format: uuid
                     type: string
+                  version:
+                    type: string
+                    enum:
+                      - "9.3"
+                      - "9.4"
+                      - "9.5"
+                      - "9.6"
+                      - "10"
+                      - "11"
+                      - "12"
+                      - "13"
               teamId:
                 type: string
               tls:

--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -472,17 +472,6 @@ spec:
                   uid:
                     format: uuid
                     type: string
-                  version:
-                    type: string
-                    enum:
-                      - "9.3"
-                      - "9.4"
-                      - "9.5"
-                      - "9.6"
-                      - "10"
-                      - "11"
-                      - "12"
-                      - "13"
                   s3_wal_path:
                     type: string
                   gs_wal_path:

--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -471,6 +471,9 @@ spec:
                     type: string
                   s3_wal_path:
                     type: string
+                  uid:
+                    format: uuid
+                    type: string
               teamId:
                 type: string
               tls:

--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -467,11 +467,6 @@ spec:
               standby:
                 type: object
                 properties:
-                  cluster:
-                    type: string
-                  uid:
-                    format: uuid
-                    type: string
                   s3_wal_path:
                     type: string
                   gs_wal_path:

--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -469,8 +469,6 @@ spec:
                 properties:
                   cluster:
                     type: string
-                  s3_wal_path:
-                    type: string
                   uid:
                     format: uuid
                     type: string
@@ -485,6 +483,10 @@ spec:
                       - "11"
                       - "12"
                       - "13"
+                  s3_wal_path:
+                    type: string
+                  gs_wal_path:
+                    type: string
               teamId:
                 type: string
               tls:

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -371,7 +371,7 @@ archives is supported.
 
 * **cluster**
   name of the cluster to clone from. Used to identify the S3 or GS bucket to replicate
-  from. Optional, but `cluster` or `s3_wal_path` is required.
+  from. Optional, but `cluster`, `s3_wal_path`  or `gs_wal_path` is required.
 
 * **uid**
   Kubernetes UID of the cluster to replicate from. Since cluster name is not a
@@ -387,7 +387,11 @@ archives is supported.
 
 * **s3_wal_path**
   the url to S3 bucket containing the WAL archive of the remote primary.
-  Optional, but `cluster` or `s3_wal_path` is required. 
+  Optional, but `cluster`, `s3_wal_path`  or `gs_wal_path` is required. 
+
+* **gs_wal_path**
+  the url to GS bucket containing the WAL archive of the remote primary.
+  Optional, but `cluster`, `s3_wal_path`  or `gs_wal_path` is required. 
 
 ## Volume properties
 

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -369,24 +369,13 @@ On startup, an existing `standby` top-level key creates a standby Postgres
 cluster streaming from a remote location. So far streaming from S3 and GCS WAL
 archives is supported.
 
-* **cluster**
-  name of the cluster to clone from. Used to identify the S3 or GS bucket to replicate
-  from. Optional, but `cluster`, `s3_wal_path`  or `gs_wal_path` is required.
-
-* **uid**
-  Kubernetes UID of the cluster to replicate from. Since cluster name is not a
-  unique identifier of the cluster (as identically named clusters may exist in
-  different namespaces) , the operator uses UID in the bucket name in order
-  to guarantee uniqueness. Can be omitted for buckets which do not include the
-  UID in their path. Optional.
-
 * **s3_wal_path**
   the url to S3 bucket containing the WAL archive of the remote primary.
-  Optional, but `cluster`, `s3_wal_path`  or `gs_wal_path` is required. 
+  Optional, but `s3_wal_path`  or `gs_wal_path` is required.
 
 * **gs_wal_path**
   the url to GS bucket containing the WAL archive of the remote primary.
-  Optional, but `cluster`, `s3_wal_path`  or `gs_wal_path` is required. 
+  Optional, but `s3_wal_path`  or `gs_wal_path` is required.
 
 ## Volume properties
 

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -380,11 +380,6 @@ archives is supported.
   to guarantee uniqueness. Can be omitted for buckets which do not include the
   UID in their path. Optional.
 
-* **version**
-  The Postgres major version of the cluster to replicate. This is needed with
-  wal-e/wal-g backups created by Spilo 13 as they append the Postgres version to
-  the bucket path. Optional.
-
 * **s3_wal_path**
   the url to S3 bucket containing the WAL archive of the remote primary.
   Optional, but `cluster`, `s3_wal_path`  or `gs_wal_path` is required. 

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -366,12 +366,28 @@ under the `clone` top-level key and do not affect the already running cluster.
 ## Standby cluster
 
 On startup, an existing `standby` top-level key creates a standby Postgres
-cluster streaming from a remote location. So far only streaming from a S3 WAL
-archive is supported.
+cluster streaming from a remote location. So far streaming from S3 and GCS WAL
+archives is supported.
+
+* **cluster**
+  name of the cluster to clone from. Used to identify the S3 or GS bucket to replicate
+  from. Optional, but `cluster` or `s3_wal_path` is required.
+
+* **uid**
+  Kubernetes UID of the cluster to replicate from. Since cluster name is not a
+  unique identifier of the cluster (as identically named clusters may exist in
+  different namespaces) , the operator uses UID in the bucket name in order
+  to guarantee uniqueness. Can be omitted for buckets which do not include the
+  UID in their path. Optional.
+
+* **version**
+  The Postgres major version of the cluster to replicate. This is needed with
+  wal-e/wal-g backups created by Spilo 13 as they append the Postgres version to
+  the bucket path. Optional.
 
 * **s3_wal_path**
   the url to S3 bucket containing the WAL archive of the remote primary.
-  Required when the `standby` section is present.
+  Optional, but `cluster` or `s3_wal_path` is required. 
 
 ## Volume properties
 

--- a/docs/user.md
+++ b/docs/user.md
@@ -796,8 +796,8 @@ version between source and target cluster has to be the same.
 To start a cluster as standby, add the following `standby` section in the YAML
 file. Specify either the S3/GS bucket path or a cluster name to use the default layout.
 Omitting both settings will result in an error and no statefulset will be created.
-Note that when specifying cluster name you may also optionally provide a UID and
-Postgres major version if those are used in your bucket.
+Note that when specifying cluster name you may also optionally provide a UID
+if one is used in your bucket path.
 
 ```yaml
 spec:
@@ -810,7 +810,6 @@ spec:
   standby:
     cluster: "acid-batman"
     uid: "efd12e58-5786-11e8-b5a7-06148230260c"
-    version: "12"
 ```
 
 At the moment, the operator only allows to stream from the WAL archive of the

--- a/docs/user.md
+++ b/docs/user.md
@@ -794,7 +794,7 @@ different location than its source database. Unlike cloning, the PostgreSQL
 version between source and target cluster has to be the same.
 
 To start a cluster as standby, add the following `standby` section in the YAML
-file. Specify either the S3 bucket path or a cluster name to use the default layout.
+file. Specify either the S3/GS bucket path or a cluster name to use the default layout.
 Omitting both settings will result in an error and no statefulset will be created.
 Note that when specifying cluster name you may also optionally provide a UID and
 Postgres major version if those are used in your bucket.

--- a/docs/user.md
+++ b/docs/user.md
@@ -794,13 +794,23 @@ different location than its source database. Unlike cloning, the PostgreSQL
 version between source and target cluster has to be the same.
 
 To start a cluster as standby, add the following `standby` section in the YAML
-file and specify the S3 bucket path. An empty path will result in an error and
-no statefulset will be created.
+file. Specify either the S3 bucket path or a cluster name to use the default layout.
+Omitting both settings will result in an error and no statefulset will be created.
+Note that when specifying cluster name you may also optionally provide a UID and
+Postgres major version if those are used in your bucket.
 
 ```yaml
 spec:
   standby:
     s3_wal_path: "s3://<bucketname>/spilo/<source_db_cluster>/<UID>/wal/<PGVERSION>"
+```
+
+```yaml
+spec:
+  standby:
+    cluster: "acid-batman"
+    uid: "efd12e58-5786-11e8-b5a7-06148230260c"
+    version: "12"
 ```
 
 At the moment, the operator only allows to stream from the WAL archive of the

--- a/docs/user.md
+++ b/docs/user.md
@@ -794,10 +794,8 @@ different location than its source database. Unlike cloning, the PostgreSQL
 version between source and target cluster has to be the same.
 
 To start a cluster as standby, add the following `standby` section in the YAML
-file. Specify either the S3/GS bucket path or a cluster name to use the default layout.
-Omitting both settings will result in an error and no statefulset will be created.
-Note that when specifying cluster name you may also optionally provide a UID
-if one is used in your bucket path.
+file. Specify the S3/GS bucket path. Omitting both settings will result in an error
+and no statefulset will be created.
 
 ```yaml
 spec:
@@ -808,8 +806,7 @@ spec:
 ```yaml
 spec:
   standby:
-    cluster: "acid-batman"
-    uid: "efd12e58-5786-11e8-b5a7-06148230260c"
+    gs_wal_path: "gs://<bucketname>/spilo/<source_db_cluster>/<UID>/wal/<PGVERSION>"
 ```
 
 At the moment, the operator only allows to stream from the WAL archive of the

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -649,9 +649,11 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 						Type: "integer",
 					},
 					"standby": {
-						Type:     "object",
-						Required: []string{"s3_wal_path"},
+						Type: "object",
 						Properties: map[string]apiextv1.JSONSchemaProps{
+							"cluster": {
+								Type: "string",
+							},
 							"s3_wal_path": {
 								Type: "string",
 							},

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -654,9 +654,6 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 							"cluster": {
 								Type: "string",
 							},
-							"s3_wal_path": {
-								Type: "string",
-							},
 							"uid": {
 								Type:   "string",
 								Format: "uuid",
@@ -689,6 +686,12 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 										Raw: []byte(`"13"`),
 									},
 								},
+							},
+							"s3_wal_path": {
+								Type: "string",
+							},
+							"gs_wal_path": {
+								Type: "string",
 							},
 						},
 					},

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -651,13 +651,6 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 					"standby": {
 						Type: "object",
 						Properties: map[string]apiextv1.JSONSchemaProps{
-							"cluster": {
-								Type: "string",
-							},
-							"uid": {
-								Type:   "string",
-								Format: "uuid",
-							},
 							"s3_wal_path": {
 								Type: "string",
 							},

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -657,6 +657,10 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 							"s3_wal_path": {
 								Type: "string",
 							},
+							"uid": {
+								Type:   "string",
+								Format: "uuid",
+							},
 						},
 					},
 					"teamId": {

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -658,35 +658,6 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 								Type:   "string",
 								Format: "uuid",
 							},
-							"version": {
-								Type: "string",
-								Enum: []apiextv1.JSON{
-									{
-										Raw: []byte(`"9.3"`),
-									},
-									{
-										Raw: []byte(`"9.4"`),
-									},
-									{
-										Raw: []byte(`"9.5"`),
-									},
-									{
-										Raw: []byte(`"9.6"`),
-									},
-									{
-										Raw: []byte(`"10"`),
-									},
-									{
-										Raw: []byte(`"11"`),
-									},
-									{
-										Raw: []byte(`"12"`),
-									},
-									{
-										Raw: []byte(`"13"`),
-									},
-								},
-							},
 							"s3_wal_path": {
 								Type: "string",
 							},

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -661,6 +661,35 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 								Type:   "string",
 								Format: "uuid",
 							},
+							"version": {
+								Type: "string",
+								Enum: []apiextv1.JSON{
+									{
+										Raw: []byte(`"9.3"`),
+									},
+									{
+										Raw: []byte(`"9.4"`),
+									},
+									{
+										Raw: []byte(`"9.5"`),
+									},
+									{
+										Raw: []byte(`"9.6"`),
+									},
+									{
+										Raw: []byte(`"10"`),
+									},
+									{
+										Raw: []byte(`"11"`),
+									},
+									{
+										Raw: []byte(`"12"`),
+									},
+									{
+										Raw: []byte(`"13"`),
+									},
+								},
+							},
 						},
 					},
 					"teamId": {

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -169,6 +169,7 @@ type StandbyDescription struct {
 	UID         string `json:"uid,omitempty"`
 	PgVersion   string `json:"version,omitempty"`
 	S3WalPath   string `json:"s3_wal_path,omitempty"`
+	GSWalPath   string `json:"gs_wal_path,omitempty"`
 }
 
 // TLSDescription specs TLS properties

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -166,6 +166,7 @@ type Patroni struct {
 // StandbyDescription contains s3 wal path
 type StandbyDescription struct {
 	ClusterName string `json:"cluster,omitempty"`
+	UID         string `json:"uid,omitempty"`
 	S3WalPath   string `json:"s3_wal_path,omitempty"`
 }
 

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -167,7 +167,6 @@ type Patroni struct {
 type StandbyDescription struct {
 	ClusterName string `json:"cluster,omitempty"`
 	UID         string `json:"uid,omitempty"`
-	PgVersion   string `json:"version,omitempty"`
 	S3WalPath   string `json:"s3_wal_path,omitempty"`
 	GSWalPath   string `json:"gs_wal_path,omitempty"`
 }

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -167,6 +167,7 @@ type Patroni struct {
 type StandbyDescription struct {
 	ClusterName string `json:"cluster,omitempty"`
 	UID         string `json:"uid,omitempty"`
+	PgVersion   string `json:"version,omitempty"`
 	S3WalPath   string `json:"s3_wal_path,omitempty"`
 }
 

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -165,7 +165,8 @@ type Patroni struct {
 
 // StandbyDescription contains s3 wal path
 type StandbyDescription struct {
-	S3WalPath string `json:"s3_wal_path,omitempty"`
+	ClusterName string `json:"cluster,omitempty"`
+	S3WalPath   string `json:"s3_wal_path,omitempty"`
 }
 
 // TLSDescription specs TLS properties

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -165,10 +165,8 @@ type Patroni struct {
 
 // StandbyDescription contains s3 wal path
 type StandbyDescription struct {
-	ClusterName string `json:"cluster,omitempty"`
-	UID         string `json:"uid,omitempty"`
-	S3WalPath   string `json:"s3_wal_path,omitempty"`
-	GSWalPath   string `json:"gs_wal_path,omitempty"`
+	S3WalPath string `json:"s3_wal_path,omitempty"`
+	GSWalPath string `json:"gs_wal_path,omitempty"`
 }
 
 // TLSDescription specs TLS properties

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1878,6 +1878,8 @@ func (c *Cluster) generateStandbyEnvironment(description *acidv1.StandbyDescript
 		msg := "Figure out which S3 bucket to use from env"
 		c.logger.Info(msg, description.S3WalPath)
 
+		cluster := description.ClusterName
+		result = append(result, v1.EnvVar{Name: "STANDBY_SCOPE", Value: cluster})
 		if c.OpConfig.WALES3Bucket != "" {
 			envs := []v1.EnvVar{
 				{

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1935,10 +1935,6 @@ func (c *Cluster) generateStandbyEnvironment(description *acidv1.StandbyDescript
 				Name:  "STANDBY_WAL_BUCKET_SCOPE_SUFFIX",
 				Value: getBucketScopeSuffix(description.UID),
 			},
-			{
-				Name:  "STANDBY_PGVERSION",
-				Value: description.PgVersion,
-			},
 		}
 
 		result = append(result, envs...)

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1904,17 +1904,14 @@ func (c *Cluster) generateStandbyEnvironment(description *acidv1.StandbyDescript
 			c.logger.Error("Cannot figure out S3 or GS bucket. Both are empty.")
 		}
 
-		// TODO add UID support for standby
-		/*
-			envs := []v1.EnvVar{
-				{
-					Name:  "CLONE_WAL_BUCKET_SCOPE_SUFFIX",
-					Value: getBucketScopeSuffix(description.UID),
-				},
-			}
+		envs := []v1.EnvVar{
+			{
+				Name:  "STANDBY_WAL_BUCKET_SCOPE_SUFFIX",
+				Value: getBucketScopeSuffix(description.UID),
+			},
+		}
 
-			result = append(result, envs...)
-		*/
+		result = append(result, envs...)
 
 	} else {
 		// standby with S3, find out the bucket to setup standby

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1909,6 +1909,10 @@ func (c *Cluster) generateStandbyEnvironment(description *acidv1.StandbyDescript
 				Name:  "STANDBY_WAL_BUCKET_SCOPE_SUFFIX",
 				Value: getBucketScopeSuffix(description.UID),
 			},
+			{
+				Name:  "STANDBY_PGVERSION",
+				Value: description.PgVersion,
+			},
 		}
 
 		result = append(result, envs...)

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1875,6 +1875,10 @@ func (c *Cluster) generateCloneEnvironment(description *acidv1.CloneDescription)
 func (c *Cluster) generateStandbyEnvironment(description *acidv1.StandbyDescription) []v1.EnvVar {
 	result := make([]v1.EnvVar, 0)
 
+	if description.S3WalPath == "" && description.GSWalPath == "" {
+		return nil
+	}
+
 	if description.S3WalPath != "" {
 		// standby with S3, find out the bucket to setup standby
 		msg := "Standby from S3 bucket using custom parsed S3WalPath from the manifest %s "


### PR DESCRIPTION
This allows standby clusters to be created from a GCS bucket by specifying either `gs_wal_path` with a full manual path, or `cluster` and optionally `uid` and `version` for similar behaviour to cloning. I've updated the documentation with the details. I have tested it against a number of GCS WAL-G backups and it seems to work nicely. I haven't tested the cluster-based replication from S3 as I don't have any data in S3 to try it out with.

It uses the main `GCPCredentials` from the operator config rather than requiring a standby-specific setting which I think should generally work. If different credentials are needed for pushing WALs then they can be changed at the same time as the standby is promoted.

I created this before I realised there was an existing PR! Let me know if it's useful. This is going to be an essential feature for us so I'm happy to amend it as needed.