### PR TITLE
replace statefulset on annotation diff

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -599,7 +599,7 @@ func (c *Cluster) enforceMinResourceLimits(spec *acidv1.PostgresSpec) error {
 // for a cluster that had no such job before. In this case a missing job is not an error.
 func (c *Cluster) Update(oldSpec, newSpec *acidv1.Postgresql) error {
 	updateFailed := false
-	syncStatetfulSet := false
+	syncStatefulSet := false
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -620,7 +620,7 @@ func (c *Cluster) Update(oldSpec, newSpec *acidv1.Postgresql) error {
 	if IsBiggerPostgresVersion(oldSpec.Spec.PostgresqlParam.PgVersion, c.GetDesiredMajorVersion()) {
 		c.logger.Infof("postgresql version increased (%s -> %s), depending on config manual upgrade needed",
 			oldSpec.Spec.PostgresqlParam.PgVersion, newSpec.Spec.PostgresqlParam.PgVersion)
-		syncStatetfulSet = true
+		syncStatefulSet = true
 	} else {
 		c.logger.Infof("postgresql major version unchanged or smaller, no changes needed")
 		// sticking with old version, this will also advance GetDesiredVersion next time.
@@ -689,9 +689,9 @@ func (c *Cluster) Update(oldSpec, newSpec *acidv1.Postgresql) error {
 			updateFailed = true
 			return
 		}
-		if syncStatetfulSet || !reflect.DeepEqual(oldSs, newSs) || !reflect.DeepEqual(oldSpec.Annotations, newSpec.Annotations) {
+		if syncStatefulSet || !reflect.DeepEqual(oldSs, newSs) || !reflect.DeepEqual(oldSpec.Annotations, newSpec.Annotations) {
 			c.logger.Debugf("syncing statefulsets")
-			syncStatetfulSet = false
+			syncStatefulSet = false
 			// TODO: avoid generating the StatefulSet object twice by passing it to syncStatefulSet
 			if err := c.syncStatefulSet(); err != nil {
 				c.logger.Errorf("could not sync statefulsets: %v", err)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -361,6 +361,7 @@ func (c *Cluster) compareStatefulSetWith(statefulSet *appsv1.StatefulSet) *compa
 	}
 	if !reflect.DeepEqual(c.Statefulset.Annotations, statefulSet.Annotations) {
 		match = false
+		needsReplace = true
 		reasons = append(reasons, "new statefulset's annotations do not match the current one")
 	}
 

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -147,25 +147,6 @@ func (c *Cluster) preScaleDown(newStatefulSet *appsv1.StatefulSet) error {
 	return nil
 }
 
-func (c *Cluster) updateStatefulSetAnnotations(annotations map[string]string) (*appsv1.StatefulSet, error) {
-	c.logger.Debugf("patching statefulset annotations")
-	patchData, err := metaAnnotationsPatch(annotations)
-	if err != nil {
-		return nil, fmt.Errorf("could not form patch for the statefulset metadata: %v", err)
-	}
-	result, err := c.KubeClient.StatefulSets(c.Statefulset.Namespace).Patch(
-		context.TODO(),
-		c.Statefulset.Name,
-		types.MergePatchType,
-		[]byte(patchData),
-		metav1.PatchOptions{},
-		"")
-	if err != nil {
-		return nil, fmt.Errorf("could not patch statefulset annotations %q: %v", patchData, err)
-	}
-	return result, nil
-}
-
 func (c *Cluster) updateStatefulSet(newStatefulSet *appsv1.StatefulSet) error {
 	c.setProcessName("updating statefulset")
 	if c.Statefulset == nil {
@@ -195,13 +176,6 @@ func (c *Cluster) updateStatefulSet(newStatefulSet *appsv1.StatefulSet) error {
 		"")
 	if err != nil {
 		return fmt.Errorf("could not patch statefulset spec %q: %v", statefulSetName, err)
-	}
-
-	if newStatefulSet.Annotations != nil {
-		statefulSet, err = c.updateStatefulSetAnnotations(newStatefulSet.Annotations)
-		if err != nil {
-			return err
-		}
 	}
 
 	c.Statefulset = statefulSet

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -373,8 +373,6 @@ func (c *Cluster) syncStatefulSet() error {
 			}
 		}
 
-		c.updateStatefulSetAnnotations(c.AnnotationsToPropagate(c.annotationsSet(c.Statefulset.Annotations)))
-
 		if len(podsToRecreate) == 0 && !c.OpConfig.EnableLazySpiloUpgrade {
 			// even if the desired and the running statefulsets match
 			// there still may be not up-to-date pods on condition

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -33,11 +33,13 @@ func TestSyncStatefulSetsAnnotations(t *testing.T) {
 	client, _ := newFakeK8sSyncClient()
 	clusterName := "acid-test-cluster"
 	namespace := "default"
+	inheritedAnnotation := "environment"
 
 	pg := acidv1.Postgresql{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterName,
-			Namespace: namespace,
+			Name:        clusterName,
+			Namespace:   namespace,
+			Annotations: map[string]string{inheritedAnnotation: "test"},
 		},
 		Spec: acidv1.PostgresSpec{
 			Volume: acidv1.Volume{
@@ -57,6 +59,7 @@ func TestSyncStatefulSetsAnnotations(t *testing.T) {
 					DefaultCPULimit:       "300m",
 					DefaultMemoryRequest:  "300Mi",
 					DefaultMemoryLimit:    "300Mi",
+					InheritedAnnotations:  []string{inheritedAnnotation},
 					PodRoleLabel:          "spilo-role",
 					ResourceCheckInterval: time.Duration(3),
 					ResourceCheckTimeout:  time.Duration(10),
@@ -103,5 +106,10 @@ func TestSyncStatefulSetsAnnotations(t *testing.T) {
 	cmp = cluster.compareStatefulSetWith(desiredSts)
 	if !cmp.match {
 		t.Errorf("%s: current and desired statefulsets are not matching %#v", testName, cmp)
+	}
+
+	// check if inherited annotation exists
+	if _, exists := desiredSts.Annotations[inheritedAnnotation]; !exists {
+		t.Errorf("%s: inherited annotation not found in desired statefulset: %#v", testName, desiredSts.Annotations)
 	}
 }

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -1,0 +1,121 @@
+package cluster
+
+import (
+	"testing"
+	"time"
+
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
+	acidv1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
+	fakeacidv1 "github.com/zalando/postgres-operator/pkg/generated/clientset/versioned/fake"
+	"github.com/zalando/postgres-operator/pkg/util/config"
+	"github.com/zalando/postgres-operator/pkg/util/k8sutil"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func newFakeK8sSyncClient() (k8sutil.KubernetesClient, *fake.Clientset) {
+	acidClientSet := fakeacidv1.NewSimpleClientset()
+	clientSet := fake.NewSimpleClientset()
+
+	return k8sutil.KubernetesClient{
+		PodsGetter:         clientSet.CoreV1(),
+		PostgresqlsGetter:  acidClientSet.AcidV1(),
+		StatefulSetsGetter: clientSet.AppsV1(),
+	}, clientSet
+}
+
+func TestSyncStatefulSetsAnnotations(t *testing.T) {
+	testName := "test syncing statefulsets annotations"
+	client, _ := newFakeK8sSyncClient()
+	clusterName := "acid-test-cluster"
+	namespace := "default"
+
+	pg := acidv1.Postgresql{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        clusterName,
+			Namespace:   namespace,
+			Annotations: map[string]string{"test-anno": "true"},
+		},
+		Spec: acidv1.PostgresSpec{
+			Volume: acidv1.Volume{
+				Size: "1Gi",
+			},
+		},
+	}
+
+	var cluster = New(
+		Config{
+			OpConfig: config.Config{
+				PodManagementPolicy: "ordered_ready",
+				Resources: config.Resources{
+					ClusterLabels:         map[string]string{"application": "spilo"},
+					ClusterNameLabel:      "cluster-name",
+					DefaultCPURequest:     "300m",
+					DefaultCPULimit:       "300m",
+					DefaultMemoryRequest:  "300Mi",
+					DefaultMemoryLimit:    "300Mi",
+					InheritedAnnotations:  []string{"test-anno"},
+					PodRoleLabel:          "spilo-role",
+					ResourceCheckInterval: time.Duration(3),
+					ResourceCheckTimeout:  time.Duration(10),
+				},
+			},
+		}, client, pg, logger, eventRecorder)
+
+	cluster.Name = clusterName
+	cluster.Namespace = namespace
+
+	// create a new Postgresql resource
+	_, err := cluster.KubeClient.Postgresqls(namespace).Create(
+		context.TODO(), &pg, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// create a statefulset
+	sts, err := cluster.createStatefulSet()
+	assert.NoError(t, err)
+	cluster.Statefulset = sts
+
+	// update postgresql and remove annotation to force sync
+	newPg := acidv1.Postgresql{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: namespace,
+		},
+		Spec: acidv1.PostgresSpec{
+			Volume: acidv1.Volume{
+				Size: "1Gi",
+			},
+		},
+	}
+
+	_, err = cluster.KubeClient.Postgresqls(namespace).Update(
+		context.TODO(), &newPg, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	// empty annotations on cluster ObjectMeta object as well
+	cluster.ObjectMeta.Annotations = map[string]string{}
+
+	// first compare running with desired statefulset - they should not match
+	desiredSts, err := cluster.generateStatefulSet(&cluster.Postgresql.Spec)
+	assert.NoError(t, err)
+
+	cmp := cluster.compareStatefulSetWith(desiredSts)
+	if cmp.match {
+		t.Errorf("%s: match between current and desired statefulsets albeit differences: %#v", testName, cmp)
+	}
+
+	// now sync statefulset - the diff should trigger a replacement
+	cluster.syncStatefulSet()
+
+	// compare them again
+	_, err = cluster.KubeClient.StatefulSets(namespace).Get(context.TODO(), clusterName, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	cmp = cluster.compareStatefulSetWith(desiredSts)
+	if !cmp.match {
+		t.Errorf("%s: current and desired statefulsets are not matching %#v", testName, cmp)
+	}
+}

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/stretchr/testify/assert"
 	acidv1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
@@ -35,9 +36,8 @@ func TestSyncStatefulSetsAnnotations(t *testing.T) {
 
 	pg := acidv1.Postgresql{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        clusterName,
-			Namespace:   namespace,
-			Annotations: map[string]string{"test-anno": "true"},
+			Name:      clusterName,
+			Namespace: namespace,
 		},
 		Spec: acidv1.PostgresSpec{
 			Volume: acidv1.Volume{
@@ -68,35 +68,24 @@ func TestSyncStatefulSetsAnnotations(t *testing.T) {
 	cluster.Name = clusterName
 	cluster.Namespace = namespace
 
-	// create a new Postgresql resource
-	_, err := cluster.KubeClient.Postgresqls(namespace).Create(
-		context.TODO(), &pg, metav1.CreateOptions{})
-	assert.NoError(t, err)
-
 	// create a statefulset
-	sts, err := cluster.createStatefulSet()
-	assert.NoError(t, err)
-	cluster.Statefulset = sts
-
-	// update postgresql and remove annotation to force sync
-	newPg := acidv1.Postgresql{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterName,
-			Namespace: namespace,
-		},
-		Spec: acidv1.PostgresSpec{
-			Volume: acidv1.Volume{
-				Size: "1Gi",
-			},
-		},
-	}
-
-	_, err = cluster.KubeClient.Postgresqls(namespace).Update(
-		context.TODO(), &newPg, metav1.UpdateOptions{})
+	_, err := cluster.createStatefulSet()
 	assert.NoError(t, err)
 
-	// empty annotations on cluster ObjectMeta object as well
-	cluster.ObjectMeta.Annotations = map[string]string{}
+	// patch statefulset and add annotation
+	patchData, err := metaAnnotationsPatch(map[string]string{"test-anno": "true"})
+	assert.NoError(t, err)
+
+	newSts, err := cluster.KubeClient.StatefulSets(namespace).Patch(
+		context.TODO(),
+		clusterName,
+		types.MergePatchType,
+		[]byte(patchData),
+		metav1.PatchOptions{},
+		"")
+	assert.NoError(t, err)
+
+	cluster.Statefulset = newSts
 
 	// first compare running with desired statefulset - they should not match
 	desiredSts, err := cluster.generateStatefulSet(&cluster.Postgresql.Spec)
@@ -107,12 +96,8 @@ func TestSyncStatefulSetsAnnotations(t *testing.T) {
 		t.Errorf("%s: match between current and desired statefulsets albeit differences: %#v", testName, cmp)
 	}
 
-	// now sync statefulset - the diff should trigger a replacement
+	// now sync statefulset - the diff should trigger a update
 	cluster.syncStatefulSet()
-
-	// compare them again
-	_, err = cluster.KubeClient.StatefulSets(namespace).Get(context.TODO(), clusterName, metav1.GetOptions{})
-	assert.NoError(t, err)
 
 	cmp = cluster.compareStatefulSetWith(desiredSts)
 	if !cmp.match {


### PR DESCRIPTION
fixes #1447 

with `v1.6.2` we moved the rolling update flag from statefulset to pods. Thus, after bumping the operator version during the next sync there will be a difference between the current and generated statefulset. If this is the only difference the statefulset is patched. But in K8s one cannot remove things with `Patch`. It requires an `Update` to do so. To avoid extending the cluster rbac, we can choose to replace the statefulset if annotations are different.

In fact, our code does not even patch the statefulset if annotations for the new statefulset are [empty](https://github.com/zalando/postgres-operator/blob/0745ce7cce63ab6431103d27eb08e54ec47d2b15/pkg/cluster/resources.go#L200).

The annotation update in [Sync.go](https://github.com/zalando/postgres-operator/blob/0745ce7cce63ab6431103d27eb08e54ec47d2b15/pkg/cluster/sync.go#L376) can go. There would be no difference at this point. I would even argue that line has been obsolete before. Actually we could also remove `updateStatefulSetAnnotations` function if we choose to replace the statefulset.