### PR TITLE
fix searching for users with namespace in name

### DIFF
--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -592,6 +592,8 @@ class EndToEndTestCase(unittest.TestCase):
         '''
             Test secrets in different namespace
         '''
+        k8s = self.k8s
+
         # enable secret creation in separate namespace
         patch_cross_namespace_secret = {
             "data": {

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -588,16 +588,11 @@ class EndToEndTestCase(unittest.TestCase):
             raise
 
     @timeout_decorator.timeout(TEST_TIMEOUT_SEC)
-    def test_zz_cross_namespace_secrets(self):
+    def test_cross_namespace_secrets(self):
         '''
             Test secrets in different namespace
         '''
-        app_namespace = "appspace"
-
-        v1_appnamespace = client.V1Namespace(metadata=client.V1ObjectMeta(name=app_namespace))
-        self.k8s.api.core_v1.create_namespace(v1_appnamespace)
-        self.k8s.wait_for_namespace_creation(app_namespace)
-
+        # enable secret creation in separate namespace
         patch_cross_namespace_secret = {
             "data": {
                 "enable_cross_namespace_secret": "true"
@@ -605,29 +600,25 @@ class EndToEndTestCase(unittest.TestCase):
         }
         self.k8s.update_config(patch_cross_namespace_secret,
                           step="cross namespace secrets enabled")
+        self.eventuallyEqual(lambda: k8s.get_operator_state(), {"0": "idle"},
+                             "Operator does not get in sync")
 
+        # create secret in test namespace
         self.k8s.api.custom_objects_api.patch_namespaced_custom_object(
             'acid.zalan.do', 'v1', 'default',
             'postgresqls', 'acid-minimal-cluster',
             {
                 'spec': {
                     'users':{
-                        'appspace.db_user': [],
+                        'test.db_user': [],
                     }
                 }
             })
-
-        self.eventuallyEqual(lambda: self.k8s.count_secrets_with_label("cluster-name=acid-minimal-cluster,application=spilo", app_namespace),
+        
+        self.eventuallyEqual(lambda: k8s.get_operator_state(), {"0": "idle"},
+                             "Operator does not get in sync")
+        self.eventuallyEqual(lambda: self.k8s.count_secrets_with_label("cluster-name=acid-minimal-cluster,application=spilo", self.test_namespace),
                              1, "Secret not created for user in namespace")
-
-        #reset the flag
-        unpatch_cross_namespace_secret = {
-                "data": {
-                    "enable_cross_namespace_secret": "false",
-                }
-            }
-        self.k8s.update_config(unpatch_cross_namespace_secret, step="disable cross namespace secrets")
-
 
     @timeout_decorator.timeout(TEST_TIMEOUT_SEC)
     def test_lazy_spilo_upgrade(self):

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -622,11 +622,6 @@ func (c *Cluster) syncRoles() (err error) {
 	// create list of database roles to query
 	for _, u := range c.pgUsers {
 		pgRole := u.Name
-		if u.Namespace != c.Namespace && u.Namespace != "" {
-			// to avoid the conflict of having multiple users of same name
-			// but each in different namespace.
-			pgRole = fmt.Sprintf("%s.%s", u.Namespace, u.Name)
-		}
 		userNames = append(userNames, pgRole)
 		// add team member role name with rename suffix in case we need to rename it back
 		if u.Origin == spec.RoleOriginTeamsAPI && c.OpConfig.EnableTeamMemberDeprecation {

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -386,7 +386,6 @@ func (c *Cluster) syncStatefulSet() error {
 		return fmt.Errorf("could not set cluster-wide PostgreSQL configuration options: %v", err)
 	}
 
-
 	if instancesRestartRequired {
 		c.logger.Debugln("restarting Postgres server within pods")
 		c.eventRecorder.Event(c.GetReference(), v1.EventTypeNormal, "Update", "restarting Postgres server within pods")
@@ -626,7 +625,7 @@ func (c *Cluster) syncRoles() (err error) {
 		if u.Namespace != c.Namespace && u.Namespace != "" {
 			// to avoid the conflict of having multiple users of same name
 			// but each in different namespace.
-			pgRole = fmt.Sprintf("%s.%s", u.Name, u.Namespace)
+			pgRole = fmt.Sprintf("%s.%s", u.Namespace, u.Name)
 		}
 		userNames = append(userNames, pgRole)
 		// add team member role name with rename suffix in case we need to rename it back


### PR DESCRIPTION
and simplify e2e test for cross namespace secrets.

Removed codelines have become obsolete, because the username will always contain the namespace at this point. At some stage of #1490 we've extracted the user from the full namespace-qualified name, hence making it necessary to add the namespace here. But, as of now, it would result in an error, because the namespace would be appended again (after the username, which seems strange, too). The name of the corresponding e2e test is changed, too, to be executed sooner and not at the end (which led to overseeing this bug).