### PR TITLE
docs: fix typo in option name for cross-ns secrets

### DIFF
--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -110,7 +110,7 @@ These parameters are grouped directly under  the `spec` key in the manifest.
   `CREATEDB`, `BYPASSURL`. A login user is created by default unless NOLOGIN is
   specified, in which case the operator creates a role. One can specify empty
   flags by providing a JSON empty array '*[]*'. If the config option
-  `enable_cross_namespace_secrets` is enabled you can specify the namespace in
+  `enable_cross_namespace_secret` is enabled you can specify the namespace in
   the user name in the form `{namespace}.{username}` and the operator will
   create the K8s secret in that namespace. The part after the first `.` is
   considered to be the user name. Optional.
@@ -215,7 +215,7 @@ information, see [user docs](../user.md#prepared-databases-with-roles-and-defaul
 * **secretNamespace**
   for each default LOGIN role the operator will create a secret. You can
   specify the namespace in which these secrets will get created, if
-  `enable_cross_namespace_secrets` is set to `true` in the config. Otherwise,
+  `enable_cross_namespace_secret` is set to `true` in the config. Otherwise,
   the cluster namespace is used.
 
 ## Postgres parameters

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -264,7 +264,7 @@ configuration they are grouped under the `kubernetes` key.
   [admin docs](../administrator.md#pod-disruption-budget) for more information.
   Default is true.
 
-* **enable_cross_namespace_secrets**
+* **enable_cross_namespace_secret**
   To allow secrets in a different namespace other than the Postgres cluster
   namespace. Once enabled, specify the namespace in the user name under the
   `users` section in the form `{namespace}.{username}`. The default is `false`.


### PR DESCRIPTION
In a few places, the docs give `enable_cross_namespace_secrets` (with a trailing `s`), where the correct option name is `enable_cross_namespace_secret`. This PR fixes those docs.