### PR TITLE
Adds required Azure backup env variable WALG_AZ_PREFIX to documentation

### DIFF
--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -885,6 +885,7 @@ data:
   USE_WALG_BACKUP: "true"
   USE_WALG_RESTORE: "true"
   CLONE_USE_WALG_RESTORE: "true"
+  WALG_AZ_PREFIX: "azure://container-name/$(SCOPE)/$(PGVERSION)" # Enables Azure Backups (SCOPE = Cluster name) (PGVERSION = Postgres version) 
 ```
 
 3. Setup your operator configuration values. With the `psql-backup-creds`


### PR DESCRIPTION
Current documentation in the postgres-operator fails to mention that WALG_AZ_PREFIX enables Azure Backups. This is a simple fix for the documentation so others won't be stranded.

Spilo image env variables: (https://github.com/zalando/spilo/blob/master/ENVIRONMENT.rst)