### PR TITLE
Mount additional volumes to 'postgres' container when 'targetContains` is an empty list

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1455,7 +1455,7 @@ func (c *Cluster) addAdditionalVolumes(podSpec *v1.PodSpec,
 			continue
 		}
 
-		if v.TargetContainers == nil {
+		if v.TargetContainers == nil || len(v.TargetContainers) == 0 {
 			spiloContainer := podSpec.Containers[0]
 			additionalVolumes[i].TargetContainers = []string{spiloContainer.Name}
 		}

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1455,7 +1455,7 @@ func (c *Cluster) addAdditionalVolumes(podSpec *v1.PodSpec,
 			continue
 		}
 
-		if v.TargetContainers == nil || len(v.TargetContainers) == 0 {
+		if len(v.TargetContainers) == 0 {
 			spiloContainer := podSpec.Containers[0]
 			additionalVolumes[i].TargetContainers = []string{spiloContainer.Name}
 		}


### PR DESCRIPTION
Fix #1459 