### PR TITLE
Initialize arrays of errors / error messages + minor refactoring

### DIFF
--- a/pkg/cluster/connection_pooler.go
+++ b/pkg/cluster/connection_pooler.go
@@ -712,7 +712,8 @@ func (c *Cluster) syncConnectionPooler(oldSpec, newSpec *acidv1.Postgresql, Look
 	if (!needSync && len(masterChanges) <= 0 && len(replicaChanges) <= 0) &&
 		((!needConnectionPooler(&newSpec.Spec) && (c.ConnectionPooler == nil || !needConnectionPooler(&oldSpec.Spec))) ||
 			(c.ConnectionPooler != nil && needConnectionPooler(&newSpec.Spec) &&
-				(c.ConnectionPooler[Master].LookupFunction || c.ConnectionPooler[Replica].LookupFunction))) {
+				((c.ConnectionPooler[Master] != nil && c.ConnectionPooler[Master].LookupFunction) ||
+					(c.ConnectionPooler[Replica] != nil && c.ConnectionPooler[Replica].LookupFunction)))) {
 		c.logger.Debugln("syncing pooler is not required")
 		return nil, nil
 	}

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -496,17 +496,16 @@ func (c *Cluster) deleteEndpoint(role PostgresRole) error {
 
 func (c *Cluster) deleteSecrets() error {
 	c.setProcessName("deleting secrets")
-	var errors []string
-	errorCount := 0
+	errors := make([]string, 0)
+
 	for uid, secret := range c.Secrets {
 		err := c.deleteSecret(uid, *secret)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("%v", err))
-			errorCount++
 		}
 	}
 
-	if errorCount > 0 {
+	if len(errors) > 0 {
 		return fmt.Errorf("could not delete all secrets: %v", errors)
 	}
 

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -506,7 +506,7 @@ func (c *Cluster) deleteSecrets() error {
 	}
 
 	if len(errors) > 0 {
-		return fmt.Errorf("could not delete all secrets: %v", errors)
+		return fmt.Errorf("could not delete all secrets: %v", strings.Join(errors, `', '`))
 	}
 
 	return nil

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -196,17 +196,15 @@ func TestCheckAndSetGlobalPostgreSQLConfiguration(t *testing.T) {
 	cluster.patroni = p
 	mockPod := newMockPod("192.168.100.1")
 
-	// simulate existing config that differs with cluster.Spec
+	// simulate existing config that differs from cluster.Spec
 	tests := []struct {
 		subtest       string
-		pod           *v1.Pod
 		patroni       acidv1.Patroni
 		pgParams      map[string]string
 		restartMaster bool
 	}{
 		{
 			subtest: "Patroni and Postgresql.Parameters differ - restart replica first",
-			pod:     mockPod,
 			patroni: acidv1.Patroni{
 				TTL: 30, // desired 20
 			},
@@ -218,7 +216,6 @@ func TestCheckAndSetGlobalPostgreSQLConfiguration(t *testing.T) {
 		},
 		{
 			subtest: "multiple Postgresql.Parameters differ - restart replica first",
-			pod:     mockPod,
 			patroni: acidv1.Patroni{
 				TTL: 20,
 			},
@@ -230,7 +227,6 @@ func TestCheckAndSetGlobalPostgreSQLConfiguration(t *testing.T) {
 		},
 		{
 			subtest: "desired max_connections bigger - restart replica first",
-			pod:     mockPod,
 			patroni: acidv1.Patroni{
 				TTL: 20,
 			},
@@ -242,7 +238,6 @@ func TestCheckAndSetGlobalPostgreSQLConfiguration(t *testing.T) {
 		},
 		{
 			subtest: "desired max_connections smaller - restart master first",
-			pod:     mockPod,
 			patroni: acidv1.Patroni{
 				TTL: 20,
 			},
@@ -255,7 +250,7 @@ func TestCheckAndSetGlobalPostgreSQLConfiguration(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		requireMasterRestart, err := cluster.checkAndSetGlobalPostgreSQLConfiguration(tt.pod, tt.patroni, tt.pgParams)
+		requireMasterRestart, err := cluster.checkAndSetGlobalPostgreSQLConfiguration(mockPod, tt.patroni, tt.pgParams)
 		assert.NoError(t, err)
 		if requireMasterRestart != tt.restartMaster {
 			t.Errorf("%s - %s: unexpect master restart strategy, got %v, expected %v", testName, tt.subtest, requireMasterRestart, tt.restartMaster)

--- a/pkg/cluster/volumes.go
+++ b/pkg/cluster/volumes.go
@@ -88,7 +88,7 @@ func (c *Cluster) syncUnderlyingEBSVolume() error {
 	awsGp3 := aws.String("gp3")
 	awsIo2 := aws.String("io2")
 
-	errors := []string{}
+	errors := make([]string, 0)
 
 	for _, volume := range c.EBSVolumes {
 		var modifyIops *int64

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -195,9 +195,9 @@ func (c *Controller) getInfrastructureRoleDefinitions() []*config.Infrastructure
 
 func (c *Controller) getInfrastructureRoles(
 	rolesSecrets []*config.InfrastructureRole) (
-	map[string]spec.PgUser, []error) {
+	map[string]spec.PgUser, error) {
 
-	errors := make([]error, 0)
+	errors := make([]string, 0)
 	noRolesProvided := true
 	roles := []spec.PgUser{}
 	uniqRoles := map[string]spec.PgUser{}
@@ -220,30 +220,32 @@ func (c *Controller) getInfrastructureRoles(
 		infraRoles, err := c.getInfrastructureRole(secret)
 
 		if err != nil || infraRoles == nil {
-			c.logger.Debugf("Cannot get infrastructure role: %+v", *secret)
+			c.logger.Debugf("cannot get infrastructure role: %+v", *secret)
 
 			if err != nil {
-				errors = append(errors, err)
+				errors = append(errors, fmt.Sprintf("%v", err))
 			}
 
 			continue
 		}
 
-		for _, r := range infraRoles {
-			roles = append(roles, r)
-		}
+		roles = append(roles, infraRoles...)
 	}
 
 	for _, r := range roles {
 		if _, exists := uniqRoles[r.Name]; exists {
-			msg := "Conflicting infrastructure roles: roles[%s] = (%q, %q)"
+			msg := "conflicting infrastructure roles: roles[%s] = (%q, %q)"
 			c.logger.Debugf(msg, r.Name, uniqRoles[r.Name], r)
 		}
 
 		uniqRoles[r.Name] = r
 	}
 
-	return uniqRoles, errors
+	if len(errors) > 0 {
+		return nil, fmt.Errorf(strings.Join(errors, `', '`))
+	}
+
+	return uniqRoles, nil
 }
 
 // Generate list of users representing one infrastructure role based on its

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -229,7 +229,9 @@ func (c *Controller) getInfrastructureRoles(
 			continue
 		}
 
-		roles = append(roles, infraRoles...)
+		for _, r := range infraRoles {
+			roles = append(roles, r)
+		}
 	}
 
 	for _, r := range roles {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -197,9 +197,8 @@ func (c *Controller) getInfrastructureRoles(
 	rolesSecrets []*config.InfrastructureRole) (
 	map[string]spec.PgUser, []error) {
 
-	var errors []error
-	var noRolesProvided = true
-
+	errors := make([]error, 0)
+	noRolesProvided := true
 	roles := []spec.PgUser{}
 	uniqRoles := map[string]spec.PgUser{}
 
@@ -230,9 +229,7 @@ func (c *Controller) getInfrastructureRoles(
 			continue
 		}
 
-		for _, r := range infraRoles {
-			roles = append(roles, r)
-		}
+		roles = append(roles, infraRoles...)
 	}
 
 	for _, r := range roles {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -200,7 +200,7 @@ func (c *Controller) getInfrastructureRoles(
 	errors := make([]string, 0)
 	noRolesProvided := true
 	roles := []spec.PgUser{}
-	uniqRoles := map[string]spec.PgUser{}
+	uniqRoles := make(map[string]spec.PgUser)
 
 	// To be compatible with the legacy implementation we need to return nil if
 	// the provided secret name is empty. The equivalent situation in the
@@ -213,7 +213,7 @@ func (c *Controller) getInfrastructureRoles(
 	}
 
 	if noRolesProvided {
-		return nil, nil
+		return uniqRoles, nil
 	}
 
 	for _, secret := range rolesSecrets {
@@ -242,7 +242,7 @@ func (c *Controller) getInfrastructureRoles(
 	}
 
 	if len(errors) > 0 {
-		return nil, fmt.Errorf(strings.Join(errors, `', '`))
+		return uniqRoles, fmt.Errorf(strings.Join(errors, `', '`))
 	}
 
 	return uniqRoles, nil

--- a/pkg/util/users/users.go
+++ b/pkg/util/users/users.go
@@ -138,7 +138,7 @@ func (strategy DefaultUserSyncStrategy) ExecuteSyncRequests(requests []spec.PgSy
 				return err
 			}
 		} else {
-			return fmt.Errorf("could not execute sync requests for users: %v", errors)
+			return fmt.Errorf("could not execute sync requests for users: %v", strings.Join(errors, `', '`))
 		}
 	}
 

--- a/pkg/util/users/users.go
+++ b/pkg/util/users/users.go
@@ -101,7 +101,7 @@ func (strategy DefaultUserSyncStrategy) ProduceSyncRequests(dbUsers spec.PgUserM
 // ExecuteSyncRequests makes actual database changes from the requests passed in its arguments.
 func (strategy DefaultUserSyncStrategy) ExecuteSyncRequests(requests []spec.PgSyncUserRequest, db *sql.DB) error {
 	var reqretries []spec.PgSyncUserRequest
-	var errors []string
+	errors := make([]string, 0)
 	for _, request := range requests {
 		switch request.Kind {
 		case spec.PGSyncUserAdd:


### PR DESCRIPTION
1. In different places we are collecting errors in an array. It should be initialized correctly with make.
2. Minor refactoring in `patroni_test` 
3. fixes #1681 