### PR TITLE
feat: Add extraEnvs to operator-ui helm chart

### DIFF
--- a/charts/postgres-operator-ui/templates/deployment.yaml
+++ b/charts/postgres-operator-ui/templates/deployment.yaml
@@ -76,3 +76,6 @@ spec:
                     "11"
                   ]
                 }
+            {{- if .Values.extraEnvs }}
+            {{- .Values.extraEnvs | toYaml | nindent 12 }}
+            {{- end }}

--- a/charts/postgres-operator-ui/values.yaml
+++ b/charts/postgres-operator-ui/values.yaml
@@ -48,6 +48,31 @@ envs:
   teams:
     - "acid"
 
+extraEnvs:
+  []
+  # Exemple of settings to make snapshot view working in the ui when using AWS
+  # - name: WALE_S3_ENDPOINT
+  #   value: https+path://s3.us-east-1.amazonaws.com:443
+  # - name: SPILO_S3_BACKUP_PREFIX
+  #   value: spilo/
+  # - name: AWS_ACCESS_KEY_ID
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: <postgres operator secret with AWS token>
+  #       key: AWS_ACCESS_KEY_ID
+  # - name: AWS_SECRET_ACCESS_KEY
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: <postgres operator secret with AWS token>
+  #       key: AWS_SECRET_ACCESS_KEY
+  # - name: AWS_DEFAULT_REGION
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: <postgres operator secret with AWS token>
+  #       key: AWS_DEFAULT_REGION
+  # - name: SPILO_S3_BACKUP_BUCKET
+  #   value: <s3 bucket used by the operator>
+
 # configure UI service
 service:
   type: "ClusterIP"
@@ -59,7 +84,8 @@ service:
 # configure UI ingress. If needed: "enabled: true"
 ingress:
   enabled: false
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:

--- a/charts/postgres-operator-ui/values.yaml
+++ b/charts/postgres-operator-ui/values.yaml
@@ -48,6 +48,11 @@ envs:
   teams:
     - "acid"
 
+# configure extra UI ENVs
+# Extra ENVs are writen in kubenertes format and added "as is" to the pod's env variables
+# https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+# https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables
+# UI specific env variables can be found here: https://github.com/zalando/postgres-operator/blob/master/ui/operator_ui/main.py
 extraEnvs:
   []
   # Exemple of settings to make snapshot view working in the ui when using AWS

--- a/ui/manifests/deployment.yaml
+++ b/ui/manifests/deployment.yaml
@@ -71,3 +71,25 @@ spec:
                     "11"
                   ]
                 }
+            # Exemple of settings to make snapshot view working in the ui when using AWS
+            # - name: WALE_S3_ENDPOINT
+            #   value: https+path://s3.us-east-1.amazonaws.com:443
+            # - name: SPILO_S3_BACKUP_PREFIX
+            #   value: spilo/
+            # - name: AWS_ACCESS_KEY_ID
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: <postgres operator secret with AWS token>
+            #       key: AWS_ACCESS_KEY_ID
+            # - name: AWS_SECRET_ACCESS_KEY
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: <postgres operator secret with AWS token>
+            #       key: AWS_SECRET_ACCESS_KEY
+            # - name: AWS_DEFAULT_REGION
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: <postgres operator secret with AWS token>
+            #       key: AWS_DEFAULT_REGION
+            # - name: SPILO_S3_BACKUP_BUCKET
+            #   value: <s3 bucket used by the operator>


### PR DESCRIPTION
This PR allows adding any needed extra anv vars to the operator-ui deployment into the helm chart.
Fixes #1523 