### PR TITLE
get postgres container by name, not index

### DIFF
--- a/pkg/cluster/exec.go
+++ b/pkg/cluster/exec.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 
 	"github.com/zalando/postgres-operator/pkg/spec"
-	"github.com/zalando/postgres-operator/pkg/util/constants"
 )
 
 //ExecCommand executes arbitrary command inside the pod
@@ -32,14 +31,14 @@ func (c *Cluster) ExecCommand(podName *spec.NamespacedName, command ...string) (
 	// iterate through all containers looking for the one running PostgreSQL.
 	targetContainer := -1
 	for i, cr := range pod.Spec.Containers {
-		if cr.Name == constants.PostgresContainerName {
+		if cr.Name == c.containerName() {
 			targetContainer = i
 			break
 		}
 	}
 
 	if targetContainer < 0 {
-		return "", fmt.Errorf("could not find %s container to exec to", constants.PostgresContainerName)
+		return "", fmt.Errorf("could not find %s container to exec to", c.containerName())
 	}
 
 	req := c.KubeClient.RESTClient.Post().

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -413,6 +413,7 @@ func TestShmVolume(t *testing.T) {
 				Volumes: []v1.Volume{},
 				Containers: []v1.Container{
 					{
+						Name:         "postgres",
 						VolumeMounts: []v1.VolumeMount{},
 					},
 				},
@@ -425,6 +426,7 @@ func TestShmVolume(t *testing.T) {
 				Volumes: []v1.Volume{{}},
 				Containers: []v1.Container{
 					{
+						Name: "postgres",
 						VolumeMounts: []v1.VolumeMount{
 							{},
 						},

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -357,8 +357,8 @@ func (c *Cluster) syncStatefulSet() error {
 			// and
 			//  (b) some of the pods were not restarted when the lazy update was still in place
 			for _, pod := range pods {
-				effectivePodImage := pod.Spec.Containers[0].Image
-				stsImage := desiredSts.Spec.Template.Spec.Containers[0].Image
+				effectivePodImage := c.getPostgresContainer(&pod.Spec).Image
+				stsImage := c.getPostgresContainer(&desiredSts.Spec.Template.Spec).Image
 
 				if stsImage != effectivePodImage {
 					if err = c.markRollingUpdateFlagForPod(&pod, "pod not yet restarted due to lazy update"); err != nil {

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -227,6 +227,16 @@ func (c *Cluster) logServiceChanges(role PostgresRole, old, new *v1.Service, isU
 	}
 }
 
+func (c *Cluster) getPostgresContainer(podSpec *v1.PodSpec) v1.Container {
+	var pgContainer v1.Container
+	for _, container := range podSpec.Containers {
+		if container.Name == constants.PostgresContainerName {
+			pgContainer = container
+		}
+	}
+	return pgContainer
+}
+
 func (c *Cluster) getTeamMembers(teamID string) ([]string, error) {
 
 	if teamID == "" {

--- a/pkg/util/constants/kubernetes.go
+++ b/pkg/util/constants/kubernetes.go
@@ -5,7 +5,6 @@ import "time"
 // General kubernetes-related constants
 const (
 	PostgresContainerName = "postgres"
-	PostgresContainerIdx  = 0
 	K8sAPIPath            = "/apis"
 
 	QueueResyncPeriodPod  = 5 * time.Minute


### PR DESCRIPTION
In some code parts we assume that containers[0] is the postgres container. #1381 has shown that this might not always be the case. This PR tries to eliminate every code with that assumption.