### PR TITLE
Add support for manually setting load balancer IPs

### DIFF
--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -314,6 +314,8 @@ spec:
                                     type: array
                                     items:
                                       type: string
+              masterLoadBalancerIP:
+                type: string
               numberOfInstances:
                 type: integer
                 minimum: 0
@@ -401,6 +403,8 @@ spec:
               replicaLoadBalancer:
                 type: boolean
                 description: deprecated
+              replicaLoadBalancerIP:
+                type: string
               resources:
                 type: object
                 properties:

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -102,6 +102,16 @@ These parameters are grouped directly under  the `spec` key in the manifest.
   `enable_replica_load_balancer` parameter) to define whether to enable the
   load balancer pointing to the Postgres standby instances. Optional.
 
+* **masterLoadBalancerIP**
+  specify the IP address to be used on the load balancer pointing to
+  the Postgres primary. A dynamic address will be allocated if not
+  specified. Optional.
+
+* **replicaLoadBalancerIP**
+  specify the IP address to be used on the load balancer pointing to
+  the Postgres standby instances. A dynamic address will be allocated
+  if not specified. Optional.
+
 * **enableReplicaPoolerLoadBalancer**
   boolean flag to override the operator defaults (set by the
   `enable_replica_pooler_load_balancer` parameter) to define whether to enable

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -312,6 +312,8 @@ spec:
                                     type: array
                                     items:
                                       type: string
+              masterLoadBalancerIP:
+                type: string
               numberOfInstances:
                 type: integer
                 minimum: 0
@@ -399,6 +401,8 @@ spec:
               replicaLoadBalancer:
                 type: boolean
                 description: deprecated
+              replicaLoadBalancerIP:
+                type: string
               resources:
                 type: object
                 properties:

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -496,6 +496,9 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 							},
 						},
 					},
+					"masterLoadBalancerIP": {
+						Type: "string",
+					},
 					"numberOfInstances": {
 						Type:    "integer",
 						Minimum: &min0,
@@ -653,6 +656,9 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 					"replicaLoadBalancer": {
 						Type:        "boolean",
 						Description: "deprecated",
+					},
+					"replicaLoadBalancerIP": {
+						Type: "string",
 					},
 					"resources": {
 						Type: "object",

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -55,6 +55,10 @@ type PostgresSpec struct {
 	// load balancers' source ranges are the same for master and replica services
 	AllowedSourceRanges []string `json:"allowedSourceRanges"`
 
+	// static IP addresses for load balancers
+	MasterLoadBalancerIP  string `json:"masterLoadBalancerIP,omitempty"`
+	ReplicaLoadBalancerIP string `json:"replicaLoadBalancerIP,omitempty"`
+
 	Users                          map[string]UserFlags `json:"users,omitempty"`
 	UsersWithSecretRotation        []string             `json:"usersWithSecretRotation,omitempty"`
 	UsersWithInPlaceSecretRotation []string             `json:"usersWithInPlaceSecretRotation,omitempty"`

--- a/pkg/cluster/connection_pooler.go
+++ b/pkg/cluster/connection_pooler.go
@@ -396,7 +396,7 @@ func (c *Cluster) generateConnectionPoolerService(connectionPooler *ConnectionPo
 	}
 
 	if c.shouldCreateLoadBalancerForPoolerService(connectionPooler.Role, spec) {
-		c.configureLoadBalanceService(&serviceSpec, spec.AllowedSourceRanges)
+		c.configureLoadBalanceService(&serviceSpec, connectionPooler.Role, spec)
 	}
 
 	service := &v1.Service{


### PR DESCRIPTION
This adds the settings `masterLoadBalancerIP` and `replicaLoadBalancerIP` to the `postgresql` CRD. Setting either of these options will cause `loadBalancerIP` to be set on the generated service.

Solves #1285 