### PR TITLE
Allow extra customisations of pod security policies in the chart

### DIFF
--- a/charts/postgres-operator/templates/clusterrole-postgres-pod.yaml
+++ b/charts/postgres-operator/templates/clusterrole-postgres-pod.yaml
@@ -63,14 +63,14 @@ rules:
   - services
   verbs:
   - create
-{{- if toString .Values.configKubernetes.spilo_privileged | eq "true" }}
+{{- if or (toString .Values.configKubernetes.spilo_privileged | eq "true") (.Values.rbac.spiloRunWithPsp) }}
 # to run privileged pods
 - apiGroups:
   - extensions
   resources:
   - podsecuritypolicies
   resourceNames:
-  - privileged
+  - {{ .Values.rbac.spiloPrivilegedPodSecurityPolicy }}
   verbs:
   - use
 {{- end }}

--- a/charts/postgres-operator/templates/clusterrole.yaml
+++ b/charts/postgres-operator/templates/clusterrole.yaml
@@ -230,14 +230,14 @@ rules:
   verbs:
   - get
   - create
-{{- if toString .Values.configKubernetes.spilo_privileged | eq "true" }}
+{{- if or (toString .Values.configKubernetes.spilo_privileged | eq "true") (.Values.rbac.operatorRunWithPsp) }}
 # to run privileged pods
 - apiGroups:
   - extensions
   resources:
   - podsecuritypolicies
   resourceNames:
-  - privileged
+  - {{ .Values.rbac.operatorPrivilegedPodSecurityPolicy }}
   verbs:
   - use
 {{- end }}

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -372,6 +372,11 @@ rbac:
   create: true
   # Specifies whether ClusterRoles that are aggregated into the K8s default roles should be created. (https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings)
   createAggregateClusterRoles: false
+  # If cluster is set to run as privileged - which pod security policy should be used
+  operatorRunWithPsp: false
+  spiloRunWithPsp: false
+  spiloPrivilegedPodSecurityPolicy: privileged
+  operatorPrivilegedPodSecurityPolicy: privileged
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
- `privileged` is an arbitrary name that in many clusters is associated with no privilege checking at all (including on host paths, host ports etc). Even though practically privileged mode is enough to break into many clusters it's still best practice to have a minimum allowed policy and to allow specifying this
- In many more locked down clusters the `allowPrivilegeEscalation` flag will also break the default pod security rule (e.g. if you are using the CIS Hardened benchmark). In this case there is now a `operatorRunWithPsp` and `spiloPrivilegedPodSecurityPolicy` flag to allow both postgres and operator pods to use a PSP without having to run in privileged mode to achieve that affect.