### PR TITLE
Fix deletion of event streams resources

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -91,6 +91,7 @@ type Cluster struct {
 	currentProcess      Process
 	processMu           sync.RWMutex // protects the current operation for reporting, no need to hold the master mutex
 	specMu              sync.RWMutex // protects the spec for reporting, no need to hold the master mutex
+	streamApplications  []string
 	ConnectionPooler    map[PostgresRole]*ConnectionPoolerObjects
 	EBSVolumes          map[string]volumes.VolumeProperties
 	VolumeResizer       volumes.VolumeResizer

--- a/pkg/cluster/streams_test.go
+++ b/pkg/cluster/streams_test.go
@@ -196,6 +196,9 @@ func TestGenerateFabricEventStream(t *testing.T) {
 	_, err := cluster.createStatefulSet()
 	assert.NoError(t, err)
 
+	// createOrUpdateStreams will loop over existing apps
+	cluster.streamApplications = []string{appId}
+
 	// create the streams
 	err = cluster.createOrUpdateStreams()
 	assert.NoError(t, err)
@@ -327,6 +330,10 @@ func TestUpdateFabricEventStream(t *testing.T) {
 	_, err := cluster.KubeClient.Postgresqls(namespace).Create(
 		context.TODO(), &pg, metav1.CreateOptions{})
 	assert.NoError(t, err)
+
+	// createOrUpdateStreams will loop over existing apps
+	cluster.streamApplications = []string{appId}
+
 	err = cluster.createOrUpdateStreams()
 	assert.NoError(t, err)
 


### PR DESCRIPTION
The delete code was still reflecting an earlier state of #1570 where only one event stream resource was possible per cluster. In fact, there can now exists multiple as per application ID. This PR introduces a cluster field to store those IDs to loop over them after cluster deletion.