### PR TITLE
Fix mock generation in go 1.17

### DIFF
--- a/pkg/util/httpclient/httpclient.go
+++ b/pkg/util/httpclient/httpclient.go
@@ -1,6 +1,6 @@
 package httpclient
 
-//go:generate mockgen -package mocks -destination=$PWD/mocks/$GOFILE -source=$GOFILE -build_flags=-mod=vendor
+//go:generate mockgen -package mocks -destination=../../../mocks/$GOFILE -source=$GOFILE -build_flags=-mod=vendor
 
 import "net/http"
 

--- a/pkg/util/volumes/volumes.go
+++ b/pkg/util/volumes/volumes.go
@@ -1,6 +1,6 @@
 package volumes
 
-//go:generate mockgen -package mocks -destination=$PWD/mocks/$GOFILE -source=$GOFILE -build_flags=-mod=vendor
+//go:generate mockgen -package mocks -destination=../../../mocks/$GOFILE -source=$GOFILE -build_flags=-mod=vendor
 
 import v1 "k8s.io/api/core/v1"
 


### PR DESCRIPTION
Fixes https://github.com/zalando/postgres-operator/issues/1614

The meaning of $PWD for "go generate" seems to have changed in go 1.17 .
See https://go-review.googlesource.com/c/go/+/287152

In go 1.16 this was the package folder and in go 1.17 it is the folder of the current file.
Using a relative path works in both go versions.
