### PR TITLE
reorder e2e tests to follow alphabetical sorting

### DIFF
--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -223,6 +223,97 @@ spec:
                 items:
                   type: string
                   pattern: '^\ *((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\d):([0-5]?\d)|(2[0-3]|[01]?\d):([0-5]?\d))-((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\d):([0-5]?\d)|(2[0-3]|[01]?\d):([0-5]?\d))\ *$'
+              nodeAffinity:
+                type: object
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - weight
+                      - preference
+                      properties:
+                        preference:
+                          type: object
+                          properties:
+                            matchExpressions:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - key
+                                - operator
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
+                            matchFields:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - key
+                                - operator
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
+                        weight:
+                          format: int32
+                          type: integer
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    type: object
+                    required:
+                    - nodeSelectorTerms
+                    properties:
+                      nodeSelectorTerms:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            matchExpressions:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - key
+                                - operator
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
+                            matchFields:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - key
+                                - operator
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
               numberOfInstances:
                 type: integer
                 minimum: 0
@@ -396,97 +487,6 @@ spec:
                     type: string
                   caSecretName:
                     type: string
-              nodeAffinity:
-                type: object
-                properties:
-                  preferredDuringSchedulingIgnoredDuringExecution:
-                    type: array
-                    items:
-                      type: object
-                      required:
-                      - weight
-                      - preference
-                      properties:
-                        preference:
-                          type: object
-                          properties:
-                            matchExpressions:
-                              type: array
-                              items:
-                                type: object
-                                required:
-                                - key
-                                - operator
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    type: array
-                                    items:
-                                      type: string
-                            matchFields:
-                              type: array
-                              items:
-                                type: object
-                                required:
-                                - key
-                                - operator
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    type: array
-                                    items:
-                                      type: string
-                        weight:
-                          format: int32
-                          type: integer
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    type: object
-                    required:
-                    - nodeSelectorTerms
-                    properties:
-                      nodeSelectorTerms:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            matchExpressions:
-                              type: array
-                              items:
-                                type: object
-                                required:
-                                - key
-                                - operator
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    type: array
-                                    items:
-                                      type: string
-                            matchFields:
-                              type: array
-                              items:
-                                type: object
-                                required:
-                                - key
-                                - operator
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    type: array
-                                    items:
-                                      type: string
               tolerations:
                 type: array
                 items:

--- a/e2e/tests/k8s_api.py
+++ b/e2e/tests/k8s_api.py
@@ -469,12 +469,17 @@ class K8sBase:
     def wait_for_pod_failover(self, failover_targets, labels, namespace='default'):
         pod_phase = 'Failing over'
         new_pod_node = ''
+        pods_with_update_flag = self.count_pods_with_rolling_update_flag(labels, namespace)
 
         while (pod_phase != 'Running') or (new_pod_node not in failover_targets):
             pods = self.api.core_v1.list_namespaced_pod(namespace, label_selector=labels).items
             if pods:
                 new_pod_node = pods[0].spec.node_name
                 pod_phase = pods[0].status.phase
+            time.sleep(self.RETRY_TIMEOUT_SEC)
+
+        while pods_with_update_flag != 0:
+            pods_with_update_flag = self.count_pods_with_rolling_update_flag(labels, namespace)
             time.sleep(self.RETRY_TIMEOUT_SEC)
 
     def get_logical_backup_job(self, namespace='default'):

--- a/e2e/tests/k8s_api.py
+++ b/e2e/tests/k8s_api.py
@@ -156,6 +156,10 @@ class K8s:
         while not get_services():
             time.sleep(self.RETRY_TIMEOUT_SEC)
 
+    def count_pods_with_rolling_update_flag(self, labels, namespace='default'):
+        pods = self.api.core_v1.list_namespaced_pod(namespace, label_selector=labels).items
+        return len(list(filter(lambda x: "zalando-postgres-operator-rolling-update-required" in x.metadata.annotations, pods)))
+
     def count_pods_with_label(self, labels, namespace='default'):
         return len(self.api.core_v1.list_namespaced_pod(namespace, label_selector=labels).items)
 
@@ -189,12 +193,17 @@ class K8s:
     def wait_for_pod_failover(self, failover_targets, labels, namespace='default'):
         pod_phase = 'Failing over'
         new_pod_node = ''
+        pods_with_update_flag = self.count_pods_with_rolling_update_flag(labels, namespace)
 
         while (pod_phase != 'Running') or (new_pod_node not in failover_targets):
             pods = self.api.core_v1.list_namespaced_pod(namespace, label_selector=labels).items
             if pods:
                 new_pod_node = pods[0].spec.node_name
                 pod_phase = pods[0].status.phase
+            time.sleep(self.RETRY_TIMEOUT_SEC)
+        
+        while pods_with_update_flag != 0:
+            pods_with_update_flag = self.count_pods_with_rolling_update_flag(labels, namespace)
             time.sleep(self.RETRY_TIMEOUT_SEC)
 
     def wait_for_namespace_creation(self, namespace='default'):
@@ -422,6 +431,10 @@ class K8sBase:
 
         while not get_services():
             time.sleep(self.RETRY_TIMEOUT_SEC)
+
+    def count_pods_with_rolling_update_flag(self, labels, namespace='default'):
+        pods = self.api.core_v1.list_namespaced_pod(namespace, label_selector=labels).items
+        return len(list(filter(lambda x: "zalando-postgres-operator-rolling-update-required" in x.metadata.annotations, pods)))
 
     def count_pods_with_label(self, labels, namespace='default'):
         return len(self.api.core_v1.list_namespaced_pod(namespace, label_selector=labels).items)

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -1232,7 +1232,7 @@ class EndToEndTestCase(unittest.TestCase):
             k8s.wait_for_pod_start('spilo-role=replica,' + cluster_label)
 
             # status should again be "SyncFailed" but turn into "Running" on the next sync
-            time.sleep(10)
+            time.sleep(20)
             self.eventuallyEqual(lambda: k8s.pg_get_status(), "Running", "Expected running cluster after two syncs")
 
             # revert config changes

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -1233,6 +1233,7 @@ class EndToEndTestCase(unittest.TestCase):
 
             # status should again be "SyncFailed" but turn into "Running" on the next sync
             time.sleep(20)
+            print('Operator log: {}'.format(k8s.get_operator_log()))
             self.eventuallyEqual(lambda: k8s.pg_get_status(), "Running", "Expected running cluster after two syncs")
 
             # revert config changes

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -502,7 +502,7 @@ class EndToEndTestCase(unittest.TestCase):
         self.eventuallyEqual(lambda: k8s.count_services_with_label('application=db-connection-pooler,cluster-name=acid-minimal-cluster'),
                              0, "Pooler service not removed")
         self.eventuallyEqual(lambda: k8s.count_secrets_with_label('application=spilo,cluster-name=acid-minimal-cluster'),
-                             5, "Secrets not deleted")
+                             4, "Secrets not deleted")
 
         # Verify that all the databases have pooler schema installed.
         # Do this via psql, since otherwise we need to deal with

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -290,6 +290,7 @@ class EndToEndTestCase(unittest.TestCase):
                              "Operator does not get in sync")
 
     @timeout_decorator.timeout(TEST_TIMEOUT_SEC)
+    def test_cross_namespace_secrets(self):
         '''
             Test secrets in different namespace
         '''

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -1199,7 +1199,7 @@ class EndToEndTestCase(unittest.TestCase):
         patch_resync_config = {
             "data": {
                 "pod_label_wait_timeout": "2s",
-                "resync_period": "20s",
+                "resync_period": "1m",
             }
         }
 
@@ -1232,7 +1232,7 @@ class EndToEndTestCase(unittest.TestCase):
             k8s.wait_for_pod_start('spilo-role=replica,' + cluster_label)
 
             # status should again be "SyncFailed" but turn into "Running" on the next sync
-            time.sleep(20)
+            time.sleep(60)
             print('Operator log: {}'.format(k8s.get_operator_log()))
             self.eventuallyEqual(lambda: k8s.pg_get_status(), "Running", "Expected running cluster after two syncs")
 

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -219,6 +219,97 @@ spec:
                 items:
                   type: string
                   pattern: '^\ *((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\d):([0-5]?\d)|(2[0-3]|[01]?\d):([0-5]?\d))-((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\d):([0-5]?\d)|(2[0-3]|[01]?\d):([0-5]?\d))\ *$'
+              nodeAffinity:
+                type: object
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - weight
+                      - preference
+                      properties:
+                        preference:
+                          type: object
+                          properties:
+                            matchExpressions:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - key
+                                - operator
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
+                            matchFields:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - key
+                                - operator
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
+                        weight:
+                          format: int32
+                          type: integer
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    type: object
+                    required:
+                    - nodeSelectorTerms
+                    properties:
+                      nodeSelectorTerms:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            matchExpressions:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - key
+                                - operator
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
+                            matchFields:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - key
+                                - operator
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
               numberOfInstances:
                 type: integer
                 minimum: 0
@@ -392,97 +483,6 @@ spec:
                     type: string
                   caSecretName:
                     type: string
-              nodeAffinity:
-                type: object
-                properties:
-                  preferredDuringSchedulingIgnoredDuringExecution:
-                    type: array
-                    items:
-                      type: object
-                      required:
-                      - weight
-                      - preference
-                      properties:
-                        preference:
-                          type: object
-                          properties:
-                            matchExpressions:
-                              type: array
-                              items:
-                                type: object
-                                required:
-                                - key
-                                - operator
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    type: array
-                                    items:
-                                      type: string
-                            matchFields:
-                              type: array
-                              items:
-                                type: object
-                                required:
-                                - key
-                                - operator
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    type: array
-                                    items:
-                                      type: string
-                        weight:
-                          format: int32
-                          type: integer
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    type: object
-                    required:
-                    - nodeSelectorTerms
-                    properties:
-                      nodeSelectorTerms:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            matchExpressions:
-                              type: array
-                              items:
-                                type: object
-                                required:
-                                - key
-                                - operator
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    type: array
-                                    items:
-                                      type: string
-                            matchFields:
-                              type: array
-                              items:
-                                type: object
-                                required:
-                                - key
-                                - operator
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    type: array
-                                    items:
-                                      type: string
               tolerations:
                 type: array
                 items:

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -341,6 +341,91 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 							},
 						},
 					},
+					"nodeAffinity": {
+						Type: "object",
+						Properties: map[string]apiextv1.JSONSchemaProps{
+							"preferredDuringSchedulingIgnoredDuringExecution": {
+								Type: "array",
+								Items: &apiextv1.JSONSchemaPropsOrArray{
+									Schema: &apiextv1.JSONSchemaProps{
+										Type:     "object",
+										Required: []string{"preference", "weight"},
+										Properties: map[string]apiextv1.JSONSchemaProps{
+											"preference": {
+												Type: "object",
+												Properties: map[string]apiextv1.JSONSchemaProps{
+													"matchExpressions": {
+														Type: "array",
+														Items: &apiextv1.JSONSchemaPropsOrArray{
+															Schema: &apiextv1.JSONSchemaProps{
+																Type: "object",
+																AdditionalProperties: &apiextv1.JSONSchemaPropsOrBool{
+																	Allows: true,
+																},
+															},
+														},
+													},
+													"matchFields": {
+														Type: "array",
+														Items: &apiextv1.JSONSchemaPropsOrArray{
+															Schema: &apiextv1.JSONSchemaProps{
+																Type: "object",
+																AdditionalProperties: &apiextv1.JSONSchemaPropsOrBool{
+																	Allows: true,
+																},
+															},
+														},
+													},
+												},
+											},
+											"weight": {
+												Type:   "integer",
+												Format: "int32",
+											},
+										},
+									},
+								},
+							},
+							"requiredDuringSchedulingIgnoredDuringExecution": {
+								Type:     "object",
+								Required: []string{"nodeSelectorTerms"},
+								Properties: map[string]apiextv1.JSONSchemaProps{
+									"nodeSelectorTerms": {
+										Type: "array",
+										Items: &apiextv1.JSONSchemaPropsOrArray{
+											Schema: &apiextv1.JSONSchemaProps{
+												Type: "object",
+												Properties: map[string]apiextv1.JSONSchemaProps{
+													"matchExpressions": {
+														Type: "array",
+														Items: &apiextv1.JSONSchemaPropsOrArray{
+															Schema: &apiextv1.JSONSchemaProps{
+																Type: "object",
+																AdditionalProperties: &apiextv1.JSONSchemaPropsOrBool{
+																	Allows: true,
+																},
+															},
+														},
+													},
+													"matchFields": {
+														Type: "array",
+														Items: &apiextv1.JSONSchemaPropsOrArray{
+															Schema: &apiextv1.JSONSchemaProps{
+																Type: "object",
+																AdditionalProperties: &apiextv1.JSONSchemaPropsOrBool{
+																	Allows: true,
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 					"numberOfInstances": {
 						Type:    "integer",
 						Minimum: &min0,
@@ -593,91 +678,6 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 							},
 							"caSecretName": {
 								Type: "string",
-							},
-						},
-					},
-					"nodeAffinity": {
-						Type: "object",
-						Properties: map[string]apiextv1.JSONSchemaProps{
-							"preferredDuringSchedulingIgnoredDuringExecution": {
-								Type: "array",
-								Items: &apiextv1.JSONSchemaPropsOrArray{
-									Schema: &apiextv1.JSONSchemaProps{
-										Type:     "object",
-										Required: []string{"preference", "weight"},
-										Properties: map[string]apiextv1.JSONSchemaProps{
-											"preference": {
-												Type: "object",
-												Properties: map[string]apiextv1.JSONSchemaProps{
-													"matchExpressions": {
-														Type: "array",
-														Items: &apiextv1.JSONSchemaPropsOrArray{
-															Schema: &apiextv1.JSONSchemaProps{
-																Type: "object",
-																AdditionalProperties: &apiextv1.JSONSchemaPropsOrBool{
-																	Allows: true,
-																},
-															},
-														},
-													},
-													"matchFields": {
-														Type: "array",
-														Items: &apiextv1.JSONSchemaPropsOrArray{
-															Schema: &apiextv1.JSONSchemaProps{
-																Type: "object",
-																AdditionalProperties: &apiextv1.JSONSchemaPropsOrBool{
-																	Allows: true,
-																},
-															},
-														},
-													},
-												},
-											},
-											"weight": {
-												Type:   "integer",
-												Format: "int32",
-											},
-										},
-									},
-								},
-							},
-							"requiredDuringSchedulingIgnoredDuringExecution": {
-								Type:     "object",
-								Required: []string{"nodeSelectorTerms"},
-								Properties: map[string]apiextv1.JSONSchemaProps{
-									"nodeSelectorTerms": {
-										Type: "array",
-										Items: &apiextv1.JSONSchemaPropsOrArray{
-											Schema: &apiextv1.JSONSchemaProps{
-												Type: "object",
-												Properties: map[string]apiextv1.JSONSchemaProps{
-													"matchExpressions": {
-														Type: "array",
-														Items: &apiextv1.JSONSchemaPropsOrArray{
-															Schema: &apiextv1.JSONSchemaProps{
-																Type: "object",
-																AdditionalProperties: &apiextv1.JSONSchemaPropsOrBool{
-																	Allows: true,
-																},
-															},
-														},
-													},
-													"matchFields": {
-														Type: "array",
-														Items: &apiextv1.JSONSchemaPropsOrArray{
-															Schema: &apiextv1.JSONSchemaProps{
-																Type: "object",
-																AdditionalProperties: &apiextv1.JSONSchemaPropsOrBool{
-																	Allows: true,
-																},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
 							},
 						},
 					},

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -622,11 +622,6 @@ func (c *Cluster) syncRoles() (err error) {
 	// create list of database roles to query
 	for _, u := range c.pgUsers {
 		pgRole := u.Name
-		if u.Namespace != c.Namespace && u.Namespace != "" {
-			// to avoid the conflict of having multiple users of same name
-			// but each in different namespace.
-			pgRole = fmt.Sprintf("%s.%s", u.Namespace, u.Name)
-		}
 		userNames = append(userNames, pgRole)
 		// add team member role name with rename suffix in case we need to rename it back
 		if u.Origin == spec.RoleOriginTeamsAPI && c.OpConfig.EnableTeamMemberDeprecation {

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -386,7 +386,6 @@ func (c *Cluster) syncStatefulSet() error {
 		return fmt.Errorf("could not set cluster-wide PostgreSQL configuration options: %v", err)
 	}
 
-
 	if instancesRestartRequired {
 		c.logger.Debugln("restarting Postgres server within pods")
 		c.eventRecorder.Event(c.GetReference(), v1.EventTypeNormal, "Update", "restarting Postgres server within pods")
@@ -626,7 +625,7 @@ func (c *Cluster) syncRoles() (err error) {
 		if u.Namespace != c.Namespace && u.Namespace != "" {
 			// to avoid the conflict of having multiple users of same name
 			// but each in different namespace.
-			pgRole = fmt.Sprintf("%s.%s", u.Name, u.Namespace)
+			pgRole = fmt.Sprintf("%s.%s", u.Namespace, u.Name)
 		}
 		userNames = append(userNames, pgRole)
 		// add team member role name with rename suffix in case we need to rename it back


### PR DESCRIPTION
e2e test are executed in alphabetical order. Because it is sometimes important in which state the cluster is left after one test, it improves understanding and debugging when all test in the e2e file also following the alphabetical sorting.

Plus, this PR fixes alphabetical sorting of nodeAffinity in crd validation