### PR TITLE
Compare container ports in a smarter way

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -516,7 +516,7 @@ func (c *Cluster) compareContainers(description string, setA, setB []v1.Containe
 		newCheck("new statefulset %s's %s (index %d) name does not match the current one",
 			func(a, b v1.Container) bool { return a.Name != b.Name }),
 		newCheck("new statefulset %s's %s (index %d) ports do not match the current one",
-			func(a, b v1.Container) bool { return !reflect.DeepEqual(a.Ports, b.Ports) }),
+			func(a, b v1.Container) bool { return !comparePorts(a.Ports, b.Ports) }),
 		newCheck("new statefulset %s's %s (index %d) resources do not match the current ones",
 			func(a, b v1.Container) bool { return !compareResources(&a.Resources, &b.Resources) }),
 		newCheck("new statefulset %s's %s (index %d) environment does not match the current one",
@@ -625,6 +625,46 @@ func compareSpiloConfiguration(configa, configb string) bool {
 	}
 	ob.Bootstrap.DCS = patroniDCS{}
 	return reflect.DeepEqual(oa, ob)
+}
+
+func areProtocolsEqual(a, b v1.Protocol) bool {
+	return a == b ||
+		(a == "" && b == v1.ProtocolTCP) ||
+		(a == v1.ProtocolTCP && b == "")
+}
+
+func comparePorts(a, b []v1.ContainerPort) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	areContainerPortsEqual := func(a, b v1.ContainerPort) bool {
+		return a.Name == b.Name &&
+			a.HostPort == b.HostPort &&
+			areProtocolsEqual(a.Protocol, b.Protocol) &&
+			a.HostIP == b.HostIP
+	}
+
+	findByPortValue := func(portSpecs []v1.ContainerPort, port int32) (v1.ContainerPort, bool) {
+		for _, portSpec := range portSpecs {
+			if portSpec.ContainerPort == port {
+				return portSpec, true
+			}
+		}
+		return v1.ContainerPort{}, false
+	}
+
+	for _, portA := range a {
+		portB, found := findByPortValue(b, portA.ContainerPort)
+		if !found {
+			return false
+		}
+		if !areContainerPortsEqual(portA, portB) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (c *Cluster) enforceMinResourceLimits(spec *acidv1.PostgresSpec) error {

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -2,9 +2,10 @@ package cluster
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/sirupsen/logrus"
 	acidv1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1091,170 +1091,101 @@ func TestValidUsernames(t *testing.T) {
 	}
 }
 
-func TestCluster_compareContainers(t *testing.T) {
+func TestClusterComparePorts(t *testing.T) {
 	testCases := []struct {
-		name                    string
-		setA                    []v1.Container
-		setB                    []v1.Container
-		expectedNeedsRollUpdate bool
-		expectedReasons         []string
+		name     string
+		setA     []v1.ContainerPort
+		setB     []v1.ContainerPort
+		expected bool
 	}{
 		{
-			name: "different set sizes",
-			setA: []v1.Container{
-				{Name: "container1"},
-			},
-			setB: []v1.Container{
-				{Name: "container1"},
-				{Name: "container2"},
-			},
-			expectedNeedsRollUpdate: true,
-			expectedReasons: []string{
-				"new statefulset description's length does not match the current ones",
-			},
-		},
-		{
-			name: "different container name",
-			setA: []v1.Container{
-				{Name: "container1"},
-			},
-			setB: []v1.Container{
-				{Name: "container2"},
-			},
-			expectedNeedsRollUpdate: true,
-			expectedReasons: []string{
-				"new statefulset description's container1 (index 0) name does not match the current one",
-			},
-		},
-		{
 			name: "different ports",
-			setA: []v1.Container{
+			setA: []v1.ContainerPort{
 				{
-					Ports: []v1.ContainerPort{
-						{
-							Name:          "metrics",
-							ContainerPort: 9187,
-							Protocol:      v1.ProtocolTCP,
-						},
-					},
+					Name:          "metrics",
+					ContainerPort: 9187,
+					Protocol:      v1.ProtocolTCP,
 				},
 			},
-			setB: []v1.Container{
+
+			setB: []v1.ContainerPort{
 				{
-					Ports: []v1.ContainerPort{
-						{
-							Name:          "http",
-							ContainerPort: 80,
-							Protocol:      v1.ProtocolTCP,
-						},
-					},
+					Name:          "http",
+					ContainerPort: 80,
+					Protocol:      v1.ProtocolTCP,
 				},
 			},
-			expectedNeedsRollUpdate: true,
-			expectedReasons: []string{
-				"new statefulset description's  (index 0) ports do not match the current one",
-			},
+			expected: false,
 		},
 		{
 			name: "no difference",
-			setA: []v1.Container{
+			setA: []v1.ContainerPort{
 				{
-					Name: "container1",
-					Ports: []v1.ContainerPort{
-						{
-							Name:          "metrics",
-							ContainerPort: 9187,
-							Protocol:      v1.ProtocolTCP,
-						},
-					},
+					Name:          "metrics",
+					ContainerPort: 9187,
+					Protocol:      v1.ProtocolTCP,
 				},
 			},
-			setB: []v1.Container{
+			setB: []v1.ContainerPort{
 				{
-					Name: "container1",
-					Ports: []v1.ContainerPort{
-						{
-							Name:          "metrics",
-							ContainerPort: 9187,
-							Protocol:      v1.ProtocolTCP,
-						},
-					},
+					Name:          "metrics",
+					ContainerPort: 9187,
+					Protocol:      v1.ProtocolTCP,
 				},
 			},
-			expectedNeedsRollUpdate: false,
+			expected: true,
 		},
 		{
 			name: "same ports, different order",
-			setA: []v1.Container{
+			setA: []v1.ContainerPort{
 				{
-					Name: "container1",
-					Ports: []v1.ContainerPort{
-						{
-							Name:          "metrics",
-							ContainerPort: 9187,
-							Protocol:      v1.ProtocolTCP,
-						},
-						{
-							Name:          "http",
-							ContainerPort: 80,
-							Protocol:      v1.ProtocolTCP,
-						},
-					},
+					Name:          "metrics",
+					ContainerPort: 9187,
+					Protocol:      v1.ProtocolTCP,
+				},
+				{
+					Name:          "http",
+					ContainerPort: 80,
+					Protocol:      v1.ProtocolTCP,
 				},
 			},
-			setB: []v1.Container{
+			setB: []v1.ContainerPort{
 				{
-					Name: "container1",
-					Ports: []v1.ContainerPort{
-						{
-							Name:          "http",
-							ContainerPort: 80,
-							Protocol:      v1.ProtocolTCP,
-						},
-						{
-							Name:          "metrics",
-							ContainerPort: 9187,
-							Protocol:      v1.ProtocolTCP,
-						},
-					},
+					Name:          "http",
+					ContainerPort: 80,
+					Protocol:      v1.ProtocolTCP,
+				},
+				{
+					Name:          "metrics",
+					ContainerPort: 9187,
+					Protocol:      v1.ProtocolTCP,
 				},
 			},
-			expectedNeedsRollUpdate: false,
+			expected: true,
 		},
 		{
 			name: "same ports, but one with default protocol",
-			setA: []v1.Container{
+			setA: []v1.ContainerPort{
 				{
-					Name: "container1",
-					Ports: []v1.ContainerPort{
-						{
-							Name:          "metrics",
-							ContainerPort: 9187,
-							Protocol:      v1.ProtocolTCP,
-						},
-					},
+					Name:          "metrics",
+					ContainerPort: 9187,
+					Protocol:      v1.ProtocolTCP,
 				},
 			},
-			setB: []v1.Container{
+			setB: []v1.ContainerPort{
 				{
-					Name: "container1",
-					Ports: []v1.ContainerPort{
-						{
-							Name:          "metrics",
-							ContainerPort: 9187,
-						},
-					},
+					Name:          "metrics",
+					ContainerPort: 9187,
 				},
 			},
-			expectedNeedsRollUpdate: false,
+			expected: true,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			needs, reasons := cl.compareContainers("description", testCase.setA, testCase.setB, false, nil)
-			assert.Equal(t, testCase.expectedNeedsRollUpdate, needs)
-			assert.ElementsMatch(t, testCase.expectedReasons, reasons)
+			got := comparePorts(testCase.setA, testCase.setB)
+			assert.Equal(t, testCase.expected, got)
 		})
 	}
 }

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1091,7 +1091,7 @@ func TestValidUsernames(t *testing.T) {
 	}
 }
 
-func TestClusterComparePorts(t *testing.T) {
+func TestComparePorts(t *testing.T) {
 	testCases := []struct {
 		name     string
 		setA     []v1.ContainerPort


### PR DESCRIPTION
This PR makes the comparison of containers' ports a bit smarter: it takes into account default protocol (TCP) and ignores different ports order.

Fixes #1384.