### PR TITLE
Fix typo on postgres-operator-ui values

### DIFF
--- a/charts/postgres-operator-ui/values.yaml
+++ b/charts/postgres-operator-ui/values.yaml
@@ -39,7 +39,7 @@ resources:
 
 # configure UI ENVs
 envs:
-  # IMPORTANT: While operator chart and UI chart are idendependent, this is the interface between
+  # IMPORTANT: While operator chart and UI chart are independent, this is the interface between
   # UI and operator API. Insert the service name of the operator API here!
   operatorApiUrl: "http://postgres-operator:8080"
   operatorClusterNameLabel: "cluster-name"


### PR DESCRIPTION
`idendependent` -> `independent`