### PR TITLE
Introduce "ignored_service_annotations" parameter

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -344,6 +344,10 @@ spec:
                     type: object
                     additionalProperties:
                       type: string
+                  ignored_service_annotations:
+                    type: array
+                    items:
+                      type: string
                   db_hosted_zone:
                     type: string
                     default: "db.example.com"

--- a/charts/postgres-operator/values-crd.yaml
+++ b/charts/postgres-operator/values-crd.yaml
@@ -202,6 +202,11 @@ configLoadBalancer:
   #   keyx: valuez
   #   keya: valuea
 
+  # annotations to be ignored during sync to not cause restarts
+  # ignored_service_annotations:
+  #   - foo
+  #   - bar
+
   # toggles service type load balancer pointing to the master pod of the cluster
   enable_master_load_balancer: false
   # toggles service type load balancer pointing to the replica pod of the cluster

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -192,6 +192,11 @@ configLoadBalancer:
   # annotations to apply to service when load balancing is enabled
   # custom_service_annotations: "keyx:valuez,keya:valuea"
 
+  # annotations to be ignored during sync to not cause restarts
+  # ignored_service_annotations:
+  #   - foo
+  #   - bar
+
   # toggles service type load balancer pointing to the master pod of the cluster
   enable_master_load_balancer: "false"
   # toggles service type load balancer pointing to the replica pod of the cluster

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -509,6 +509,11 @@ In the CRD-based configuration they are grouped under the `load_balancer` key.
 * **external_traffic_policy** defines external traffic policy for load
   balancers. Allowed values are `Cluster` (default) and `Local`.
 
+* **ignored_service_annotations**
+  Defines ignored service annotations during sync. Helpful when another
+  operator or k8s element adds annotations to services, which would cause a
+  service resync seemingly without reason.
+
 * **master_dns_name_format** defines the DNS name string template for the
   master load balancer cluster.  The default is
   `{cluster}.{team}.{hostedzone}`, where `{cluster}` is replaced by the cluster

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -23,6 +23,7 @@ data:
   # connection_pooler_schema: "pooler"
   # connection_pooler_user: "pooler"
   # custom_service_annotations: "keyx:valuez,keya:valuea"
+  # ignored_service_annotations: "foo,bar"
   # custom_pod_annotations: "keya:valuea,keyb:valueb"
   db_hosted_zone: db.example.com
   debug_logging: "true"

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -105,6 +105,9 @@ configuration:
     # custom_service_annotations:
     #   keyx: valuex
     #   keyy: valuey
+    # ignored_service_annotations:
+    #   - foo
+    #   - bar
     # db_hosted_zone: ""
     enable_master_load_balancer: false
     enable_replica_load_balancer: false

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -119,6 +119,7 @@ type LoadBalancerConfiguration struct {
 	EnableMasterLoadBalancer  bool                  `json:"enable_master_load_balancer,omitempty"`
 	EnableReplicaLoadBalancer bool                  `json:"enable_replica_load_balancer,omitempty"`
 	CustomServiceAnnotations  map[string]string     `json:"custom_service_annotations,omitempty"`
+	IgnoredServiceAnnotations []string              `json:"ignored_service_annotations,omitempty"`
 	MasterDNSNameFormat       config.StringTemplate `json:"master_dns_name_format,omitempty"`
 	ReplicaDNSNameFormat      config.StringTemplate `json:"replica_dns_name_format,omitempty"`
 	ExternalTrafficPolicy     string                `json:"external_traffic_policy" default:"Cluster"`

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1684,6 +1684,10 @@ func (c *Cluster) generateServiceAnnotations(role PostgresRole, spec *acidv1.Pos
 		}
 	}
 
+	if len(c.OpConfig.IgnoredServiceAnnotations) > 0 {
+		annotations["ignore_service_annotations"] = strings.Join(c.OpConfig.IgnoredServiceAnnotations, ",")
+	}
+
 	if c.shouldCreateLoadBalancerForService(role, spec) {
 		var dnsName string
 		if role == Master {

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -134,6 +134,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.EnableMasterLoadBalancer = fromCRD.LoadBalancer.EnableMasterLoadBalancer
 	result.EnableReplicaLoadBalancer = fromCRD.LoadBalancer.EnableReplicaLoadBalancer
 	result.CustomServiceAnnotations = fromCRD.LoadBalancer.CustomServiceAnnotations
+	result.IgnoredServiceAnnotations = fromCRD.LoadBalancer.IgnoredServiceAnnotations
 	result.MasterDNSNameFormat = fromCRD.LoadBalancer.MasterDNSNameFormat
 	result.ReplicaDNSNameFormat = fromCRD.LoadBalancer.ReplicaDNSNameFormat
 	result.ExternalTrafficPolicy = util.Coalesce(fromCRD.LoadBalancer.ExternalTrafficPolicy, "Cluster")

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -182,6 +182,7 @@ type Config struct {
 	EnableMasterLoadBalancer               bool              `name:"enable_master_load_balancer" default:"true"`
 	EnableReplicaLoadBalancer              bool              `name:"enable_replica_load_balancer" default:"false"`
 	CustomServiceAnnotations               map[string]string `name:"custom_service_annotations"`
+	IgnoredServiceAnnotations              []string          `name:"ignored_service_annotations"`
 	CustomPodAnnotations                   map[string]string `name:"custom_pod_annotations"`
 	EnablePodAntiAffinity                  bool              `name:"enable_pod_antiaffinity" default:"false"`
 	PodAntiAffinityTopologyKey             string            `name:"pod_antiaffinity_topology_key" default:"kubernetes.io/hostname"`

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
 	b64 "encoding/base64"
 	"encoding/json"
@@ -217,8 +218,13 @@ func SameService(cur, new *v1.Service) (match bool, reason string) {
 
 	match = true
 
+	ignoredServiceAnnotations := new.Annotations["ignore_service_annotations"]
 	reasonPrefix := "new service's annotations does not match the current one:"
 	for ann := range cur.Annotations {
+		if strings.Contains(ignoredServiceAnnotations, ann) {
+			continue
+		}
+
 		if _, ok := new.Annotations[ann]; !ok {
 			match = false
 			if len(reason) == 0 {

--- a/pkg/util/k8sutil/k8sutil_test.go
+++ b/pkg/util/k8sutil/k8sutil_test.go
@@ -288,6 +288,27 @@ func TestSameService(t *testing.T) {
 			// Test just the prefix to avoid flakiness and map sorting
 			reason: `new service's annotations does not match the current one: Added `,
 		},
+		{
+			about: "current service has annotations that should be ignored",
+			current: newsService(
+				map[string]string{
+					constants.ZalandoDNSNameAnnotation: "clstr.acid.zalan.do",
+					constants.ElbTimeoutAnnotationName: constants.ElbTimeoutAnnotationValue,
+					"ignore_service_annotations":       "foo,ignore,bar",
+					"ignore":                           "me",
+				},
+				v1.ServiceTypeClusterIP,
+				[]string{"128.141.0.0/16", "137.138.0.0/16"}),
+			new: newsService(
+				map[string]string{
+					constants.ZalandoDNSNameAnnotation: "clstr.acid.zalan.do",
+					constants.ElbTimeoutAnnotationName: constants.ElbTimeoutAnnotationValue,
+					"ignore_service_annotations":       "foo,ignore,bar",
+				},
+				v1.ServiceTypeClusterIP,
+				[]string{"128.141.0.0/16", "137.138.0.0/16"}),
+			match: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.about, func(t *testing.T) {


### PR DESCRIPTION
This PR attempts to fix #1478 by introducing a parameter to ignore specific service annotations.

Rationale: on, e.g., Rancher, additional annotations are added to the LB services. They seem to cause a connection drop on service syncs. These annotations are added again after removal by the operator, enforcing recurring but unnecessary syncs. A solution to prevent this is to ignore these if they are known.