### PR TITLE
Operator fails with nil pointer dereference when CR validation is not passed

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -95,7 +95,9 @@ func NewController(controllerConfig *spec.ControllerConfig, controllerId string)
 	// disabling the sending of events also to the logoutput
 	// the operator currently duplicates a lot of log entries with this setup
 	// eventBroadcaster.StartLogging(logger.Infof)
-	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: myComponentName})
+	scheme := scheme.Scheme
+	acidv1.AddToScheme(scheme)
+	recorder := eventBroadcaster.NewRecorder(scheme, v1.EventSource{Component: myComponentName})
 
 	c := &Controller{
 		config:           *controllerConfig,


### PR DESCRIPTION
fixes #1696 