### PR TITLE
Ability to set pod environment variables on cluster resource

### DIFF
--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -196,6 +196,12 @@ spec:
                 type: boolean
               enableShmVolume:
                 type: boolean
+              env:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
               init_containers:
                 type: array
                 description: deprecated

--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -708,11 +708,10 @@ to the Postgres StatefulSet/pods.
 
 ### For individual cluster
 
-It is possible to set environment variables in the Spilo pods directly as parameters or
-as a link to secrets for each individual cluster, in addition to or instead of the
-global parameters given in the examples above.
-
-In order to do this, you need to configure the cluster parameters, as in the example below
+It is possible to define environment variables directly in the Postgres cluster
+manifest to configure it individually. The variables must be listed under the
+`env` section in the same way you would do for [containers](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/).
+Global parameters served from a custom config map or secret will be overridden.
 
 ```yaml
 apiVersion: "acid.zalan.do/v1"

--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -729,11 +729,6 @@ spec:
           key: minio_secret_key
 ```
 
-If global parameters are set at the level of the entire controller in the form of
-a ConfigMap or a Secret, then the individual cluster parameters will have a higher
-priority and the same keys will be overridden, and different ones will be merged into
-a single array of environment variable parameter values.
-
 ## Limiting the number of min and max instances in clusters
 
 As a preventive measure, one can restrict the minimum and the maximum number of

--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -706,6 +706,35 @@ data:
 The key-value pairs of the Secret are all accessible as environment variables
 to the Postgres StatefulSet/pods.
 
+### For individual cluster
+
+It is possible to set environment variables in the Spilo pods directly as parameters or
+as a link to secrets for each individual cluster, in addition to or instead of the
+global parameters given in the examples above.
+
+In order to do this, you need to configure the cluster parameters, as in the example below
+
+```yaml
+apiVersion: "acid.zalan.do/v1"
+kind: postgresql
+metadata:
+  name: acid-test-cluster
+spec:
+  env:
+  - name: wal_s3_bucket
+    value: my-custom-bucket
+  - name: minio_secret_key
+      valueFrom:
+        secretKeyRef:
+          name: my-custom-secret
+          key: minio_secret_key
+```
+
+If global parameters are set at the level of the entire controller in the form of
+a ConfigMap or a Secret, then the individual cluster parameters will have a higher
+priority and the same keys will be overridden, and different ones will be merged into
+a single array of environment variable parameter values.
+
 ## Limiting the number of min and max instances in clusters
 
 As a preventive measure, one can restrict the minimum and the maximum number of

--- a/manifests/complete-postgres-manifest.yaml
+++ b/manifests/complete-postgres-manifest.yaml
@@ -49,6 +49,10 @@ spec:
       shared_buffers: "32MB"
       max_connections: "10"
       log_statement: "all"
+#  env:
+#  - name: wal_s3_bucket
+#    value: my-custom-bucket
+
   volume:
     size: 1Gi
 #    storageClass: my-sc
@@ -120,7 +124,7 @@ spec:
 #        database: foo
 #        plugin: pgoutput
     ttl: 30
-    loop_wait: &loop_wait 10
+    loop_wait: 10
     retry_timeout: 10
     synchronous_mode: false
     synchronous_mode_strict: false

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -194,6 +194,12 @@ spec:
                 type: boolean
               enableShmVolume:
                 type: boolean
+              env:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
               init_containers:
                 type: array
                 description: deprecated

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -311,6 +311,16 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 					"enableShmVolume": {
 						Type: "boolean",
 					},
+					"env": {
+						Type:     "array",
+						Nullable: true,
+						Items: &apiextv1.JSONSchemaPropsOrArray{
+							Schema: &apiextv1.JSONSchemaProps{
+								Type:                   "object",
+								XPreserveUnknownFields: util.True(),
+							},
+						},
+					},
 					"init_containers": {
 						Type:        "array",
 						Description: "deprecated",

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -80,6 +80,7 @@ type PostgresSpec struct {
 	TLS                   *TLSDescription             `json:"tls,omitempty"`
 	AdditionalVolumes     []AdditionalVolume          `json:"additionalVolumes,omitempty"`
 	Streams               []Stream                    `json:"streams,omitempty"`
+	Env                   []v1.EnvVar                 `json:"env,omitempty"`
 
 	// deprecated json tags
 	InitContainersOld       []v1.Container `json:"init_containers,omitempty"`

--- a/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
@@ -779,6 +779,13 @@ func (in *PostgresSpec) DeepCopyInto(out *PostgresSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make([]corev1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.InitContainersOld != nil {
 		in, out := &in.InitContainersOld, &out.InitContainersOld
 		*out = make([]corev1.Container, len(*in))

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -769,7 +769,13 @@ func (c *Cluster) generateSpiloPodEnvVars(
 	cloneDescription *acidv1.CloneDescription,
 	standbyDescription *acidv1.StandbyDescription,
 	customPodEnvVarsList []v1.EnvVar) []v1.EnvVar {
-	envVars := []v1.EnvVar{
+	envVars := make([]v1.EnvVar, 0)
+
+	if len(c.Spec.Env) > 0 {
+		envVars = append(envVars, c.Spec.Env...)
+	}
+
+	envVars = append(envVars, []v1.EnvVar{
 		{
 			Name:  "SCOPE",
 			Value: c.Name,
@@ -842,7 +848,8 @@ func (c *Cluster) generateSpiloPodEnvVars(
 			Name:  "HUMAN_ROLE",
 			Value: c.OpConfig.PamRoleName,
 		},
-	}
+	}...)
+
 	if c.OpConfig.EnablePgVersionEnvVar {
 		envVars = append(envVars, v1.EnvVar{Name: "PGVERSION", Value: c.GetDesiredMajorVersion()})
 	}

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -969,7 +969,7 @@ func (c *Cluster) getPodEnvironmentConfigMapVariables() ([]v1.EnvVar, error) {
 		}
 	}
 	for k, v := range cm.Data {
-		if !isEnvVarExist(configMapPodEnvVarsList, k) {
+		if !isEnvVarPresent(configMapPodEnvVarsList, k) {
 			configMapPodEnvVarsList = append(configMapPodEnvVarsList, v1.EnvVar{Name: k, Value: v})
 		}
 	}
@@ -1015,7 +1015,7 @@ func (c *Cluster) getPodEnvironmentSecretVariables() ([]v1.EnvVar, error) {
 	}
 
 	for k := range secret.Data {
-		if !isEnvVarExist(secretPodEnvVarsList, k) {
+		if !isEnvVarPresent(secretPodEnvVarsList, k) {
 			secretPodEnvVarsList = append(secretPodEnvVarsList,
 				v1.EnvVar{Name: k, ValueFrom: &v1.EnvVarSource{
 					SecretKeyRef: &v1.SecretKeySelector{
@@ -1031,7 +1031,7 @@ func (c *Cluster) getPodEnvironmentSecretVariables() ([]v1.EnvVar, error) {
 	return secretPodEnvVarsList, nil
 }
 
-func isEnvVarExist(envs []v1.EnvVar, key string) bool {
+func isEnvVarPresent(envs []v1.EnvVar, key string) bool {
 	for _, env := range envs {
 		if env.Name == key {
 			return true

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -944,6 +944,10 @@ func deduplicateEnvVars(input []v1.EnvVar, containerName string, logger *logrus.
 func (c *Cluster) getPodEnvironmentConfigMapVariables() ([]v1.EnvVar, error) {
 	configMapPodEnvVarsList := make([]v1.EnvVar, 0)
 
+	if len(c.Spec.Env) > 0 {
+		configMapPodEnvVarsList = append(configMapPodEnvVarsList, c.Spec.Env...)
+	}
+
 	if c.OpConfig.PodEnvironmentConfigMap.Name == "" {
 		return configMapPodEnvVarsList, nil
 	}
@@ -965,7 +969,9 @@ func (c *Cluster) getPodEnvironmentConfigMapVariables() ([]v1.EnvVar, error) {
 		}
 	}
 	for k, v := range cm.Data {
-		configMapPodEnvVarsList = append(configMapPodEnvVarsList, v1.EnvVar{Name: k, Value: v})
+		if !isEnvVarExist(configMapPodEnvVarsList, k) {
+			configMapPodEnvVarsList = append(configMapPodEnvVarsList, v1.EnvVar{Name: k, Value: v})
+		}
 	}
 	return configMapPodEnvVarsList, nil
 }
@@ -973,6 +979,10 @@ func (c *Cluster) getPodEnvironmentConfigMapVariables() ([]v1.EnvVar, error) {
 // Return list of variables the pod received from the configured Secret
 func (c *Cluster) getPodEnvironmentSecretVariables() ([]v1.EnvVar, error) {
 	secretPodEnvVarsList := make([]v1.EnvVar, 0)
+
+	if len(c.Spec.Env) > 0 {
+		secretPodEnvVarsList = append(secretPodEnvVarsList, c.Spec.Env...)
+	}
 
 	if c.OpConfig.PodEnvironmentSecret == "" {
 		return secretPodEnvVarsList, nil
@@ -1005,18 +1015,29 @@ func (c *Cluster) getPodEnvironmentSecretVariables() ([]v1.EnvVar, error) {
 	}
 
 	for k := range secret.Data {
-		secretPodEnvVarsList = append(secretPodEnvVarsList,
-			v1.EnvVar{Name: k, ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: c.OpConfig.PodEnvironmentSecret,
+		if !isEnvVarExist(secretPodEnvVarsList, k) {
+			secretPodEnvVarsList = append(secretPodEnvVarsList,
+				v1.EnvVar{Name: k, ValueFrom: &v1.EnvVarSource{
+					SecretKeyRef: &v1.SecretKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: c.OpConfig.PodEnvironmentSecret,
+						},
+						Key: k,
 					},
-					Key: k,
-				},
-			}})
+				}})
+		}
 	}
 
 	return secretPodEnvVarsList, nil
+}
+
+func isEnvVarExist(envs []v1.EnvVar, key string) bool {
+	for _, env := range envs {
+		if env.Name == key {
+			return true
+		}
+	}
+	return false
 }
 
 func getSidecarContainer(sidecar acidv1.Sidecar, index int, resources *v1.ResourceRequirements) *v1.Container {

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -821,8 +821,9 @@ func newMockKubernetesClient() k8sutil.KubernetesClient {
 		ConfigMapsGetter: &MockConfigMapsGetter{},
 	}
 }
-func newMockCluster(opConfig config.Config) *Cluster {
+func newMockCluster(opConfig config.Config, pgsql acidv1.Postgresql) *Cluster {
 	cluster := &Cluster{
+		Postgresql: pgsql,
 		Config:     Config{OpConfig: opConfig},
 		KubeClient: newMockKubernetesClient(),
 	}
@@ -834,6 +835,7 @@ func TestPodEnvironmentConfigMapVariables(t *testing.T) {
 	tests := []struct {
 		subTest  string
 		opConfig config.Config
+		pgsql    acidv1.Postgresql
 		envVars  []v1.EnvVar
 		err      error
 	}{
@@ -853,7 +855,7 @@ func TestPodEnvironmentConfigMapVariables(t *testing.T) {
 			err: fmt.Errorf("could not read PodEnvironmentConfigMap: NotFound"),
 		},
 		{
-			subTest: "simple PodEnvironmentConfigMap",
+			subTest: "Pod environment vars configured by PodEnvironmentConfigMap",
 			opConfig: config.Config{
 				Resources: config.Resources{
 					PodEnvironmentConfigMap: spec.NamespacedName{
@@ -872,9 +874,62 @@ func TestPodEnvironmentConfigMapVariables(t *testing.T) {
 				},
 			},
 		},
+		{
+			subTest: "Pod environment vars getting from the Postgresql spec EnvVar object",
+			pgsql: acidv1.Postgresql{
+				Spec: acidv1.PostgresSpec{
+					Env: []v1.EnvVar{
+						{
+							Name:  "custom1",
+							Value: "value1",
+						},
+					},
+				},
+			},
+			envVars: []v1.EnvVar{
+				{
+					Name:  "custom1",
+					Value: "value1",
+				},
+			},
+		},
+		{
+			subTest: "Pod environment vars configured by PodEnvironmentConfigMap joined with Postgresql spec EnvVar object",
+			opConfig: config.Config{
+				Resources: config.Resources{
+					PodEnvironmentConfigMap: spec.NamespacedName{
+						Name: testPodEnvironmentConfigMapName,
+					},
+				},
+			},
+			pgsql: acidv1.Postgresql{
+				Spec: acidv1.PostgresSpec{
+					Env: []v1.EnvVar{
+						{
+							Name:  "custom1",
+							Value: "value1",
+						},
+					},
+				},
+			},
+			envVars: []v1.EnvVar{
+				{
+					Name:  "custom1",
+					Value: "value1",
+				},
+				{
+					Name:  "foo1",
+					Value: "bar1",
+				},
+				{
+					Name:  "foo2",
+					Value: "bar2",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
-		c := newMockCluster(tt.opConfig)
+		c := newMockCluster(tt.opConfig, tt.pgsql)
 		vars, err := c.getPodEnvironmentConfigMapVariables()
 		sort.Slice(vars, func(i, j int) bool { return vars[i].Name < vars[j].Name })
 		if !reflect.DeepEqual(vars, tt.envVars) {
@@ -902,6 +957,7 @@ func TestPodEnvironmentSecretVariables(t *testing.T) {
 	tests := []struct {
 		subTest  string
 		opConfig config.Config
+		pgsql    acidv1.Postgresql
 		envVars  []v1.EnvVar
 		err      error
 	}{
@@ -965,10 +1021,105 @@ func TestPodEnvironmentSecretVariables(t *testing.T) {
 				},
 			},
 		},
+		{
+			subTest: "Pod environment vars reference all keys from the Postgresql spec EnvVar object",
+			pgsql: acidv1.Postgresql{
+				Spec: acidv1.PostgresSpec{
+					Env: []v1.EnvVar{
+						{
+							Name: "minio_root_password",
+							ValueFrom: &v1.EnvVarSource{
+								SecretKeyRef: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: testPodEnvironmentSecretName,
+									},
+									Key: "minio_root_password",
+								},
+							},
+						},
+					},
+				},
+			},
+			envVars: []v1.EnvVar{
+				{
+					Name: "minio_root_password",
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: testPodEnvironmentSecretName,
+							},
+							Key: "minio_root_password",
+						},
+					},
+				},
+			},
+		},
+		{
+			subTest: "Pod environment vars reference all keys from the Postgresql spec EnvVar object joined with secret configured by PodEnvironmentSecret",
+			opConfig: config.Config{
+				Resources: config.Resources{
+					PodEnvironmentSecret:  testPodEnvironmentSecretName,
+					ResourceCheckInterval: time.Duration(testResourceCheckInterval),
+					ResourceCheckTimeout:  time.Duration(testResourceCheckTimeout),
+				},
+			},
+			pgsql: acidv1.Postgresql{
+				Spec: acidv1.PostgresSpec{
+					Env: []v1.EnvVar{
+						{
+							Name: "minio_root_password",
+							ValueFrom: &v1.EnvVarSource{
+								SecretKeyRef: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: testPodEnvironmentSecretName,
+									},
+									Key: "minio_root_password",
+								},
+							},
+						},
+					},
+				},
+			},
+			envVars: []v1.EnvVar{
+				{
+					Name: "minio_access_key",
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: testPodEnvironmentSecretName,
+							},
+							Key: "minio_access_key",
+						},
+					},
+				},
+				{
+					Name: "minio_root_password",
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: testPodEnvironmentSecretName,
+							},
+							Key: "minio_root_password",
+						},
+					},
+				},
+				{
+					Name: "minio_secret_key",
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: testPodEnvironmentSecretName,
+							},
+							Key: "minio_secret_key",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
-		c := newMockCluster(tt.opConfig)
+		c := newMockCluster(tt.opConfig, tt.pgsql)
 		vars, err := c.getPodEnvironmentSecretVariables()
 		sort.Slice(vars, func(i, j int) bool { return vars[i].Name < vars[j].Name })
 		if !reflect.DeepEqual(vars, tt.envVars) {


### PR DESCRIPTION
Fixes #1566
Closes #1209
Closes #1422
Closes #907
Closes #1807

Please pay attention, that this PR implementing an individual `[]EnvVar` option to the cluster CR and has higher priority to the cluster `pod_environment_secret` and `pod_environment_configmap` options.

TODO (after approach approve)

- [x] Doc changes
- [x] Unit testing