### PR TITLE
pick first container if postgres is not found

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -462,7 +462,7 @@ func (c *Cluster) compareStatefulSetWith(statefulSet *appsv1.StatefulSet) *compa
 
 	if len(c.Statefulset.Spec.Template.Spec.Volumes) != len(statefulSet.Spec.Template.Spec.Volumes) {
 		needsReplace = true
-		reasons = append(reasons, fmt.Sprintf("new statefulset's Volumes contains different number of volumes to the old one"))
+		reasons = append(reasons, "new statefulset's volumes contains different number of volumes to the old one")
 	}
 
 	// we assume any change in priority happens by rolling out a new priority class
@@ -476,7 +476,9 @@ func (c *Cluster) compareStatefulSetWith(statefulSet *appsv1.StatefulSet) *compa
 
 	// lazy Spilo update: modify the image in the statefulset itself but let its pods run with the old image
 	// until they are re-created for other reasons, for example node rotation
-	if c.OpConfig.EnableLazySpiloUpgrade && !reflect.DeepEqual(c.Statefulset.Spec.Template.Spec.Containers[0].Image, statefulSet.Spec.Template.Spec.Containers[0].Image) {
+	effectivePodImage := getPostgresContainer(&c.Statefulset.Spec.Template.Spec).Image
+	desiredImage := getPostgresContainer(&statefulSet.Spec.Template.Spec).Image
+	if c.OpConfig.EnableLazySpiloUpgrade && !reflect.DeepEqual(effectivePodImage, desiredImage) {
 		needsReplace = true
 		reasons = append(reasons, "lazy Spilo update: new statefulset's pod image does not match the current one")
 	}

--- a/pkg/cluster/exec.go
+++ b/pkg/cluster/exec.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 
 	"github.com/zalando/postgres-operator/pkg/spec"
+	"github.com/zalando/postgres-operator/pkg/util/constants"
 )
 
 //ExecCommand executes arbitrary command inside the pod
@@ -31,14 +32,14 @@ func (c *Cluster) ExecCommand(podName *spec.NamespacedName, command ...string) (
 	// iterate through all containers looking for the one running PostgreSQL.
 	targetContainer := -1
 	for i, cr := range pod.Spec.Containers {
-		if cr.Name == c.containerName() {
+		if cr.Name == constants.PostgresContainerName {
 			targetContainer = i
 			break
 		}
 	}
 
 	if targetContainer < 0 {
-		return "", fmt.Errorf("could not find %s container to exec to", c.containerName())
+		return "", fmt.Errorf("could not find %s container to exec to", constants.PostgresContainerName)
 	}
 
 	req := c.KubeClient.RESTClient.Post().

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -357,8 +357,8 @@ func (c *Cluster) syncStatefulSet() error {
 			// and
 			//  (b) some of the pods were not restarted when the lazy update was still in place
 			for _, pod := range pods {
-				effectivePodImage := c.getPostgresContainer(&pod.Spec).Image
-				stsImage := c.getPostgresContainer(&desiredSts.Spec.Template.Spec).Image
+				effectivePodImage := getPostgresContainer(&pod.Spec).Image
+				stsImage := getPostgresContainer(&desiredSts.Spec.Template.Spec).Image
 
 				if stsImage != effectivePodImage {
 					if err = c.markRollingUpdateFlagForPod(&pod, "pod not yet restarted due to lazy update"); err != nil {

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -227,12 +227,18 @@ func (c *Cluster) logServiceChanges(role PostgresRole, old, new *v1.Service, isU
 	}
 }
 
-func (c *Cluster) getPostgresContainer(podSpec *v1.PodSpec) v1.Container {
+func getPostgresContainer(podSpec *v1.PodSpec) v1.Container {
 	var pgContainer v1.Container
+
 	for _, container := range podSpec.Containers {
 		if container.Name == constants.PostgresContainerName {
 			pgContainer = container
 		}
+	}
+
+	// if no postgres container was found, take the first one in the podSpec
+	if reflect.DeepEqual(pgContainer, v1.Container{}) && len(podSpec.Containers) > 0 {
+		pgContainer = podSpec.Containers[0]
 	}
 	return pgContainer
 }

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -227,9 +227,7 @@ func (c *Cluster) logServiceChanges(role PostgresRole, old, new *v1.Service, isU
 	}
 }
 
-func getPostgresContainer(podSpec *v1.PodSpec) v1.Container {
-	var pgContainer v1.Container
-
+func getPostgresContainer(podSpec *v1.PodSpec) (pgContainer v1.Container) {
 	for _, container := range podSpec.Containers {
 		if container.Name == constants.PostgresContainerName {
 			pgContainer = container


### PR DESCRIPTION
with #1504 we stopped assuming the first container being the postgres container. Hower, to avoid breaking things, bring back the old behavior as a fallback. Plus, some more refactoring.