### PR TITLE
Helm chart generates incomplete ConfigMap

### DIFF
--- a/charts/postgres-operator/templates/_helpers.tpl
+++ b/charts/postgres-operator/templates/_helpers.tpl
@@ -57,18 +57,16 @@ Flatten nested config options when ConfigMap is used as ConfigTarget
 */}}
 {{- define "flattenValuesForConfigMap" }}
 {{- range $key, $value := . }}
-    {{- if or (kindIs "string" $value) (kindIs "int" $value) }}
-{{ $key }}: {{ $value | quote }}
-    {{- end }}
     {{- if kindIs "slice" $value }}
 {{ $key }}: {{ join "," $value | quote }}
-    {{- end }}
-    {{- if kindIs "map" $value }}
+    {{- else if kindIs "map" $value }}
         {{- $list := list }}
         {{- range $subKey, $subValue := $value }}
             {{- $list = append $list (printf "%s:%s" $subKey $subValue) }}
 {{ $key }}: {{ join "," $list | quote }}
         {{- end }}
+    {{- else }}
+{{ $key }}: {{ $value | quote }}
     {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
As reported by @StepanKuksenko in https://github.com/zalando/postgres-operator/pull/1224#issuecomment-909247065, some properties are missing in the ConfigMap generated by the Helm chart.
This is due to the strict check on `if or (kindIs "string" $value) (kindIs "int" $value)`, whereas the list of variable types encountered by the function is `string`, `map`, `slice`, `bool` and `float64` (see that the last 2 are missing in `flattenValuesForConfigMap`.
My proposal is to actually use a `else` fallback, instead of explicitly looking for certain types.
(The alternative would be to expand/modify the list of type if the first `if` to include `bool` and `float64`.

Question: how can we prevent this kind of problem from happening again the future? Is there an integration that could be expanded?