### PR TITLE
Provide a bit more flexibility for where images live

### DIFF
--- a/charts/postgres-operator/templates/operatorconfiguration.yaml
+++ b/charts/postgres-operator/templates/operatorconfiguration.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 configuration:
+  docker_image: {{ .Values.spilo_image.registry }}/{{ .Values.spilo_image.repository }}{{ .Values.spilo_image.tag }}
 {{ toYaml .Values.configGeneral | indent 2 }}
   users:
 {{ toYaml .Values.configUsers | indent 4 }}
@@ -31,6 +32,7 @@ configuration:
   aws_or_gcp:
 {{ toYaml .Values.configAwsOrGcp | indent 4 }}
   logical_backup:
+    logical_backup_docker_image: {{ .Values.logical_image.registry }}/{{ .Values.logical_image.repository }}:{{ .Values.logical_image.tag }}
 {{ toYaml .Values.configLogicalBackup | indent 4 }}
   debug:
 {{ toYaml .Values.configDebug | indent 4 }}
@@ -39,5 +41,6 @@ configuration:
   logging_rest_api:
 {{ toYaml .Values.configLoggingRestApi | indent 4 }}
   connection_pooler:
+    connection_pooler_image: {{ .Values.pooler_image.registry }}/{{ .Values.pooler_image.repository }}:{{ .Values.pooler_image.tag }}
 {{ toYaml .Values.configConnectionPooler | indent 4 }}
 {{- end }}

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -1,8 +1,27 @@
+# Operator image
 image:
   registry: registry.opensource.zalan.do
   repository: acid/postgres-operator
   tag: v1.7.1
   pullPolicy: "IfNotPresent"
+
+# image for pods of the logical backup job (example runs pg_dumpall)
+logical_image:
+  registry: registry.opensource.zalan.do
+  repository: acid/logical-backup
+  tag: v1.7.1
+
+# Spilo docker image
+spilo_image:
+  registry: registry.opensource.zalan.do
+  repository: acid/spilo-
+  tag: 14:2.1-p3
+
+# connection pooler docker image
+pooler_image:
+  registry: registry.opensource.zalan.do
+  repository: acid/pgbouncer
+  tag: master-19
 
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.
@@ -34,8 +53,7 @@ configGeneral:
   etcd_host: ""
   # Select if setup uses endpoints (default), or configmaps to manage leader (DCS=k8s)
   # kubernetes_use_configmaps: false
-  # Spilo docker image
-  docker_image: registry.opensource.zalan.do/acid/spilo-14:2.1-p3
+
   # min number of instances in Postgres cluster. -1 = no limit
   min_instances: -1
   # max number of instances in Postgres cluster. -1 = no limit
@@ -279,8 +297,6 @@ configAwsOrGcp:
 
 # configure K8s cron job managed by the operator
 configLogicalBackup:
-  # image for pods of the logical backup job (example runs pg_dumpall)
-  logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.7.1"
   # path of google cloud service account json file
   # logical_backup_google_application_credentials: ""
 
@@ -344,8 +360,6 @@ configConnectionPooler:
   connection_pooler_schema: "pooler"
   # db user for pooler to use
   connection_pooler_user: "pooler"
-  # docker image
-  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-19"
   # max db connections the pooler should hold
   connection_pooler_max_db_connections: 60
   # default pooling mode


### PR DESCRIPTION
Proposed helm chart changes would allow to just update image tags and not have to touch the rest of the values.

This just mirrors how the operator image is derived.  Very useful if you have code to mirror images locally to your own docker repos.  (If you use something like [docker-mirror](https://github.com/seatgeek/docker-mirror))