### PR TITLE
define readinessProbe on statefulSet

### DIFF
--- a/charts/postgres-operator/templates/clusterrole-postgres-pod.yaml
+++ b/charts/postgres-operator/templates/clusterrole-postgres-pod.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
-# Patroni needs to watch and manage endpoints
+# Patroni needs to watch and manage config maps or endpoints
 {{- if toString .Values.configGeneral.kubernetes_use_configmaps | eq "true" }}
 - apiGroups:
   - ""
@@ -24,12 +24,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
 {{- else }}
 - apiGroups:
   - ""

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,7 +37,7 @@ The Postgres Operator can be deployed in the following ways:
 * Kustomization
 * Helm chart
 
-### Manual deployment setup
+### Manual deployment setup on Kubernetes
 
 The Postgres Operator can be installed simply by applying yaml manifests. Note,
 we provide the `/manifests` directory as an example only; you should consider
@@ -69,6 +69,18 @@ manifest.
 
 ```bash
 ./run_operator_locally.sh
+```
+
+### Manual deployment setup on OpenShift
+
+To install the Postgres Operator in OpenShift you have to change the config
+parameter `kubernetes_use_configmaps` to `"true"`. Otherwise, the operator
+and Patroni will store leader and config keys in `Endpoints` that are not
+supported in OpenShift. This requires also a slightly different set of rules
+for the `postgres-operator` and `postgres-pod` cluster roles.
+
+```bash
+oc create -f manifests/operator-service-account-rbac-openshift.yaml
 ```
 
 ### Helm chart

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -1759,6 +1759,8 @@ class EndToEndTestCase(unittest.TestCase):
             self.eventuallyEqual(lambda: len(k8s.api.custom_objects_api.list_namespaced_custom_object(
                 "acid.zalan.do", "v1", "default", "postgresqls", label_selector="cluster-name=acid-minimal-cluster")["items"]), 0, "Manifest not deleted")
 
+            self.eventuallyEqual(lambda: k8s.get_operator_state(), {"0": "idle"}, "Operator does not get in sync")
+
             # check if everything has been deleted
             self.eventuallyEqual(lambda: k8s.count_pods_with_label(cluster_label), 0, "Pods not deleted")
             self.eventuallyEqual(lambda: k8s.count_services_with_label(cluster_label), 0, "Service not deleted")

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -63,13 +63,13 @@ data:
   # etcd_host: ""
   external_traffic_policy: "Cluster"
   # gcp_credentials: ""
-  # kubernetes_use_configmaps: "false"
   # ignored_annotations: ""
   # infrastructure_roles_secret_name: "postgresql-infrastructure-roles"
   # infrastructure_roles_secrets: "secretname:monitoring-roles,userkey:user,passwordkey:password,rolekey:inrole"
   # inherited_annotations: owned-by
   # inherited_labels: application,environment
   # kube_iam_role: ""
+  # kubernetes_use_configmaps: "false"
   # log_s3_bucket: ""
   logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.7.1"
   # logical_backup_google_application_credentials: ""

--- a/manifests/operator-service-account-rbac-openshift.yaml
+++ b/manifests/operator-service-account-rbac-openshift.yaml
@@ -1,13 +1,14 @@
-{{ if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: postgres-operator
+  namespace: default
+
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "postgres-operator.serviceAccountName" . }}
-  labels:
-    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
-    helm.sh/chart: {{ template "postgres-operator.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: postgres-operator
 rules:
 # all verbs allowed for custom operator resources
 - apiGroups:
@@ -34,12 +35,35 @@ rules:
   - get
   - list
   - watch
-# all verbs allowed for event streams
-{{- if .Values.enableStreams }}
+# all verbs allowed for event streams (Zalando-internal feature)
+# - apiGroups:
+#   - zalando.org
+#   resources:
+#   - fabriceventstreams
+#   verbs:
+#   - create
+#   - delete
+#   - deletecollection
+#   - get
+#   - list
+#   - patch
+#   - update
+#   - watch
+# to create or get/update CRDs when starting up
 - apiGroups:
-  - zalando.org
+  - apiextensions.k8s.io
   resources:
-  - fabriceventstreams
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+# to read configuration and manage ConfigMaps used by Patroni
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
   verbs:
   - create
   - delete
@@ -49,19 +73,6 @@ rules:
   - patch
   - update
   - watch
-{{- end }}
-# to create or get/update CRDs when starting up
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-{{- if toString .Values.configGeneral.enable_crd_registration | eq "true" }}
-  - create
-  - patch
-  - update
-{{- end }}
 # to send events to the CRs
 - apiGroups:
   - ""
@@ -74,43 +85,6 @@ rules:
   - patch
   - update
   - watch
-# to manage endpoints/configmaps which are also used by Patroni
-{{- if toString .Values.configGeneral.kubernetes_use_configmaps | eq "true" }}
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-{{- else }}
-# to read configuration from ConfigMaps
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-{{- end }}
 # to CRUD secrets for database access
 - apiGroups:
   - ""
@@ -139,10 +113,8 @@ rules:
   - delete
   - get
   - list
-{{- if toString .Values.configKubernetes.storage_resize_mode | eq "pvc" }}
   - patch
   - update
-{{- end }}
  # to read existing PVs. Creation should be done via dynamic provisioning
 - apiGroups:
   - ""
@@ -151,9 +123,7 @@ rules:
   verbs:
   - get
   - list
-{{- if toString .Values.configKubernetes.storage_resize_mode | eq "ebs" }}
   - update  # only for resizing AWS volumes
-{{- end }}
 # to watch Spilo pods and do rolling updates. Creation via StatefulSet
 - apiGroups:
   - ""
@@ -240,15 +210,74 @@ rules:
   verbs:
   - get
   - create
-{{- if toString .Values.configKubernetes.spilo_privileged | eq "true" }}
-# to run privileged pods
+# to grant privilege to run privileged pods (not needed by default)
+#- apiGroups:
+#  - extensions
+#  resources:
+#  - podsecuritypolicies
+#  resourceNames:
+#  - privileged
+#  verbs:
+#  - use
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: postgres-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: postgres-operator
+subjects:
+- kind: ServiceAccount
+  name: postgres-operator
+  namespace: default
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: postgres-pod
+rules:
+# Patroni needs to watch and manage config maps
 - apiGroups:
-  - extensions
+  - ""
   resources:
-  - podsecuritypolicies
-  resourceNames:
-  - privileged
+  - configmaps
   verbs:
-  - use
-{{- end }}
-{{ end }}
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+# Patroni needs to watch pods
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+# to let Patroni create a headless service
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+# to grant privilege to run privileged pods (not needed by default)
+#- apiGroups:
+#  - extensions
+#  resources:
+#  - podsecuritypolicies
+#  resourceNames:
+#  - privileged
+#  verbs:
+#  - use

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -59,7 +59,6 @@ type Config struct {
 type kubeResources struct {
 	Services            map[PostgresRole]*v1.Service
 	Endpoints           map[PostgresRole]*v1.Endpoints
-	ConfigMaps          map[PostgresRole]*v1.ConfigMap
 	Secrets             map[types.UID]*v1.Secret
 	Statefulset         *appsv1.StatefulSet
 	PodDisruptionBudget *policybeta1.PodDisruptionBudget

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1499,12 +1499,9 @@ func (c *Cluster) GetStatus() *ClusterStatus {
 		Error: fmt.Errorf("error: %s", c.Error),
 	}
 
-	if c.patroniKubernetesUseConfigMaps() {
+	if !c.patroniKubernetesUseConfigMaps() {
 		status.MasterEndpoint = c.GetEndpointMaster()
 		status.ReplicaEndpoint = c.GetEndpointReplica()
-	} else {
-		status.MasterConfigMap = c.GetConfigMapMaster()
-		status.ReplicaConfigMap = c.GetConfigMapReplica()
 	}
 
 	return status

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -43,7 +43,7 @@ var (
 	alphaNumericRegexp    = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9]*$")
 	databaseNameRegexp    = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
 	userRegexp            = regexp.MustCompile(`^[a-z0-9]([-_a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-_a-z0-9]*[a-z0-9])?)*$`)
-	patroniObjectSuffixes = []string{"config", "failover", "sync", "leader"}
+	patroniObjectSuffixes = []string{"leader", "config", "sync", "failover"}
 )
 
 // Config contains operator-wide clients and configuration used from a cluster. TODO: remove struct duplication.
@@ -1582,12 +1582,12 @@ func (c *Cluster) deletePatroniClusterObjects() error {
 		c.logger.Infof("not cleaning up Etcd Patroni objects on cluster delete")
 	}
 
+	actionsList = append(actionsList, c.deletePatroniClusterServices)
 	if c.patroniKubernetesUseConfigMaps() {
 		actionsList = append(actionsList, c.deletePatroniClusterConfigMaps)
 	} else {
 		actionsList = append(actionsList, c.deletePatroniClusterEndpoints)
 	}
-	actionsList = append(actionsList, c.deletePatroniClusterServices)
 
 	c.logger.Debugf("removing leftover Patroni objects (endpoints / services and configmaps)")
 	for _, deleter := range actionsList {

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -76,20 +76,13 @@ func (c *Cluster) statefulSetName() string {
 	return c.Name
 }
 
-func (c *Cluster) configMapName(role PostgresRole) string {
+func (c *Cluster) endpointName(role PostgresRole) string {
 	name := c.Name
-	if role == Master {
-		name = name + "-leader"
-	}
 	if role == Replica {
 		name = name + "-repl"
 	}
 
 	return name
-}
-
-func (c *Cluster) endpointName(role PostgresRole) string {
-	return c.serviceName(role)
 }
 
 func (c *Cluster) serviceName(role PostgresRole) string {
@@ -1826,16 +1819,6 @@ func (c *Cluster) generateEndpoint(role PostgresRole, subsets []v1.EndpointSubse
 	}
 
 	return endpoints
-}
-
-func (c *Cluster) generateConfigMap(role PostgresRole) *v1.ConfigMap {
-	return &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.configMapName(role),
-			Namespace: c.Namespace,
-			Labels:    c.roleLabelsSet(true, role),
-		},
-	}
 }
 
 func (c *Cluster) generateCloneEnvironment(description *acidv1.CloneDescription) []v1.EnvVar {

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -76,13 +76,12 @@ func (c *Cluster) statefulSetName() string {
 	return c.Name
 }
 
-func (c *Cluster) endpointName(role PostgresRole) string {
-	name := c.Name
-	if role == Replica {
-		name = name + "-repl"
-	}
+func (c *Cluster) configMapName(role PostgresRole) string {
+	return c.serviceName(role)
+}
 
-	return name
+func (c *Cluster) endpointName(role PostgresRole) string {
+	return c.serviceName(role)
 }
 
 func (c *Cluster) serviceName(role PostgresRole) string {
@@ -1819,6 +1818,16 @@ func (c *Cluster) generateEndpoint(role PostgresRole, subsets []v1.EndpointSubse
 	}
 
 	return endpoints
+}
+
+func (c *Cluster) generateConfigMap(role PostgresRole) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.configMapName(role),
+			Namespace: c.Namespace,
+			Labels:    c.roleLabelsSet(true, role),
+		},
+	}
 }
 
 func (c *Cluster) generateCloneEnvironment(description *acidv1.CloneDescription) []v1.EnvVar {

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -26,6 +26,7 @@ import (
 	"github.com/zalando/postgres-operator/pkg/util/config"
 	"github.com/zalando/postgres-operator/pkg/util/constants"
 	"github.com/zalando/postgres-operator/pkg/util/k8sutil"
+	"github.com/zalando/postgres-operator/pkg/util/patroni"
 	"github.com/zalando/postgres-operator/pkg/util/retryutil"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -111,7 +112,7 @@ func (c *Cluster) servicePort(role PostgresRole) int32 {
 		return service.Spec.Ports[0].Port
 	}
 
-	c.logger.Warningf("No service for role %s - defaulting to port 5432", role)
+	c.logger.Warningf("No service for role %s - defaulting to port %d", role, pgPort)
 	return pgPort
 }
 
@@ -558,15 +559,15 @@ func generateContainer(
 		Resources:       *resourceRequirements,
 		Ports: []v1.ContainerPort{
 			{
-				ContainerPort: 8008,
+				ContainerPort: patroni.ApiPort,
 				Protocol:      v1.ProtocolTCP,
 			},
 			{
-				ContainerPort: 5432,
+				ContainerPort: pgPort,
 				Protocol:      v1.ProtocolTCP,
 			},
 			{
-				ContainerPort: 8080,
+				ContainerPort: patroni.ApiPort,
 				Protocol:      v1.ProtocolTCP,
 			},
 		},
@@ -1058,6 +1059,22 @@ func extractPgVersionFromBinPath(binPath string, template string) (string, error
 	return fmt.Sprintf("%v", pgVersion), nil
 }
 
+func generateSpiloReadinessProbe() *v1.Probe {
+	return &v1.Probe{
+		Handler: v1.Handler{
+			HTTPGet: &v1.HTTPGetAction{
+				Path: "/readiness",
+				Port: intstr.IntOrString{IntVal: patroni.ApiPort},
+			},
+		},
+		InitialDelaySeconds: 6,
+		PeriodSeconds:       10,
+		TimeoutSeconds:      5,
+		SuccessThreshold:    1,
+		FailureThreshold:    3,
+	}
+}
+
 func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.StatefulSet, error) {
 
 	var (
@@ -1238,6 +1255,12 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 		c.OpConfig.Resources.SpiloAllowPrivilegeEscalation,
 		generateCapabilities(c.OpConfig.AdditionalPodCapabilities),
 	)
+
+	// if kubernetes_use_configmaps define a readinessProbe since the master service has a selector
+	// Patroni responds 200 to probe only if it either owns the leader lock or postgres is running and DCS is accessible
+	if c.patroniKubernetesUseConfigMaps() {
+		spiloContainer.ReadinessProbe = generateSpiloReadinessProbe()
+	}
 
 	// generate container specs for sidecars specified in the cluster manifest
 	clusterSpecificSidecars := []v1.Container{}
@@ -1708,10 +1731,12 @@ func (c *Cluster) shouldCreateLoadBalancerForService(role PostgresRole, spec *ac
 
 func (c *Cluster) generateService(role PostgresRole, spec *acidv1.PostgresSpec) *v1.Service {
 	serviceSpec := v1.ServiceSpec{
-		Ports: []v1.ServicePort{{Name: "postgresql", Port: 5432, TargetPort: intstr.IntOrString{IntVal: 5432}}},
+		Ports: []v1.ServicePort{{Name: "postgresql", Port: pgPort, TargetPort: intstr.IntOrString{IntVal: pgPort}}},
 		Type:  v1.ServiceTypeClusterIP,
 	}
 
+	// no selector for master, see https://github.com/zalando/postgres-operator/issues/340
+	// if kubernetes_use_configmaps is set master service needs a selector
 	if role == Replica || c.patroniKubernetesUseConfigMaps() {
 		serviceSpec.Selector = c.roleLabelsSet(false, role)
 	}
@@ -1989,7 +2014,7 @@ func (c *Cluster) generatePodDisruptionBudget() *policybeta1.PodDisruptionBudget
 // TODO: handle clusters in different namespaces
 func (c *Cluster) getClusterServiceConnectionParameters(clusterName string) (host string, port string) {
 	host = clusterName
-	port = "5432"
+	port = fmt.Sprintf("%d", pgPort)
 	return
 }
 
@@ -2170,7 +2195,7 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 		},
 		{
 			Name:  "PGPORT",
-			Value: "5432",
+			Value: fmt.Sprintf("%d", pgPort),
 		},
 		{
 			Name:  "PGUSER",

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -77,7 +77,15 @@ func (c *Cluster) statefulSetName() string {
 }
 
 func (c *Cluster) configMapName(role PostgresRole) string {
-	return c.serviceName(role)
+	name := c.Name
+	if role == Master {
+		name = name + "-leader"
+	}
+	if role == Replica {
+		name = name + "-repl"
+	}
+
+	return name
 }
 
 func (c *Cluster) endpointName(role PostgresRole) string {

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1256,11 +1256,8 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 		generateCapabilities(c.OpConfig.AdditionalPodCapabilities),
 	)
 
-	// if kubernetes_use_configmaps define a readinessProbe since the master service has a selector
 	// Patroni responds 200 to probe only if it either owns the leader lock or postgres is running and DCS is accessible
-	if c.patroniKubernetesUseConfigMaps() {
-		spiloContainer.ReadinessProbe = generateSpiloReadinessProbe()
-	}
+	spiloContainer.ReadinessProbe = generateSpiloReadinessProbe()
 
 	// generate container specs for sidecars specified in the cluster manifest
 	clusterSpecificSidecars := []v1.Container{}

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -35,11 +35,7 @@ func (c *Cluster) listResources() error {
 		c.logger.Infof("found secret: %q (uid: %q) namesapce: %s", util.NameFromMeta(obj.ObjectMeta), obj.UID, obj.ObjectMeta.Namespace)
 	}
 
-	if c.patroniKubernetesUseConfigMaps() {
-		for role, configMap := range c.ConfigMaps {
-			c.logger.Infof("found %s config map: %q (uid: %q)", role, util.NameFromMeta(configMap.ObjectMeta), configMap.UID)
-		}
-	} else {
+	if !c.patroniKubernetesUseConfigMaps() {
 		for role, endpoint := range c.Endpoints {
 			c.logger.Infof("found %s endpoint: %q (uid: %q)", role, util.NameFromMeta(endpoint.ObjectMeta), endpoint.UID)
 		}
@@ -408,20 +404,6 @@ func (c *Cluster) generateEndpointSubsets(role PostgresRole) []v1.EndpointSubset
 	return result
 }
 
-func (c *Cluster) createConfigMap(role PostgresRole) (*v1.ConfigMap, error) {
-	c.setProcessName("creating config map")
-	configMapSpec := c.generateConfigMap(role)
-
-	configMap, err := c.KubeClient.ConfigMaps(configMapSpec.Namespace).Create(context.TODO(), configMapSpec, metav1.CreateOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("could not create %s config map: %v", role, err)
-	}
-
-	c.ConfigMaps[role] = configMap
-
-	return configMap, nil
-}
-
 func (c *Cluster) createPodDisruptionBudget() (*policybeta1.PodDisruptionBudget, error) {
 	podDisruptionBudgetSpec := c.generatePodDisruptionBudget()
 	podDisruptionBudget, err := c.KubeClient.
@@ -612,16 +594,6 @@ func (c *Cluster) GetEndpointMaster() *v1.Endpoints {
 // GetEndpointReplica returns cluster's kubernetes replica Endpoint
 func (c *Cluster) GetEndpointReplica() *v1.Endpoints {
 	return c.Endpoints[Replica]
-}
-
-// GetConfigMapMaster returns cluster's kubernetes master ConfigMap
-func (c *Cluster) GetConfigMapMaster() *v1.ConfigMap {
-	return c.ConfigMaps[Master]
-}
-
-// GetConfigMapReplica returns cluster's kubernetes replica ConfigMap
-func (c *Cluster) GetConfigMapReplica() *v1.ConfigMap {
-	return c.ConfigMaps[Replica]
 }
 
 // GetStatefulSet returns cluster's kubernetes StatefulSet

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -144,7 +144,11 @@ func (c *Cluster) syncServices() error {
 	for _, role := range []PostgresRole{Master, Replica} {
 		c.logger.Debugf("syncing %s service", role)
 
-		if !c.patroniKubernetesUseConfigMaps() {
+		if c.patroniKubernetesUseConfigMaps() {
+			if err := c.syncConfigMap(role); err != nil {
+				return fmt.Errorf("could not sync %s config map: %v", role, err)
+			}
+		} else {
 			if err := c.syncEndpoint(role); err != nil {
 				return fmt.Errorf("could not sync %s endpoint: %v", role, err)
 			}
@@ -231,6 +235,40 @@ func (c *Cluster) syncEndpoint(role PostgresRole) error {
 		}
 	}
 	c.Endpoints[role] = ep
+	return nil
+}
+
+func (c *Cluster) syncConfigMap(role PostgresRole) error {
+	var (
+		cm  *v1.ConfigMap
+		err error
+	)
+	c.setProcessName("syncing %s config map", role)
+
+	if cm, err = c.KubeClient.ConfigMaps(c.Namespace).Get(context.TODO(), c.configMapName(role), metav1.GetOptions{}); err == nil {
+		// TODO: No syncing of config map here, is this covered completely by updateService?
+		c.ConfigMaps[role] = cm
+		return nil
+	}
+	if !k8sutil.ResourceNotFound(err) {
+		return fmt.Errorf("could not get %s config map: %v", role, err)
+	}
+	// no existing config map, create new one
+	c.ConfigMaps[role] = nil
+	c.logger.Infof("could not find the cluster's %s config map", role)
+
+	if cm, err = c.createConfigMap(role); err == nil {
+		c.logger.Infof("created missing %s config map %q", role, util.NameFromMeta(cm.ObjectMeta))
+	} else {
+		if !k8sutil.ResourceAlreadyExists(err) {
+			return fmt.Errorf("could not create missing %s config map: %v", role, err)
+		}
+		c.logger.Infof("%s config map %q already exists", role, util.NameFromMeta(cm.ObjectMeta))
+		if cm, err = c.KubeClient.ConfigMaps(c.Namespace).Get(context.TODO(), c.configMapName(role), metav1.GetOptions{}); err != nil {
+			return fmt.Errorf("could not fetch existing %s config map: %v", role, err)
+		}
+	}
+	c.ConfigMaps[role] = cm
 	return nil
 }
 

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -63,8 +63,6 @@ type ClusterStatus struct {
 	ReplicaService      *v1.Service
 	MasterEndpoint      *v1.Endpoints
 	ReplicaEndpoint     *v1.Endpoints
-	MasterConfigMap     *v1.ConfigMap
-	ReplicaConfigMap    *v1.ConfigMap
 	StatefulSet         *appsv1.StatefulSet
 	PodDisruptionBudget *policybeta1.PodDisruptionBudget
 

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -63,6 +63,8 @@ type ClusterStatus struct {
 	ReplicaService      *v1.Service
 	MasterEndpoint      *v1.Endpoints
 	ReplicaEndpoint     *v1.Endpoints
+	MasterConfigMap     *v1.ConfigMap
+	ReplicaConfigMap    *v1.ConfigMap
 	StatefulSet         *appsv1.StatefulSet
 	PodDisruptionBudget *policybeta1.PodDisruptionBudget
 

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -544,7 +544,8 @@ func (c *Controller) postgresqlCheck(obj interface{}) *acidv1.Postgresql {
   Ensures the pod service account and role bindings exists in a namespace
   before a PG cluster is created there so that a user does not have to deploy
   these credentials manually.  StatefulSets require the service account to
-  create pods; Patroni requires relevant RBAC bindings to access endpoints.
+  create pods; Patroni requires relevant RBAC bindings to access endpoints
+  or config maps.
 
   The operator does not sync accounts/role bindings after creation.
 */

--- a/pkg/util/patroni/patroni.go
+++ b/pkg/util/patroni/patroni.go
@@ -25,7 +25,7 @@ const (
 	clusterPath  = "/cluster"
 	statusPath   = "/patroni"
 	restartPath  = "/restart"
-	apiPort      = 8008
+	ApiPort      = 8008
 	timeout      = 30 * time.Second
 )
 
@@ -74,7 +74,7 @@ func apiURL(masterPod *v1.Pod) (string, error) {
 			return "", fmt.Errorf("%s is not a valid IPv4/IPv6 address", masterPod.Status.PodIP)
 		}
 	}
-	return fmt.Sprintf("http://%s", net.JoinHostPort(ip.String(), strconv.Itoa(apiPort))), nil
+	return fmt.Sprintf("http://%s", net.JoinHostPort(ip.String(), strconv.Itoa(ApiPort))), nil
 }
 
 func (p *Patroni) httpPostOrPatch(method string, url string, body *bytes.Buffer) (err error) {

--- a/pkg/util/patroni/patroni_test.go
+++ b/pkg/util/patroni/patroni_test.go
@@ -36,17 +36,17 @@ func TestApiURL(t *testing.T) {
 	}{
 		{
 			"127.0.0.1",
-			fmt.Sprintf("http://127.0.0.1:%d", apiPort),
+			fmt.Sprintf("http://127.0.0.1:%d", ApiPort),
 			nil,
 		},
 		{
 			"0000:0000:0000:0000:0000:0000:0000:0001",
-			fmt.Sprintf("http://[::1]:%d", apiPort),
+			fmt.Sprintf("http://[::1]:%d", ApiPort),
 			nil,
 		},
 		{
 			"::1",
-			fmt.Sprintf("http://[::1]:%d", apiPort),
+			fmt.Sprintf("http://[::1]:%d", ApiPort),
 			nil,
 		},
 		{


### PR DESCRIPTION
With #1760 merged, we should add a readinessProbe to the statefultSet because the ConfigMaps option defines a selector on the master service. Label selectors incl. readiness probes. We will add it either way.

#1760 also introduced a new suffix for deleting Patroni cluster objects which will result in an error for the new "leader" suffix if endpoints are used. Instead, the operator should just l log a warning and try to delete as much as it can. Another bug was introduced by not deleting all services if endpoints are used.

Other changes:
- user variables when specifying container ports
- check configmaps option when syncing ClusterStatus not omit endpoints
- remove endpoints from RBAC (provide RBAC manifest for OpenShift)