### PR TITLE
Fix logical backup script sigpipe problem

### DIFF
--- a/docker/logical-backup/dump.sh
+++ b/docker/logical-backup/dump.sh
@@ -84,15 +84,15 @@ declare -a search_strategy=(
 )
 
 function list_all_replica_pods_current_node {
-    get_pods "labelSelector=${CLUSTER_NAME_LABEL}%3D${SCOPE},spilo-role%3Dreplica&fieldSelector=spec.nodeName%3D${CURRENT_NODENAME}" | head -n 1
+    get_pods "labelSelector=${CLUSTER_NAME_LABEL}%3D${SCOPE},spilo-role%3Dreplica&fieldSelector=spec.nodeName%3D${CURRENT_NODENAME}" | tee | head -n 1
 }
 
 function list_all_replica_pods_any_node {
-    get_pods "labelSelector=${CLUSTER_NAME_LABEL}%3D${SCOPE},spilo-role%3Dreplica" | head -n 1
+    get_pods "labelSelector=${CLUSTER_NAME_LABEL}%3D${SCOPE},spilo-role%3Dreplica" | tee | head -n 1
 }
 
 function get_master_pod {
-    get_pods "labelSelector=${CLUSTER_NAME_LABEL}%3D${SCOPE},spilo-role%3Dmaster" | head -n 1
+    get_pods "labelSelector=${CLUSTER_NAME_LABEL}%3D${SCOPE},spilo-role%3Dmaster" | tee | head -n 1
 }
 
 CURRENT_NODENAME=$(get_current_pod | jq .items[].spec.nodeName --raw-output)


### PR DESCRIPTION
Sometimes the `head -n` pipe in the logical backup script (when getting the cluster host ip), causes SIGPIPE which will cause the script to exit with code 141, since `head` will only read the first line and cause a SIGPIPE signal to `jq`. I added an extra pipe to `tee` to resolve this issue.