### PR TITLE
allow secrets of default users in a different namespace

### DIFF
--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -394,6 +394,8 @@ spec:
                             type: boolean
                           defaultRoles:
                             type: boolean
+                    secretNamespace:
+                      type: string
               replicaLoadBalancer:  # deprecated
                 type: boolean
               resources:

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -267,9 +267,7 @@ configuration they are grouped under the `kubernetes` key.
 * **enable_cross_namespace_secrets**
   To allow secrets in a different namespace other than the Postgres cluster
   namespace. Once enabled, specify the namespace in the user name under the
-  `users` section in the form `{namespace}.{username}`. The operator will then
-  create the user secret in that namespace. The part after the first `.` is
-  considered to be the user name. The default is `false`.
+  `users` section in the form `{namespace}.{username}`. The default is `false`.
 
 * **enable_init_containers**
   global option to allow for creating init containers in the cluster manifest to

--- a/docs/user.md
+++ b/docs/user.md
@@ -139,9 +139,9 @@ secret, without ever sharing it outside of the cluster.
 At the moment it is not possible to define membership of the manifest role in
 other roles.
 
-To define the secrets for the users in a different namespace than that of the cluster,
-one can set `enable_cross_namespace_secret` and declare the namespace for the
-secrets in the manifest in the following manner,
+To define the secrets for the users in a different namespace than that of the
+cluster, one can set `enable_cross_namespace_secret` and declare the namespace
+for the secrets in the manifest in the following manner,
 
 ```yaml
 spec:
@@ -150,7 +150,8 @@ spec:
    appspace.db_user:
     - createdb
 ```
-Here, anything before the first dot is taken as the namespace and the text after
+
+Here, anything before the first dot is considered the namespace and the text after
 the first dot is the username. Also, the postgres roles of these usernames would
 be in the form of `namespace.username`.
 
@@ -520,7 +521,7 @@ Then, the schemas are owned by the database owner, too.
 
 The roles described in the previous paragraph can be granted to LOGIN roles from
 the `users` section in the manifest. Optionally, the Postgres Operator can also
-create default LOGIN roles for the database an each schema individually. These
+create default LOGIN roles for the database and each schema individually. These
 roles will get the `_user` suffix and they inherit all rights from their NOLOGIN
 counterparts. Therefore, you cannot have `defaultRoles` set to `false` and enable
 `defaultUsers` at the same time.
@@ -549,6 +550,19 @@ spec:
 Default access privileges are also defined for LOGIN roles on database and
 schema creation. This means they are currently not set when `defaultUsers`
 (or `defaultRoles` for schemas) are enabled at a later point in time.
+
+For all LOGIN roles the operator will create K8s secrets in the namespace
+specified in `secretNamespace`, if `enable_cross_namespace_secret` is set to
+`true` in the config. Otherwise, they are created in the same namespace like
+the Postgres cluster.
+
+```yaml
+spec:
+  preparedDatabases:
+    foo:
+      defaultUsers: true
+      secretNamespace: appspace
+```
 
 ### Schema `search_path` for default roles
 

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -390,6 +390,8 @@ spec:
                             type: boolean
                           defaultRoles:
                             type: boolean
+                    secretNamespace:
+                      type: string
               replicaLoadBalancer:  # deprecated
                 type: boolean
               resources:

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -573,6 +573,9 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 											},
 										},
 									},
+									"secretNamespace": {
+										Type: "string",
+									},
 								},
 							},
 						},

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -95,6 +95,7 @@ type PreparedDatabase struct {
 	PreparedSchemas map[string]PreparedSchema `json:"schemas,omitempty"`
 	DefaultUsers    bool                      `json:"defaultUsers,omitempty" defaults:"false"`
 	Extensions      map[string]string         `json:"extensions,omitempty"`
+	SecretNamespace string                    `json:"secretNamespace,omitempty"`
 }
 
 // PreparedSchema describes elements to be bootstrapped per schema

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1077,11 +1077,11 @@ func (c *Cluster) initPreparedDatabaseRoles() error {
 		}
 
 		// default roles per database
-		if err := c.initDefaultRoles(defaultRoles, "admin", preparedDbName, searchPath.String()); err != nil {
+		if err := c.initDefaultRoles(defaultRoles, "admin", preparedDbName, searchPath.String(), preparedDB.SecretNamespace); err != nil {
 			return fmt.Errorf("could not initialize default roles for database %s: %v", preparedDbName, err)
 		}
 		if preparedDB.DefaultUsers {
-			if err := c.initDefaultRoles(defaultUsers, "admin", preparedDbName, searchPath.String()); err != nil {
+			if err := c.initDefaultRoles(defaultUsers, "admin", preparedDbName, searchPath.String(), preparedDB.SecretNamespace); err != nil {
 				return fmt.Errorf("could not initialize default roles for database %s: %v", preparedDbName, err)
 			}
 		}
@@ -1092,14 +1092,14 @@ func (c *Cluster) initPreparedDatabaseRoles() error {
 				if err := c.initDefaultRoles(defaultRoles,
 					preparedDbName+constants.OwnerRoleNameSuffix,
 					preparedDbName+"_"+preparedSchemaName,
-					constants.DefaultSearchPath+", "+preparedSchemaName); err != nil {
+					constants.DefaultSearchPath+", "+preparedSchemaName, preparedDB.SecretNamespace); err != nil {
 					return fmt.Errorf("could not initialize default roles for database schema %s: %v", preparedSchemaName, err)
 				}
 				if preparedSchema.DefaultUsers {
 					if err := c.initDefaultRoles(defaultUsers,
 						preparedDbName+constants.OwnerRoleNameSuffix,
 						preparedDbName+"_"+preparedSchemaName,
-						constants.DefaultSearchPath+", "+preparedSchemaName); err != nil {
+						constants.DefaultSearchPath+", "+preparedSchemaName, preparedDB.SecretNamespace); err != nil {
 						return fmt.Errorf("could not initialize default users for database schema %s: %v", preparedSchemaName, err)
 					}
 				}
@@ -1109,10 +1109,15 @@ func (c *Cluster) initPreparedDatabaseRoles() error {
 	return nil
 }
 
-func (c *Cluster) initDefaultRoles(defaultRoles map[string]string, admin, prefix string, searchPath string) error {
+func (c *Cluster) initDefaultRoles(defaultRoles map[string]string, admin, prefix, searchPath, secretNamespace string) error {
 
 	for defaultRole, inherits := range defaultRoles {
 
+		namespace := c.Namespace
+		//if namespaced secrets are allowed
+		if c.Config.OpConfig.EnableCrossNamespaceSecret && secretNamespace != "" {
+			namespace = secretNamespace
+		}
 		roleName := prefix + defaultRole
 
 		flags := []string{constants.RoleFlagNoLogin}
@@ -1135,7 +1140,7 @@ func (c *Cluster) initDefaultRoles(defaultRoles map[string]string, admin, prefix
 		newRole := spec.PgUser{
 			Origin:     spec.RoleOriginBootstrap,
 			Name:       roleName,
-			Namespace:  c.Namespace,
+			Namespace:  namespace,
 			Password:   util.RandomPassword(constants.PasswordLength),
 			Flags:      flags,
 			MemberOf:   memberOf,

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1115,8 +1115,12 @@ func (c *Cluster) initDefaultRoles(defaultRoles map[string]string, admin, prefix
 
 		namespace := c.Namespace
 		//if namespaced secrets are allowed
-		if c.Config.OpConfig.EnableCrossNamespaceSecret && secretNamespace != "" {
-			namespace = secretNamespace
+		if secretNamespace != "" {
+			if c.Config.OpConfig.EnableCrossNamespaceSecret {
+				namespace = secretNamespace
+			} else {
+				c.logger.Warn("secretNamespace ignored because enable_cross_namespace_secret set to false. Creating secrets in cluster namespace.")
+			}
 		}
 		roleName := prefix + defaultRole
 


### PR DESCRIPTION
fixes #1580 

introduces a small addition to `preparedDatabases` to allow secrets of default LOGIN roles in other namespaces