### PR TITLE
fix(ui): update ingress api versions in helm chart for newer k8s vers…

### DIFF
--- a/charts/postgres-operator-ui/templates/ingress.yaml
+++ b/charts/postgres-operator-ui/templates/ingress.yaml
@@ -1,7 +1,10 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "postgres-operator-ui.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -37,9 +40,18 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            {{ if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion -}}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+            {{- else -}}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+            {{- end -}}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/ui/manifests/ingress.yaml
+++ b/ui/manifests/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: "networking.k8s.io/v1beta1"
+apiVersion: "networking.k8s.io/v1"
 kind: "Ingress"
 metadata:
   name: "postgres-operator-ui"
@@ -10,6 +10,10 @@ spec:
     - host: "ui.example.org"
       http:
         paths:
-          - backend:
-              serviceName: "postgres-operator-ui"
-              servicePort: 80
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: "postgres-operator-ui"
+                port:
+                  number: 80


### PR DESCRIPTION
fixes #1574 

I have added an additional condition which applies the newer `networking.k8s.io/v1` ingress configuration if the cluster version is greater than `1.19.0`.

Maybe it should be considered to check which configuration is used based on `Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress"` instead of comparing the cluster version. I used the second approach, because it was already implemented like this.