### PR TITLE
Update user.md

### DIFF
--- a/docs/user.md
+++ b/docs/user.md
@@ -88,7 +88,7 @@ which was generated when creating the `acid-minimal-cluster`. As non-encrypted
 connections are rejected by default set the SSL mode to `require`:
 
 ```bash
-export PGPASSWORD=$(kubectl get secret postgres.acid-minimal-cluster.credentials -o 'jsonpath={.data.password}' | base64 -d)
+export PGPASSWORD=$(kubectl get secret postgres.acid-minimal-cluster.credentials.postgresql.acid.zalan.do -o 'jsonpath={.data.password}' | base64 -d)
 export PGSSLMODE=require
 psql -U postgres -h localhost -p 6432
 ```


### PR DESCRIPTION
The name of the created secret with the minimal postgres deployment is "postgres.acid-minimal-cluster.credentials.postgresql.acid.zalan.do" so when trying the command export "PGPASSWORD=$(kubectl get secret postgres.acid-minimal-cluster.credentials -o 'jsonpath={.data.password}' | base64 -d)"   base64 complains about invalid input and when running the command "kubectl get secret postgres.acid-minimal-cluster.credentials -o 'jsonpath={.data.password}'" it complains about not finding the resource. it worked when I used the full name, i.e. "postgres.acid-minimal-cluster.credentials.postgresql.acid.zalan.do".