### PR TITLE
docs: add note about archive timeline reset on upgrade

### DIFF
--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -48,6 +48,11 @@ upgrade procedure, refer to the [corresponding PR in Spilo](https://github.com/z
 When `major_version_upgrade_mode` is set to `manual` the operator will run
 the upgrade script for you after the manifest is updated and pods are rotated.
 
+A major version upgrade will reset the archive timeline to 1. If you are archiving
+to cloud storage you will need to manually remove basebackups and WAL segments from
+pre-upgrade timelines so Postgres does not try to restore from these seemingly-later
+timelines.
+
 ## CRD Validation
 
 [CustomResourceDefinitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions)


### PR DESCRIPTION
For example, a Postgres 12 cluster with backups saved for 7 days may have timelines 5-8. Upon major version upgrade, the timeline is reset to 1. After a few days there may now be timelines 1-4 (PG 13) and 5-8 (PG 12) in cloud storage.  A recovery attempt without a specific timeline set via `recovery_target_timeline` will fail as the PG 12 timeline 5 does not follow the PG 13 timeline 4.