### PR TITLE
bump pooler image with pgBouncer 1.17.0 and auth_type md5

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -588,7 +588,7 @@ spec:
                     default: "pooler"
                   connection_pooler_image:
                     type: string
-                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-19"
+                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-22"
                   connection_pooler_max_db_connections:
                     type: integer
                     default: 60

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -381,7 +381,7 @@ configConnectionPooler:
   # db user for pooler to use
   connection_pooler_user: "pooler"
   # docker image
-  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-19"
+  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-22"
   # max db connections the pooler should hold
   connection_pooler_max_db_connections: 60
   # default pooling mode

--- a/docs/user.md
+++ b/docs/user.md
@@ -101,7 +101,6 @@ possible to use the more recent `scram-sha-256` method by changing the
 directly from the cluster manifest:
 
 ```yaml
-```yaml
 apiVersion: "acid.zalan.do/v1"
 kind: postgresql
 metadata:

--- a/docs/user.md
+++ b/docs/user.md
@@ -83,14 +83,35 @@ kubectl port-forward $PGMASTER 6432:5432 -n default
 ```
 
 Open another CLI and connect to the database using e.g. the psql client.
-When connecting with the `postgres` user read its password from the K8s secret
-which was generated when creating the `acid-minimal-cluster`. As non-encrypted
-connections are rejected by default set the SSL mode to `require`:
+When connecting with a manifest role like `foo_user` user, read its password
+from the K8s secret which was generated when creating `acid-minimal-cluster`.
+As non-encrypted connections are rejected by default set SSL mode to `require`:
 
 ```bash
 export PGPASSWORD=$(kubectl get secret postgres.acid-minimal-cluster.credentials.postgresql.acid.zalan.do -o 'jsonpath={.data.password}' | base64 -d)
 export PGSSLMODE=require
 psql -U postgres -h localhost -p 6432
+```
+
+## Password encryption
+
+Passwords are encrypted with `md5` hash generation by default. However, it is
+possible to use the more recent `scram-sha-256` method by changing the
+`password_encryption` parameter in the Postgres config. You can define it
+directly from the cluster manifest:
+
+```yaml
+```yaml
+apiVersion: "acid.zalan.do/v1"
+kind: postgresql
+metadata:
+  name: acid-minimal-cluster
+spec:
+  [...]
+  postgresql:
+    version: "14"
+    parameters:
+      password_encryption: scram-sha-256
 ```
 
 ## Defining database roles in the operator

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -17,7 +17,7 @@ data:
   # connection_pooler_default_cpu_request: "500m"
   # connection_pooler_default_memory_limit: 100Mi
   # connection_pooler_default_memory_request: 100Mi
-  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-19"
+  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-22"
   # connection_pooler_max_db_connections: 60
   # connection_pooler_mode: "transaction"
   # connection_pooler_number_of_instances: 2

--- a/manifests/minimal-fake-pooler-deployment.yaml
+++ b/manifests/minimal-fake-pooler-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: postgres-operator
       containers:
       - name: postgres-operator
-        image: registry.opensource.zalan.do/acid/pgbouncer:master-19
+        image: registry.opensource.zalan.do/acid/pgbouncer:master-22
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -586,7 +586,7 @@ spec:
                     default: "pooler"
                   connection_pooler_image:
                     type: string
-                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-19"
+                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-22"
                   connection_pooler_max_db_connections:
                     type: integer
                     default: 60

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -187,7 +187,7 @@ configuration:
     connection_pooler_default_cpu_request: "500m"
     connection_pooler_default_memory_limit: 100Mi
     connection_pooler_default_memory_request: 100Mi
-    connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-19"
+    connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-22"
     # connection_pooler_max_db_connections: 60
     connection_pooler_mode: "transaction"
     connection_pooler_number_of_instances: 2


### PR DESCRIPTION
Fixes #1750 

We changed auth_type in our pgBouncer image from `plain` to `md5`. According to pgBouncer [docs](https://www.pgbouncer.org/config.html#authentication-settings) if "md5 is configured and a user has a SCRAM secret, then SCRAM authentication is used automatically instead."

Added a paragraph how one can configure using secrets with `scram-sha-256` hashing.