### PR TITLE
Add log messages for usernames

### DIFF
--- a/docs/user.md
+++ b/docs/user.md
@@ -141,14 +141,18 @@ other roles.
 
 To define the secrets for the users in a different namespace than that of the
 cluster, one can set `enable_cross_namespace_secret` and declare the namespace
-for the secrets in the manifest in the following manner,
+for the secrets in the manifest in the following manner (note, that it has to
+be reflected in the `database` section, too),
 
 ```yaml
 spec:
   users:
-  #users with secret in dfferent namespace
-   appspace.db_user:
+    # users with secret in different namespace
+    appspace.db_user:
     - createdb
+  databases:
+    # namespace notation is part of user name
+    app_db: appspace.db_user
 ```
 
 Here, anything before the first dot is considered the namespace and the text after
@@ -554,7 +558,8 @@ schema creation. This means they are currently not set when `defaultUsers`
 For all LOGIN roles the operator will create K8s secrets in the namespace
 specified in `secretNamespace`, if `enable_cross_namespace_secret` is set to
 `true` in the config. Otherwise, they are created in the same namespace like
-the Postgres cluster.
+the Postgres cluster. Unlike roles specified with `namespace.username` under
+`users`, the namespace will not be part of the role name here.
 
 ```yaml
 spec:

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1118,6 +1118,7 @@ func (c *Cluster) initDefaultRoles(defaultRoles map[string]string, admin, prefix
 		if secretNamespace != "" {
 			if c.Config.OpConfig.EnableCrossNamespaceSecret {
 				namespace = secretNamespace
+				c.logger.Warningf("enable_cross_namespace_secret is set. Hence username contains the respective namespace i.e. %s is the created user", prefix+defaultRole)
 			} else {
 				c.logger.Warn("secretNamespace ignored because enable_cross_namespace_secret set to false. Creating secrets in cluster namespace.")
 			}
@@ -1176,6 +1177,7 @@ func (c *Cluster) initRobotUsers() error {
 			if strings.Contains(username, ".") {
 				splits := strings.Split(username, ".")
 				namespace = splits[0]
+				c.logger.Warningf("enable_cross_namespace_secret is set. Hence username contains the respective namespace i.e. %s is the created user", username)
 			}
 		}
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1118,7 +1118,6 @@ func (c *Cluster) initDefaultRoles(defaultRoles map[string]string, admin, prefix
 		if secretNamespace != "" {
 			if c.Config.OpConfig.EnableCrossNamespaceSecret {
 				namespace = secretNamespace
-				c.logger.Warningf("enable_cross_namespace_secret is set. Hence username contains the respective namespace i.e. %s is the created user", prefix+defaultRole)
 			} else {
 				c.logger.Warn("secretNamespace ignored because enable_cross_namespace_secret set to false. Creating secrets in cluster namespace.")
 			}
@@ -1177,7 +1176,7 @@ func (c *Cluster) initRobotUsers() error {
 			if strings.Contains(username, ".") {
 				splits := strings.Split(username, ".")
 				namespace = splits[0]
-				c.logger.Warningf("enable_cross_namespace_secret is set. Hence username contains the respective namespace i.e. %s is the created user", username)
+				c.logger.Warningf("enable_cross_namespace_secret is set. Database role name contains the respective namespace i.e. %s is the created user", username)
 			}
 		}
 


### PR DESCRIPTION
If enable_cross_namespaced_secret is set then emit log messages that the created username is with the namespace.

fixes #1684