### PR TITLE
Support for readOnlyRootFilesystem and not setting requests/limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ _cgo_export.*
 
 _testmain.go
 
+*.swp
 *.exe
 *.test
 *.prof

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -353,6 +353,10 @@ configuration they are grouped under the `kubernetes` key.
   that should be assigned to the Postgres pods. The priority class itself must
   be defined in advance. Default is empty (use the default priority class).
 
+  * **read_only_root_filesystem**
+  boolean parameter controlling whether containers should use [readOnlyRootFilesystem](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#volumes-and-file-systems).
+  `kubectl explain statefulset.spec.template.spec.securityContext.readOnlyRootFilesystem`
+
 * **spilo_runasuser**
   sets the user ID which should be used in the container to run the process.
   This must be set to run the container without root. By default the container

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -299,6 +299,8 @@ spec:
                             type: boolean
                           defaultRoles:
                             type: boolean
+              readOnlyRootFilesystem:
+                type: boolean
               replicaLoadBalancer:  # deprecated
                 type: boolean
               resources:

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -53,27 +53,28 @@ type PostgresSpec struct {
 	// load balancers' source ranges are the same for master and replica services
 	AllowedSourceRanges []string `json:"allowedSourceRanges"`
 
-	NumberOfInstances     int32                       `json:"numberOfInstances"`
-	Users                 map[string]UserFlags        `json:"users,omitempty"`
-	MaintenanceWindows    []MaintenanceWindow         `json:"maintenanceWindows,omitempty"`
-	Clone                 *CloneDescription           `json:"clone,omitempty"`
-	ClusterName           string                      `json:"-"`
-	Databases             map[string]string           `json:"databases,omitempty"`
-	PreparedDatabases     map[string]PreparedDatabase `json:"preparedDatabases,omitempty"`
-	SchedulerName         *string                     `json:"schedulerName,omitempty"`
-	NodeAffinity          *v1.NodeAffinity            `json:"nodeAffinity,omitempty"`
-	Tolerations           []v1.Toleration             `json:"tolerations,omitempty"`
-	Sidecars              []Sidecar                   `json:"sidecars,omitempty"`
-	InitContainers        []v1.Container              `json:"initContainers,omitempty"`
-	PodPriorityClassName  string                      `json:"podPriorityClassName,omitempty"`
-	ShmVolume             *bool                       `json:"enableShmVolume,omitempty"`
-	EnableLogicalBackup   bool                        `json:"enableLogicalBackup,omitempty"`
-	LogicalBackupSchedule string                      `json:"logicalBackupSchedule,omitempty"`
-	StandbyCluster        *StandbyDescription         `json:"standby,omitempty"`
-	PodAnnotations        map[string]string           `json:"podAnnotations,omitempty"`
-	ServiceAnnotations    map[string]string           `json:"serviceAnnotations,omitempty"`
-	TLS                   *TLSDescription             `json:"tls,omitempty"`
-	AdditionalVolumes     []AdditionalVolume          `json:"additionalVolumes,omitempty"`
+	NumberOfInstances      int32                       `json:"numberOfInstances"`
+	Users                  map[string]UserFlags        `json:"users,omitempty"`
+	MaintenanceWindows     []MaintenanceWindow         `json:"maintenanceWindows,omitempty"`
+	Clone                  *CloneDescription           `json:"clone,omitempty"`
+	ClusterName            string                      `json:"-"`
+	Databases              map[string]string           `json:"databases,omitempty"`
+	PreparedDatabases      map[string]PreparedDatabase `json:"preparedDatabases,omitempty"`
+	SchedulerName          *string                     `json:"schedulerName,omitempty"`
+	NodeAffinity           *v1.NodeAffinity            `json:"nodeAffinity,omitempty"`
+	Tolerations            []v1.Toleration             `json:"tolerations,omitempty"`
+	Sidecars               []Sidecar                   `json:"sidecars,omitempty"`
+	InitContainers         []v1.Container              `json:"initContainers,omitempty"`
+	ReadOnlyRootFilesystem *bool                       `json:"readOnlyRootFilesystem,omitempty"`
+	PodPriorityClassName   string                      `json:"podPriorityClassName,omitempty"`
+	ShmVolume              *bool                       `json:"enableShmVolume,omitempty"`
+	EnableLogicalBackup    bool                        `json:"enableLogicalBackup,omitempty"`
+	LogicalBackupSchedule  string                      `json:"logicalBackupSchedule,omitempty"`
+	StandbyCluster         *StandbyDescription         `json:"standby,omitempty"`
+	PodAnnotations         map[string]string           `json:"podAnnotations,omitempty"`
+	ServiceAnnotations     map[string]string           `json:"serviceAnnotations,omitempty"`
+	TLS                    *TLSDescription             `json:"tls,omitempty"`
+	AdditionalVolumes      []AdditionalVolume          `json:"additionalVolumes,omitempty"`
 
 	// deprecated json tags
 	InitContainersOld       []v1.Container `json:"init_containers,omitempty"`

--- a/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
@@ -686,6 +686,11 @@ func (in *PostgresSpec) DeepCopyInto(out *PostgresSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ReadOnlyRootFilesystem != nil {
+		in, out := &in.ReadOnlyRootFilesystem, &out.ReadOnlyRootFilesystem
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ShmVolume != nil {
 		in, out := &in.ShmVolume, &out.ShmVolume
 		*out = new(bool)

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -441,6 +441,7 @@ func generateContainer(
 	resourceRequirements *v1.ResourceRequirements,
 	envVars []v1.EnvVar,
 	volumeMounts []v1.VolumeMount,
+	readOnlyRootFilesystem *bool,
 	privilegedMode bool,
 	privilegeEscalationMode *bool,
 	additionalPodCapabilities *v1.Capabilities,
@@ -469,7 +470,7 @@ func generateContainer(
 		SecurityContext: &v1.SecurityContext{
 			AllowPrivilegeEscalation: privilegeEscalationMode,
 			Privileged:               &privilegedMode,
-			ReadOnlyRootFilesystem:   util.False(),
+			ReadOnlyRootFilesystem:   readOnlyRootFilesystem,
 			Capabilities:             additionalPodCapabilities,
 		},
 	}
@@ -931,7 +932,6 @@ func extractPgVersionFromBinPath(binPath string, template string) (string, error
 }
 
 func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.StatefulSet, error) {
-
 	var (
 		err                 error
 		initContainers      []v1.Container
@@ -945,7 +945,6 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 	if c.OpConfig.SetMemoryRequestToLimit {
 
 		// controller adjusts the default memory request at operator startup
-
 		request := spec.Resources.ResourceRequests.Memory
 		if request == "" {
 			request = c.OpConfig.Resources.DefaultMemoryRequest
@@ -963,7 +962,6 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 		if isSmaller {
 			c.logger.Warningf("The memory request of %v for the Postgres container is increased to match the memory limit of %v.", request, limit)
 			spec.Resources.ResourceRequests.Memory = limit
-
 		}
 
 		// controller adjusts the Scalyr sidecar request at operator startup
@@ -992,7 +990,6 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 				sidecar.Resources.ResourceRequests.Memory = sidecar.Resources.ResourceLimits.Memory
 			}
 		}
-
 	}
 
 	defaultResources := c.makeDefaultResources()
@@ -1162,6 +1159,7 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 		resourceRequirements,
 		deduplicateEnvVars(spiloEnvVars, c.containerName(), c.logger),
 		volumeMounts,
+		c.OpConfig.Resources.ReadOnlyRootFilesystem,
 		c.OpConfig.Resources.SpiloPrivileged,
 		c.OpConfig.Resources.SpiloAllowPrivilegeEscalation,
 		generateCapabilities(c.OpConfig.AdditionalPodCapabilities),
@@ -1916,6 +1914,7 @@ func (c *Cluster) generateLogicalBackupJob() (*batchv1beta1.CronJob, error) {
 		resourceRequirements,
 		envVars,
 		[]v1.VolumeMount{},
+		c.OpConfig.ReadOnlyRootFilesystem,
 		c.OpConfig.SpiloPrivileged, // use same value as for normal DB pods
 		c.OpConfig.SpiloAllowPrivilegeEscalation,
 		nil,

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -160,32 +160,38 @@ func generateResourceRequirements(resources acidv1.Resources, defaultResources a
 
 func fillResourceList(spec acidv1.ResourceDescription, defaults acidv1.ResourceDescription) (v1.ResourceList, error) {
 	var err error
-	requests := v1.ResourceList{}
+	resources := v1.ResourceList{}
 
 	if spec.CPU != "" {
-		requests[v1.ResourceCPU], err = resource.ParseQuantity(spec.CPU)
-		if err != nil {
-			return nil, fmt.Errorf("could not parse CPU quantity: %v", err)
+		if spec.CPU != "0" {
+			resources[v1.ResourceCPU], err = resource.ParseQuantity(spec.CPU)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse CPU quantity: %v", err)
+			}
 		}
 	} else {
-		requests[v1.ResourceCPU], err = resource.ParseQuantity(defaults.CPU)
-		if err != nil {
-			return nil, fmt.Errorf("could not parse default CPU quantity: %v", err)
+		if spec.CPU != "0" {
+			resources[v1.ResourceCPU], err = resource.ParseQuantity(defaults.CPU)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse default CPU quantity: %v", err)
+			}
 		}
 	}
 	if spec.Memory != "" {
-		requests[v1.ResourceMemory], err = resource.ParseQuantity(spec.Memory)
-		if err != nil {
-			return nil, fmt.Errorf("could not parse memory quantity: %v", err)
+		if spec.Memory != "0" {
+			resources[v1.ResourceMemory], err = resource.ParseQuantity(spec.Memory)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse memory quantity: %v", err)
+			}
 		}
 	} else {
-		requests[v1.ResourceMemory], err = resource.ParseQuantity(defaults.Memory)
+		resources[v1.ResourceMemory], err = resource.ParseQuantity(defaults.Memory)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse default memory quantity: %v", err)
 		}
 	}
 
-	return requests, nil
+	return resources, nil
 }
 
 func generateSpiloJSONConfiguration(pg *acidv1.PostgresqlParam, patroni *acidv1.Patroni, pamRoleName string, EnablePgVersionEnvVar bool, logger *logrus.Entry) (string, error) {

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -32,6 +32,7 @@ type Resources struct {
 	SpiloRunAsGroup               *int64              `name:"spilo_runasgroup,omitempty"`
 	SpiloFSGroup                  *int64              `name:"spilo_fsgroup"`
 	PodPriorityClassName          string              `name:"pod_priority_class_name"`
+	ReadOnlyRootFilesystem        *bool               `name:"read_only_root_filesystem" default:"false"`
 	ClusterDomain                 string              `name:"cluster_domain" default:"cluster.local"`
 	SpiloPrivileged               bool                `name:"spilo_privileged" default:"false"`
 	SpiloAllowPrivilegeEscalation *bool               `name:"spilo_allow_privilege_escalation" default:"true"`

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -338,5 +338,9 @@ func IsSmallerQuantity(requestStr, limitStr string) (bool, error) {
 		return false, fmt.Errorf("could not parse limit %v : %v", limitStr, err2)
 	}
 
+	if limitStr == "0" { // Zero disables setting a limit
+		return false, nil
+	}
+
 	return request.Cmp(limit) == -1, nil
 }


### PR DESCRIPTION
#1371 fell through but I still had some improvements to contribute that i've rebuilt: readOnlyRootFilesystem support (best security practice where doable) and the ability to not set resource requests/limits of containers/sidecars.