### PR TITLE
Pass AWS region to Spilo

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -786,6 +786,7 @@ func (c *Cluster) generateSpiloPodEnvVars(uid types.UID, spiloConfiguration stri
 	}
 
 	if c.OpConfig.WALES3Bucket != "" {
+		envVars = append(envVars, v1.EnvVar{Name: "AWS_REGION", Value: c.OpConfig.AWSRegion})
 		envVars = append(envVars, v1.EnvVar{Name: "WAL_S3_BUCKET", Value: c.OpConfig.WALES3Bucket})
 		envVars = append(envVars, v1.EnvVar{Name: "WAL_BUCKET_SCOPE_SUFFIX", Value: getBucketScopeSuffix(string(uid))})
 		envVars = append(envVars, v1.EnvVar{Name: "WAL_BUCKET_SCOPE_PREFIX", Value: ""})
@@ -1796,6 +1797,10 @@ func (c *Cluster) generateCloneEnvironment(description *acidv1.CloneDescription)
 					{
 						Name:  "CLONE_WAL_S3_BUCKET",
 						Value: c.OpConfig.WALES3Bucket,
+					},
+					{
+						Name:  "CLONE_AWS_REGION",
+						Value: c.OpConfig.AWSRegion,
 					},
 				}
 				result = append(result, envs...)

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -498,7 +498,7 @@ func TestCloneEnv(t *testing.T) {
 			subTest: "generated s3 path, AWS region",
 			cloneOpts: &acidv1.CloneDescription{
 				ClusterName:  "test-cluster",
-				S3WalPath:    "s3://some/path/",
+				S3WalPath:    "",
 				EndTimestamp: "somewhen",
 			},
 			env: v1.EnvVar{

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -492,13 +492,26 @@ func TestCloneEnv(t *testing.T) {
 				Name:  "CLONE_TARGET_TIME",
 				Value: "somewhen",
 			},
-			envPos: 4,
+			envPos: 5,
+		},
+		{
+			subTest: "generated s3 path, AWS region",
+			cloneOpts: &acidv1.CloneDescription{
+				ClusterName:  "test-cluster",
+				EndTimestamp: "somewhen",
+			},
+			env: v1.EnvVar{
+				Name:  "CLONE_AWS_REGION",
+				Value: "test-region",
+			},
+			envPos: 2,
 		},
 	}
 
 	var cluster = New(
 		Config{
 			OpConfig: config.Config{
+				AWSRegion:      "test-region",
 				WALES3Bucket:   "wale-bucket",
 				ProtectedRoles: []string{"admin"},
 				Auth: config.Auth{

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -498,6 +498,7 @@ func TestCloneEnv(t *testing.T) {
 			subTest: "generated s3 path, AWS region",
 			cloneOpts: &acidv1.CloneDescription{
 				ClusterName:  "test-cluster",
+				S3WalPath:    "s3://some/path/",
 				EndTimestamp: "somewhen",
 			},
 			env: v1.EnvVar{


### PR DESCRIPTION
Pass `aws_region` operator setting to Spilo via `AWS_REGION` environment variable.

fixes #1550