### PR TITLE
Add support for logical backups to Azure

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -173,6 +173,9 @@ spec:
                   enable_init_containers:
                     type: boolean
                     default: true
+                  enable_cross_namespace_secret:
+                    type: boolean
+                    default: false
                   enable_pod_antiaffinity:
                     type: boolean
                     default: false
@@ -388,11 +391,11 @@ spec:
                     type: string
                   log_s3_bucket:
                     type: string
-                  wal_az_storage_account:
-                    type: string
                   wal_gs_bucket:
                     type: string
                   wal_s3_bucket:
+                    type: string
+                  wal_az_storage_account:
                     type: string
               logical_backup:
                 type: object

--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -435,6 +435,8 @@ spec:
                     type: string
                   logical_backup_storage_account_key:
                     type: string
+                  logical_backup_cronjob_environment_secret:
+                    type: string
               debug:
                 type: object
                 properties:

--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -173,9 +173,6 @@ spec:
                   enable_init_containers:
                     type: boolean
                     default: true
-                  enable_cross_namespace_secret:
-                    type: boolean
-                    default: false
                   enable_pod_antiaffinity:
                     type: boolean
                     default: false
@@ -391,11 +388,11 @@ spec:
                     type: string
                   log_s3_bucket:
                     type: string
+                  wal_az_storage_account:
+                    type: string
                   wal_gs_bucket:
                     type: string
                   wal_s3_bucket:
-                    type: string
-                  wal_az_storage_account:
                     type: string
               logical_backup:
                 type: object
@@ -427,6 +424,14 @@ spec:
                     type: string
                     pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
                     default: "30 00 * * *"
+                  logical_backup_storage_account_name:
+                    type: string
+                  logical_backup_storage_container:
+                    type: string
+                  logical_backup_storage_blob:
+                    type: string
+                  logical_backup_storage_account_key:
+                    type: string
               debug:
                 type: object
                 properties:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -310,6 +310,8 @@ configLogicalBackup:
   logical_backup_storage_blob: ""
   # storage account key
   logical_backup_storage_account_key: ""
+  # secret to be used as reference for env variables in cronjob
+  logical_backup_cronjob_environment_secret: ""
 
 # automate creation of human users with teams API service
 configTeamsApi:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -302,6 +302,14 @@ configLogicalBackup:
   logical_backup_s3_sse: "AES256"
   # backup schedule in the cron format
   logical_backup_schedule: "30 00 * * *"
+  # storage account name
+  logical_backup_storage_account_name: ""
+  # storage account container
+  logical_backup_storage_container: ""
+  # storage blob
+  logical_backup_storage_blob: ""
+  # storage account key
+  logical_backup_storage_account_key: ""
 
 # automate creation of human users with teams API service
 configTeamsApi:

--- a/docker/logical-backup/Dockerfile
+++ b/docker/logical-backup/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update     \
         gnupg \
         gcc \
         libffi-dev \
+    && curl -sL https://aka.ms/InstallAzureCLIDeb | bash \
     && pip3 install --upgrade pip \
     && pip3 install --no-cache-dir awscli --upgrade \
     && pip3 install --no-cache-dir gsutil --upgrade \

--- a/docker/logical-backup/dump.sh
+++ b/docker/logical-backup/dump.sh
@@ -53,7 +53,7 @@ function gcs_upload {
 }
 
 function az_upload {
-    PATH_TO_BACKUP="test/logical_backups/"$(date +%s).sql.gz
+    PATH_TO_BACKUP=$LOGICAL_BACKUP_S3_BUCKET"/spilo/"$SCOPE$LOGICAL_BACKUP_S3_BUCKET_SCOPE_SUFFIX"/logical_backups/"$(date +%s).sql.gz
 
     az storage blob upload --file "$1" --account-name "$LOGICAL_BACKUP_STORAGE_ACCOUNT_NAME" --account-key "$LOGICAL_BACKUP_STORAGE_ACCOUNT_KEY" -c "$LOGICAL_BACKUP_STORAGE_CONTAINER" -n "$PATH_TO_BACKUP"
 }

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -643,6 +643,18 @@ grouped under the `logical_backup` key.
   [reference schedule format](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule)
   into account. Default: "30 00 \* \* \*"
 
+* **logical_backup_storage_account_name**
+  Storage account name used to upload logical backups to when using Azure. Default: ""
+
+* **logical_backup_storage_container**
+  Storage container used to upload logical backups to when using Azure. Default: ""
+
+* **logical_backup_storage_blob**
+  Storage blob used to upload logical backups to when using Azure. Default: ""
+
+* **logical_backup_storage_account_key**
+  Storage account key used to authenticate with Azure when uploading logical backups. Default: ""
+
 ## Debugging the operator
 
 Options to aid debugging of the operator itself. Grouped under the `debug` key.

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -655,6 +655,9 @@ grouped under the `logical_backup` key.
 * **logical_backup_storage_account_key**
   Storage account key used to authenticate with Azure when uploading logical backups. Default: ""
 
+* **logical_backup_cronjob_environment_secret**
+  Reference to a Kubernetes secret, which keys will be added as environment variables to the cronjob. Default: ""
+
 ## Debugging the operator
 
 Options to aid debugging of the operator itself. Grouped under the `debug` key.

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -65,10 +65,10 @@ data:
   # inherited_labels: application,environment
   # kube_iam_role: ""
   # log_s3_bucket: ""
-  logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.7.0"
+  logical_backup_docker_image: "harbor.sofico.be/dev/logical-backup:dev"
   # logical_backup_google_application_credentials: ""
   logical_backup_job_prefix: "logical-backup-"
-  logical_backup_provider: "s3"
+  logical_backup_provider: "az"
   # logical_backup_s3_access_key_id: ""
   logical_backup_s3_bucket: "my-bucket-url"
   # logical_backup_s3_region: ""
@@ -76,6 +76,10 @@ data:
   # logical_backup_s3_secret_access_key: ""
   logical_backup_s3_sse: "AES256"
   logical_backup_schedule: "30 00 * * *"
+  # logical_backup_storage_account_name: ""
+  # logical_backup_storage_container: ""
+  # logical_backup_storage_blob: ""
+  # logical_backup_storage_account_key: ""
   major_version_upgrade_mode: "manual"
   master_dns_name_format: "{cluster}.{team}.{hostedzone}"
   # master_pod_move_timeout: 20m

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -65,10 +65,10 @@ data:
   # inherited_labels: application,environment
   # kube_iam_role: ""
   # log_s3_bucket: ""
-  logical_backup_docker_image: "harbor.sofico.be/dev/logical-backup:dev"
+  logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.7.0"
   # logical_backup_google_application_credentials: ""
   logical_backup_job_prefix: "logical-backup-"
-  logical_backup_provider: "az"
+  logical_backup_provider: "s3"
   # logical_backup_s3_access_key_id: ""
   logical_backup_s3_bucket: "my-bucket-url"
   # logical_backup_s3_region: ""

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -80,6 +80,7 @@ data:
   # logical_backup_storage_container: ""
   # logical_backup_storage_blob: ""
   # logical_backup_storage_account_key: ""
+  # logical_backup_cronjob_environment_secret: ""
   major_version_upgrade_mode: "manual"
   master_dns_name_format: "{cluster}.{team}.{hostedzone}"
   # master_pod_move_timeout: 20m

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -420,6 +420,14 @@ spec:
                     type: string
                     pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
                     default: "30 00 * * *"
+                  logical_backup_storage_account_name:
+                    type: string
+                  logical_backup_storage_container:
+                    type: string
+                  logical_backup_storage_blob:
+                    type: string
+                  logical_backup_storage_account_key:
+                    type: string
               debug:
                 type: object
                 properties:

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -428,6 +428,8 @@ spec:
                     type: string
                   logical_backup_storage_account_key:
                     type: string
+                  logical_backup_cronjob_environment_secret:
+                    type: string
               debug:
                 type: object
                 properties:

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -139,6 +139,10 @@ configuration:
     # logical_backup_s3_secret_access_key: ""
     logical_backup_s3_sse: "AES256"
     logical_backup_schedule: "30 00 * * *"
+    # logical_backup_storage_account_name: ""
+    # logical_backup_storage_container: ""
+    # logical_backup_storage_blob: ""
+    # logical_backup_storage_account_key: ""
   debug:
     debug_logging: true
     enable_database_access: true

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -143,6 +143,7 @@ configuration:
     # logical_backup_storage_container: ""
     # logical_backup_storage_blob: ""
     # logical_backup_storage_account_key: ""
+    # logical_backup_cronjob_environment_secret: ""
   debug:
     debug_logging: true
     enable_database_access: true

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1415,6 +1415,9 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 							"logical_backup_storage_account_key": {
 								Type: "string",
 							},
+							"logical_backup_cronjob_environment_secret": {
+								Type: "string",
+							},
 						},
 					},
 					"debug": {

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1403,6 +1403,18 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 								Type:    "string",
 								Pattern: "^(\\d+|\\*)(/\\d+)?(\\s+(\\d+|\\*)(/\\d+)?){4}$",
 							},
+							"logical_backup_storage_account_name": {
+								Type: "string",
+							},
+							"logical_backup_storage_container": {
+								Type: "string",
+							},
+							"logical_backup_storage_blob": {
+								Type: "string",
+							},
+							"logical_backup_storage_account_key": {
+								Type: "string",
+							},
 						},
 					},
 					"debug": {

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -210,6 +210,11 @@ type OperatorLogicalBackupConfiguration struct {
 	S3SSE                        string `json:"logical_backup_s3_sse,omitempty"`
 	GoogleApplicationCredentials string `json:"logical_backup_google_application_credentials,omitempty"`
 	JobPrefix                    string `json:"logical_backup_job_prefix,omitempty"`
+	StorageAccountName           string `json:"logical_backup_storage_account_name,omitempty"`
+	StorageContainer             string `json:"logical_backup_storage_container,omitempty"`
+	StorageBlob                  string `json:"logical_backup_storage_blob,omitempty"`
+	StorageAccountKey            string `json:"logical_backup_storage_account_key,omitempty"`
+	CronjobEnvironmentSecret     string `json:"logical_backup_cronjob_environment_secret,omitempty"`
 }
 
 // OperatorConfigurationData defines the operation config

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -906,6 +906,37 @@ func (c *Cluster) getPodEnvironmentSecretVariables() ([]v1.EnvVar, error) {
 	return secretPodEnvVarsList, nil
 }
 
+// Return list of variables the cronjob received from the configured Secret
+func (c *Cluster) getCronjobEnvironmentSecretVariables() ([]v1.EnvVar, error) {
+	secretCronjobEnvVarsList := make([]v1.EnvVar, 0)
+
+	if c.OpConfig.LogicalBackupCronjobEnvironmentSecret == "" {
+		return secretCronjobEnvVarsList, nil
+	}
+
+	secret, err := c.KubeClient.Secrets(c.Namespace).Get(
+		context.TODO(),
+		c.OpConfig.LogicalBackupCronjobEnvironmentSecret,
+		metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not read Secret CronjobEnvironmentSecretName: %v", err)
+	}
+
+	for k := range secret.Data {
+		secretCronjobEnvVarsList = append(secretCronjobEnvVarsList,
+			v1.EnvVar{Name: k, ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: c.OpConfig.LogicalBackupCronjobEnvironmentSecret,
+					},
+					Key: k,
+				},
+			}})
+	}
+
+	return secretCronjobEnvVarsList, nil
+}
+
 func getSidecarContainer(sidecar acidv1.Sidecar, index int, resources *v1.ResourceRequirements) *v1.Container {
 	name := sidecar.Name
 	if name == "" {
@@ -1945,7 +1976,14 @@ func (c *Cluster) generateLogicalBackupJob() (*batchv1beta1.CronJob, error) {
 		return nil, fmt.Errorf("could not generate resource requirements for logical backup pods: %v", err)
 	}
 
+	secretEnvVarsList, err := c.getCronjobEnvironmentSecretVariables()
+	if err != nil {
+		return nil, err
+	}
+
 	envVars := c.generateLogicalBackupPodEnvVars()
+	envVars = append(envVars, secretEnvVarsList...)
+
 	logicalBackupContainer := generateContainer(
 		"logical-backup",
 		&c.OpConfig.LogicalBackup.LogicalBackupDockerImage,

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2092,6 +2092,22 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 			Name:  "LOGICAL_BACKUP_GOOGLE_APPLICATION_CREDENTIALS",
 			Value: c.OpConfig.LogicalBackup.LogicalBackupGoogleApplicationCredentials,
 		},
+		{
+			Name:  "LOGICAL_BACKUP_STORAGE_ACCOUNT_NAME",
+			Value: c.OpConfig.LogicalBackup.LogicalBackupStorageAccountName,
+		},
+		{
+			Name:  "LOGICAL_BACKUP_STORAGE_CONTAINER",
+			Value: c.OpConfig.LogicalBackup.LogicalBackupStorageContainer,
+		},
+		{
+			Name:  "LOGICAL_BACKUP_STORAGE_BLOB",
+			Value: c.OpConfig.LogicalBackup.LogicalBackupStorageBlob,
+		},
+		{
+			Name:  "LOGICAL_BACKUP_STORAGE_ACCOUNT_KEY",
+			Value: c.OpConfig.LogicalBackup.LogicalBackupStorageAccountKey,
+		},
 		// Postgres env vars
 		{
 			Name:  "PG_VERSION",

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -645,8 +645,9 @@ func TestSecretVolume(t *testing.T) {
 }
 
 const (
-	testPodEnvironmentConfigMapName = "pod_env_cm"
-	testPodEnvironmentSecretName    = "pod_env_sc"
+	testPodEnvironmentConfigMapName  = "pod_env_cm"
+	testPodEnvironmentSecretName     = "pod_env_sc"
+	testCronjobEnvironmentSecretName = "pod_env_sc"
 )
 
 type mockSecret struct {
@@ -836,6 +837,85 @@ func TestPodEnvironmentSecretVariables(t *testing.T) {
 	for _, tt := range tests {
 		c := newMockCluster(tt.opConfig)
 		vars, err := c.getPodEnvironmentSecretVariables()
+		sort.Slice(vars, func(i, j int) bool { return vars[i].Name < vars[j].Name })
+		if !reflect.DeepEqual(vars, tt.envVars) {
+			t.Errorf("%s %s: expected `%v` but got `%v`",
+				testName, tt.subTest, tt.envVars, vars)
+		}
+		if tt.err != nil {
+			if err.Error() != tt.err.Error() {
+				t.Errorf("%s %s: expected error `%v` but got `%v`",
+					testName, tt.subTest, tt.err, err)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("%s %s: expected no error but got error: `%v`",
+					testName, tt.subTest, err)
+			}
+		}
+	}
+
+}
+
+// Test if the keys of an existing secret are properly referenced
+func TestCronjobEnvironmentSecretVariables(t *testing.T) {
+	testName := "TestCronjobEnvironmentSecretVariables"
+	tests := []struct {
+		subTest  string
+		opConfig config.Config
+		envVars  []v1.EnvVar
+		err      error
+	}{
+		{
+			subTest: "No CronjobEnvironmentSecret configured",
+			envVars: []v1.EnvVar{},
+		},
+		{
+			subTest: "Secret referenced by CronjobEnvironmentSecret does not exist",
+			opConfig: config.Config{
+				LogicalBackup: config.LogicalBackup{
+					LogicalBackupCronjobEnvironmentSecret: "idonotexist",
+				},
+			},
+			err: fmt.Errorf("could not read Secret CronjobEnvironmentSecretName: Secret PodEnvironmentSecret not found"),
+		},
+		{
+			subTest: "Cronjob environment vars reference all keys from secret configured by CronjobEnvironmentSecret",
+			opConfig: config.Config{
+				LogicalBackup: config.LogicalBackup{
+					LogicalBackupCronjobEnvironmentSecret: testCronjobEnvironmentSecretName,
+				},
+			},
+			envVars: []v1.EnvVar{
+				{
+					Name: "minio_access_key",
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: testCronjobEnvironmentSecretName,
+							},
+							Key: "minio_access_key",
+						},
+					},
+				},
+				{
+					Name: "minio_secret_key",
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: testCronjobEnvironmentSecretName,
+							},
+							Key: "minio_secret_key",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		c := newMockCluster(tt.opConfig)
+		vars, err := c.getCronjobEnvironmentSecretVariables()
 		sort.Slice(vars, func(i, j int) bool { return vars[i].Name < vars[j].Name })
 		if !reflect.DeepEqual(vars, tt.envVars) {
 			t.Errorf("%s %s: expected `%v` but got `%v`",

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -165,6 +165,11 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.LogicalBackupS3SSE = fromCRD.LogicalBackup.S3SSE
 	result.LogicalBackupGoogleApplicationCredentials = fromCRD.LogicalBackup.GoogleApplicationCredentials
 	result.LogicalBackupJobPrefix = util.Coalesce(fromCRD.LogicalBackup.JobPrefix, "logical-backup-")
+	result.LogicalBackupStorageAccountName = fromCRD.LogicalBackup.StorageAccountName
+	result.LogicalBackupStorageAccountKey = fromCRD.LogicalBackup.StorageAccountKey
+	result.LogicalBackupStorageBlob = fromCRD.LogicalBackup.StorageBlob
+	result.LogicalBackupStorageContainer = fromCRD.LogicalBackup.StorageContainer
+	result.LogicalBackupCronjobEnvironmentSecret = fromCRD.LogicalBackup.CronjobEnvironmentSecret
 
 	// debug config
 	result.DebugLogging = fromCRD.OperatorDebug.DebugLogging

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -128,6 +128,7 @@ type LogicalBackup struct {
 	LogicalBackupStorageContainer             string `name:"logical_backup_storage_container" default:""`
 	LogicalBackupStorageBlob                  string `name:"logical_backup_storage_blob" default:""`
 	LogicalBackupStorageAccountKey            string `name:"logical_backup_storage_account_key" default:""`
+	LogicalBackupCronjobEnvironmentSecret     string `name:"logical_backup_cronjob_environment_secret" default:""`
 }
 
 // Operator options for connection pooler

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -124,6 +124,10 @@ type LogicalBackup struct {
 	LogicalBackupS3SSE                        string `name:"logical_backup_s3_sse" default:""`
 	LogicalBackupGoogleApplicationCredentials string `name:"logical_backup_google_application_credentials" default:""`
 	LogicalBackupJobPrefix                    string `name:"logical_backup_job_prefix" default:"logical-backup-"`
+	LogicalBackupStorageAccountName           string `name:"logical_backup_storage_account_name" default:""`
+	LogicalBackupStorageContainer             string `name:"logical_backup_storage_container" default:""`
+	LogicalBackupStorageBlob                  string `name:"logical_backup_storage_blob" default:""`
+	LogicalBackupStorageAccountKey            string `name:"logical_backup_storage_account_key" default:""`
 }
 
 // Operator options for connection pooler


### PR DESCRIPTION
This PR adds support for logical backups to be pushed to Azure

In the backup script used to create a logical backup and push to cloud, I had to temporarily write the logical backup to a file in tmp, because Azure's cli cannot by upload data from stdin to a file in a storage account.
There is an extension that can do so, but this extension only works with strings, and fails when you pipe the result of the compress to it. (https://github.com/Azure/azure-cli-extensions/blob/main/src/storage-blob-preview/azext_storage_blob_preview/_help.py#L172) 

I also added an option to add a secret as env variables, like for the postgres pod. It makes the cronjobs easier to use in my opinion, and it was also not possible to mount the config file for AZ in the cronjob pod, because azure tries to write to the config folder, and k8s mounts it into a readonly directory.