### PR TITLE
Fix malformed YAML in the manifest

### DIFF
--- a/manifests/complete-postgres-manifest.yaml
+++ b/manifests/complete-postgres-manifest.yaml
@@ -157,7 +157,7 @@ spec:
 #   - name: "telegraf-sidecar"
 #     image: "telegraf:latest"
 #     ports:
-#       name: metrics
+#     - name: metrics
 #       containerPort: 8094
 #       protocol: TCP
 #     resources:


### PR DESCRIPTION
The ports section should be a list. Without this fix  you'll trigger the following error:

```
Warning  Create  2m38s  postgres-operator  json: cannot unmarshal object into Go struct field Sidecar.spec.sidecars.ports of type []v1.ContainerPort
```