### PR TITLE
Allow configuration of gs_wall_path in for standby clusters

### DIFF
--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -374,10 +374,10 @@ spec:
                 type: integer
               standby:
                 type: object
-                required:
-                  - s3_wal_path
                 properties:
                   s3_wal_path:
+                    type: string
+                  gs_wal_path:
                     type: string
               teamId:
                 type: string

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -337,6 +337,11 @@ archive is supported.
 * **s3_wal_path**
   the url to S3 bucket containing the WAL archive of the remote primary.
   Required when the `standby` section is present.
+  Either this or gs_wal_path is required when the `standby` section is present.
+
+- **gs_wal_path**
+  the url to GCS bucket containing the WAL archive of the remote primary.
+  Either this or s3_wal_path is required when the `standby` section is present.
 
 ## Volume properties
 

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -370,10 +370,10 @@ spec:
                 type: integer
               standby:
                 type: object
-                required:
-                  - s3_wal_path
                 properties:
                   s3_wal_path:
+                    type: string
+                  gs_wal_path:
                     type: string
               teamId:
                 type: string

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -565,9 +565,11 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 					},
 					"standby": {
 						Type:     "object",
-						Required: []string{"s3_wal_path"},
 						Properties: map[string]apiextv1.JSONSchemaProps{
 							"s3_wal_path": {
+								Type: "string",
+							},
+							"gs_wal_path": {
 								Type: "string",
 							},
 						},

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -164,6 +164,7 @@ type Patroni struct {
 // StandbyDescription contains s3 wal path
 type StandbyDescription struct {
 	S3WalPath string `json:"s3_wal_path,omitempty"`
+	GSWalPath string `json:"gs_wal_path,omitempty"`
 }
 
 // TLSDescription specs TLS properties

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1033,8 +1033,8 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 	sort.Slice(customPodEnvVarsList,
 		func(i, j int) bool { return customPodEnvVarsList[i].Name < customPodEnvVarsList[j].Name })
 
-	if spec.StandbyCluster != nil && spec.StandbyCluster.S3WalPath == "" {
-		return nil, fmt.Errorf("s3_wal_path is empty for standby cluster")
+	if spec.StandbyCluster != nil && spec.StandbyCluster.S3WalPath == "" && spec.StandbyCluster.GSWalPath == "" {
+		return nil, fmt.Errorf("s3_wal_path and gs_wal_path are empty for standby cluster")
 	}
 
 	// backward compatible check for InitContainers
@@ -1841,17 +1841,29 @@ func (c *Cluster) generateCloneEnvironment(description *acidv1.CloneDescription)
 func (c *Cluster) generateStandbyEnvironment(description *acidv1.StandbyDescription) []v1.EnvVar {
 	result := make([]v1.EnvVar, 0)
 
-	if description.S3WalPath == "" {
+	if description.S3WalPath != "" {
+		// standby with S3, find out the bucket to setup standby
+		msg := "Standby from S3 bucket using custom parsed S3WalPath from the manifest %s "
+		c.logger.Infof(msg, description.S3WalPath)
+
+		result = append(result, v1.EnvVar{
+			Name:  "STANDBY_WALE_S3_PREFIX",
+			Value: description.S3WalPath,
+		})
+
+	} else if description.GSWalPath != "" {
+		// standby with GS, find out the bucket to setup standby
+		msg := "Standby from GS bucket using custom parsed GSWalPath from the manifest %s "
+		c.logger.Infof(msg, description.GSWalPath)
+
+		result = append(result, v1.EnvVar{
+			Name:  "STANDBY_WALE_GS_PREFIX",
+			Value: description.GSWalPath,
+		})
+
+	} else {
 		return nil
 	}
-	// standby with S3, find out the bucket to setup standby
-	msg := "Standby from S3 bucket using custom parsed S3WalPath from the manifest %s "
-	c.logger.Infof(msg, description.S3WalPath)
-
-	result = append(result, v1.EnvVar{
-		Name:  "STANDBY_WALE_S3_PREFIX",
-		Value: description.S3WalPath,
-	})
 
 	result = append(result, v1.EnvVar{Name: "STANDBY_METHOD", Value: "STANDBY_WITH_WALE"})
 	result = append(result, v1.EnvVar{Name: "STANDBY_WAL_BUCKET_SCOPE_PREFIX", Value: ""})


### PR DESCRIPTION
Hello,

This PR is essentially the same as #1058, but rebased on current master.
I've been using a version of the operator with these modifications for some time and have had no issues.
These changes allow the gs_wal_path value to  be passed along to wale, which is already able to make use of it.