### PR TITLE
fix helm's postgres-operator/values.yaml

### DIFF
--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -21,15 +21,15 @@ enableJsonLogging: false
 # general configuration parameters
 configGeneral:
   # choose if deployment creates/updates CRDs with OpenAPIV3Validation
-  enable_crd_validation: "true"
+  enable_crd_validation: true
   # update only the statefulsets without immediately doing the rolling update
-  enable_lazy_spilo_upgrade: "false"
+  enable_lazy_spilo_upgrade: false
   # set the PGVERSION env var instead of providing the version via postgresql.bin_dir in SPILO_CONFIGURATION
-  enable_pgversion_env_var: "true"
+  enable_pgversion_env_var: true
   # start any new database pod without limitations on shm memory
-  enable_shm_volume: "true"
+  enable_shm_volume: true
   # enables backwards compatible path between Spilo 12 and Spilo 13 images
-  enable_spilo_wal_path_compat: "false"
+  enable_spilo_wal_path_compat: false
   # etcd connection string for Patroni. Empty uses K8s-native DCS.
   etcd_host: ""
   # Select if setup uses endpoints (default), or configmaps to manage leader (DCS=k8s)
@@ -37,9 +37,9 @@ configGeneral:
   # Spilo docker image
   docker_image: registry.opensource.zalan.do/acid/spilo-13:2.0-p6
   # min number of instances in Postgres cluster. -1 = no limit
-  min_instances: "-1"
+  min_instances: -1
   # max number of instances in Postgres cluster. -1 = no limit
-  max_instances: "-1"
+  max_instances: -1
   # period between consecutive repair requests
   repair_period: 5m
   # period between consecutive sync requests
@@ -51,7 +51,7 @@ configGeneral:
   # sidecar_docker_images: ""
 
   # number of routines the operator spawns to process requests concurrently
-  workers: "8"
+  workers: 8
 
 # parameters describing Postgres users
 configUsers:
@@ -75,7 +75,8 @@ configKubernetes:
   # default DNS domain of K8s cluster where operator is running
   cluster_domain: cluster.local
   # additional labels assigned to the cluster objects
-  cluster_labels: application:spilo
+  cluster_labels:
+    application: spilo
   # label assigned to Kubernetes objects created by the operator
   cluster_name_label: cluster-name
   # annotations attached to each database pod
@@ -91,13 +92,13 @@ configKubernetes:
   # downscaler_annotations: "deployment-time,downscaler/*"
 
   # enables initContainers to run actions before Spilo is started
-  enable_init_containers: "true"
+  enable_init_containers: true
   # toggles pod anti affinity on the Postgres pods
-  enable_pod_antiaffinity: "false"
+  enable_pod_antiaffinity: false
   # toggles PDB to set to MinAvailabe 0 or 1
-  enable_pod_disruption_budget: "true"
+  enable_pod_disruption_budget: true
   # enables sidecar containers to run alongside Spilo in the same pod
-  enable_sidecars: "true"
+  enable_sidecars: true
   # namespaced name of the secret containing infrastructure roles names and passwords
   # infrastructure_roles_secret_name: postgresql-infrastructure-roles
 
@@ -146,10 +147,10 @@ configKubernetes:
   # spilo_fsgroup: "103"
 
   # whether the Spilo container should run in privileged mode
-  spilo_privileged: "false"
+  spilo_privileged: false
   # whether the Spilo container should run with additional permissions other than parent.
   # required by cron which needs setuid
-  spilo_allow_privilege_escalation: "true"
+  spilo_allow_privilege_escalation: true
   # storage resize strategy, available options are: ebs, pvc, off
   storage_resize_mode: pvc
   # operator watches for postgres objects in the given namespace
@@ -193,9 +194,9 @@ configLoadBalancer:
   # custom_service_annotations: "keyx:valuez,keya:valuea"
 
   # toggles service type load balancer pointing to the master pod of the cluster
-  enable_master_load_balancer: "false"
+  enable_master_load_balancer: false
   # toggles service type load balancer pointing to the replica pod of the cluster
-  enable_replica_load_balancer: "false"
+  enable_replica_load_balancer: false
   # define external traffic policy for the load balancer
   external_traffic_policy: "Cluster"
   # defines the DNS name string template for the master load balancer cluster
@@ -206,18 +207,18 @@ configLoadBalancer:
 # options to aid debugging of the operator itself
 configDebug:
   # toggles verbose debug logs from the operator
-  debug_logging: "true"
+  debug_logging: true
   # toggles operator functionality that require access to the postgres database
-  enable_database_access: "true"
+  enable_database_access: true
 
 # parameters affecting logging and REST API listener
 configLoggingRestApi:
   # REST API listener listens to this port
-  api_port: "8080"
+  api_port: 8080
   # number of entries in the cluster history ring buffer
-  cluster_history_entries: "1000"
+  cluster_history_entries: 1000
   # number of lines in the ring buffer used to store cluster logs
-  ring_log_lines: "100"
+  ring_log_lines: 100
 
 # configure interaction with non-Kubernetes objects from AWS or GCP
 configAwsOrGcp:
@@ -231,7 +232,7 @@ configAwsOrGcp:
   aws_region: eu-central-1
 
   # enable automatic migration on AWS from gp2 to gp3 volumes
-  enable_ebs_gp3_migration: "false"
+  enable_ebs_gp3_migration: false
   # defines maximum volume size in GB until which auto migration happens
   # enable_ebs_gp3_migration_max_size: "1000"
 
@@ -283,7 +284,7 @@ configTeamsApi:
   # enable_admin_role_for_users: "true"
 
   # operator watches for PostgresTeam CRs to assign additional teams and members to clusters
-  enable_postgres_team_crd: "false"
+  enable_postgres_team_crd: false
   # toogle to create additional superuser teams from PostgresTeam CRs
   # enable_postgres_team_crd_superusers: "false"
 
@@ -291,7 +292,7 @@ configTeamsApi:
   # enable_team_superuser: "false"
 
   # toggles usage of the Teams API by the operator
-  enable_teams_api: "false"
+  enable_teams_api: false
   # should contain a URL to use for authentication (username and token)
   # pam_configuration: https://info.example.com/oauth2/tokeninfo?access_token= uid realm=/employees
 
@@ -322,11 +323,11 @@ configConnectionPooler:
   # docker image
   connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-16"
   # max db connections the pooler should hold
-  connection_pooler_max_db_connections: "60"
+  connection_pooler_max_db_connections: 60
   # default pooling mode
   connection_pooler_mode: "transaction"
   # number of pooler instances
-  connection_pooler_number_of_instances: "2"
+  connection_pooler_number_of_instances: 2
   # default resources
   connection_pooler_default_cpu_request: 500m
   connection_pooler_default_memory_request: 100Mi


### PR DESCRIPTION
the data types in values.yaml are "wrong". if you just perform an "helm install" then the installation fails with a LOT of error messages about wrong data types. 

for example configGeneral.enable_crd_validation is '"true"' (i.e. a string value) in the values.yaml file, but should be just 'true' (a yaml boolean value).

weirdly, configPostgresPodResources.default_cpu_limit is expected to be string although a numerical value (wrong as well?), just like configConnectionPooler.connection_pooler_default_cpu_limit.

this commit fixes it. AFTER applying you can just do this:

    helm upgrade -i pg-operator zalando/pg-operator

TESTED WITH 1.6.2.

see also:
  - https://git.io/J3z4S