### PR TITLE
Add user facing ClusterRoles to Helm chart

### DIFF
--- a/charts/postgres-operator/templates/user-facing-clusterroles.yaml
+++ b/charts/postgres-operator/templates/user-facing-clusterroles.yaml
@@ -1,0 +1,71 @@
+{{ if .Values.rbac.createAggregateClusterRoles }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
+    helm.sh/chart: {{ template "postgres-operator.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ template "postgres-operator.fullname" . }}:users:admin
+rules:
+- apiGroups:
+  - acid.zalan.do
+  resources:
+  - postgresqls
+  - postgresqls/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
+    helm.sh/chart: {{ template "postgres-operator.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ template "postgres-operator.fullname" . }}:users:edit
+rules:
+- apiGroups:
+  - acid.zalan.do
+  resources:
+  - postgresqls
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
+    helm.sh/chart: {{ template "postgres-operator.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ template "postgres-operator.fullname" . }}:users:view
+rules:
+- apiGroups:
+  - acid.zalan.do
+  resources:
+  - postgresqls
+  - postgresqls/status
+  verbs:
+  - get
+  - list
+  - watch
+{{ end }}

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -361,6 +361,8 @@ configConnectionPooler:
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
+  # Specifies whether ClusterRoles that are aggregated into the K8s default roles should be created. (https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings)
+  createAggregateClusterRoles: false
 
 crd:
   # Specifies whether custom resource definitions should be created

--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -291,6 +291,8 @@ kubectl create -f manifests/user-facing-clusterroles.yaml
 It creates zalando-postgres-operator:user:view, :edit and :admin clusterroles
 that are aggregated into the K8s [default roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings).
 
+For Helm deployments setting `rbac.createAggregateClusterRoles: true` adds these clusterroles to the deployment.
+
 ## Use taints and tolerations for dedicated PostgreSQL nodes
 
 To ensure Postgres pods are running on nodes without any other application pods,
@@ -762,7 +764,7 @@ WALE_S3_PREFIX=$WAL_S3_BUCKET/spilo/{WAL_BUCKET_SCOPE_PREFIX}{SCOPE}{WAL_BUCKET_
 ```
 
 The operator sets the prefix to an empty string so that spilo will generate it
-from the configured `WAL_S3_BUCKET`. 
+from the configured `WAL_S3_BUCKET`.
 
 :warning: When you overwrite the configuration by defining `WAL_S3_BUCKET` in
 the [pod_environment_configmap](#custom-pod-environment-variables) you have


### PR DESCRIPTION
To allow the usage of the [aggregate ClusterRoles](https://github.com/zalando/postgres-operator/blob/master/manifests/user-facing-clusterroles.yaml), an option in the Helm chart is added.

Fixes https://github.com/zalando/postgres-operator/issues/1668