### PR TITLE
Add custom annotations to postgres-operator-ui objects

### DIFF
--- a/charts/postgres-operator-ui/templates/deployment.yaml
+++ b/charts/postgres-operator-ui/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "postgres-operator-ui.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "postgres-operator-ui.serviceAccountName" . }}
       {{- if .Values.imagePullSecrets }}

--- a/charts/postgres-operator-ui/templates/service.yaml
+++ b/charts/postgres-operator-ui/templates/service.yaml
@@ -6,6 +6,10 @@ metadata:
     helm.sh/chart: {{ template "postgres-operator-ui.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ template "postgres-operator-ui.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/postgres-operator-ui/values.yaml
+++ b/charts/postgres-operator-ui/values.yaml
@@ -85,6 +85,8 @@ service:
   # If the type of the service is NodePort a port can be specified using the nodePort field
   # If the nodePort field is not specified, or if it has no value, then a random port is used
   # nodePort: 32521
+  annotations:
+    {}
 
 # configure UI ingress. If needed: "enabled: true"
 ingress:

--- a/charts/postgres-operator-ui/values.yaml
+++ b/charts/postgres-operator-ui/values.yaml
@@ -48,6 +48,10 @@ envs:
   teams:
     - "acid"
 
+# Extra pod annotations
+podAnnotations:
+  {}
+
 # configure extra UI ENVs
 # Extra ENVs are writen in kubenertes format and added "as is" to the pod's env variables
 # https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/


### PR DESCRIPTION
This PR adds variables to the helm chart of postgres-operator-ui to be able to set custom annotations on both the service and the pods.

Fixes #1747