### PR TITLE
Update Logical Backup environment variables for GCP and Azure

### DIFF
--- a/docker/logical-backup/Dockerfile
+++ b/docker/logical-backup/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update     \
         gnupg \
         gcc \
         libffi-dev \
+        nodejs \
+        npm \
     && pip3 install --upgrade pip \
     && pip3 install --no-cache-dir awscli --upgrade \
     && pip3 install --no-cache-dir gsutil --upgrade \
@@ -32,6 +34,8 @@ RUN apt-get update     \
         postgresql-client-9.5 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+RUN npm install --global azbak
 
 COPY dump.sh ./
 

--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -1146,6 +1146,15 @@ of the backup cron job.
 `cronjobs` resource from the `batch` API group for the operator service account.
 See [example RBAC](https://github.com/zalando/postgres-operator/blob/master/manifests/operator-service-account-rbac.yaml)
 
+Logical Backup environment Variables:
+1. AWS:
+		"LOGICAL_BACKUP_S3_BUCKET", "LOGICAL_BACKUP_S3_REGION", "LOGICAL_BACKUP_S3_ENDPOINT", "LOGICAL_BACKUP_S3_SSE", 
+    "LOGICAL_BACKUP_S3_RETENTION_TIME", "LOGICAL_BACKUP_S3_BUCKET_SCOPE_SUFFIX"
+2. GCP:
+		"LOGICAL_BACKUP_GS_BUCKET", "LOGICAL_BACKUP_GS_BUCKET_SCOPE_SUFFIX", "LOGICAL_BACKUP_GOOGLE_APPLICATION_CREDENTIALS"
+3. Azure:
+		"LOGICAL_BACKUP_AZ_BUCKET", "LOGICAL_BACKUP_AZ_BUCKET_SCOPE_SUFFIX", "LOGICAL_BACKUP_AZ_STORAGE_ACCOUNT"
+
 ## Sidecars for Postgres clusters
 
 A list of sidecars is added to each cluster created by the operator. The default

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2161,38 +2161,9 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 				},
 			},
 		},
-		// Bucket env vars
 		{
 			Name:  "LOGICAL_BACKUP_PROVIDER",
 			Value: c.OpConfig.LogicalBackup.LogicalBackupProvider,
-		},
-		{
-			Name:  "LOGICAL_BACKUP_S3_BUCKET",
-			Value: c.OpConfig.LogicalBackup.LogicalBackupS3Bucket,
-		},
-		{
-			Name:  "LOGICAL_BACKUP_S3_REGION",
-			Value: c.OpConfig.LogicalBackup.LogicalBackupS3Region,
-		},
-		{
-			Name:  "LOGICAL_BACKUP_S3_ENDPOINT",
-			Value: c.OpConfig.LogicalBackup.LogicalBackupS3Endpoint,
-		},
-		{
-			Name:  "LOGICAL_BACKUP_S3_SSE",
-			Value: c.OpConfig.LogicalBackup.LogicalBackupS3SSE,
-		},
-		{
-			Name:  "LOGICAL_BACKUP_S3_RETENTION_TIME",
-			Value: c.OpConfig.LogicalBackup.LogicalBackupS3RetentionTime,
-		},
-		{
-			Name:  "LOGICAL_BACKUP_S3_BUCKET_SCOPE_SUFFIX",
-			Value: getBucketScopeSuffix(string(c.Postgresql.GetUID())),
-		},
-		{
-			Name:  "LOGICAL_BACKUP_GOOGLE_APPLICATION_CREDENTIALS",
-			Value: c.OpConfig.LogicalBackup.LogicalBackupGoogleApplicationCredentials,
 		},
 		// Postgres env vars
 		{
@@ -2226,6 +2197,25 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 				},
 			},
 		},
+	}
+
+	// logical backup storage env vars
+	if c.OpConfig.LogicalBackup.LogicalBackupProvider == "aws" || c.OpConfig.LogicalBackup.LogicalBackupProvider == "s3" {
+		envVars = append(envVars, v1.EnvVar{Name: "LOGICAL_BACKUP_S3_BUCKET", Value: c.OpConfig.LogicalBackup.LogicalBackupS3Bucket})
+		envVars = append(envVars, v1.EnvVar{Name: "LOGICAL_BACKUP_S3_REGION", Value: c.OpConfig.LogicalBackup.LogicalBackupS3Region})
+		envVars = append(envVars, v1.EnvVar{Name: "LOGICAL_BACKUP_S3_ENDPOINT", Value: c.OpConfig.LogicalBackup.LogicalBackupS3Endpoint})
+		envVars = append(envVars, v1.EnvVar{Name: "LOGICAL_BACKUP_S3_SSE", Value: c.OpConfig.LogicalBackup.LogicalBackupS3SSE})
+		envVars = append(envVars, v1.EnvVar{Name: "LOGICAL_BACKUP_S3_RETENTION_TIME", Value: c.OpConfig.LogicalBackup.LogicalBackupS3RetentionTime})
+		envVars = append(envVars, v1.EnvVar{Name: "LOGICAL_BACKUP_S3_BUCKET_SCOPE_SUFFIX", Value: getBucketScopeSuffix(string(c.Postgresql.GetUID()))})
+	} else if c.OpConfig.LogicalBackup.LogicalBackupProvider == "google" || c.OpConfig.LogicalBackup.LogicalBackupProvider == "gcs" {
+		envVars = append(envVars, v1.EnvVar{Name: "LOGICAL_BACKUP_GS_BUCKET", Value: c.OpConfig.LogicalBackup.LogicalBackupGSBucket})
+		envVars = append(envVars, v1.EnvVar{Name: "LOGICAL_BACKUP_GS_BUCKET_SCOPE_SUFFIX", Value: getBucketScopeSuffix(string(c.Postgresql.GetUID()))})
+		envVars = append(envVars, v1.EnvVar{Name: "LOGICAL_BACKUP_GOOGLE_APPLICATION_CREDENTIALS", Value: c.OpConfig.LogicalBackup.LogicalBackupGoogleApplicationCredentials})
+	} else if c.OpConfig.LogicalBackup.LogicalBackupProvider == "azure" {
+		// assumes logical backups are going to the same place as wal archives.
+		envVars = append(envVars, v1.EnvVar{Name: "LOGICAL_BACKUP_AZ_BUCKET", Value: c.OpConfig.LogicalBackup.LogicalBackupAZBucket})
+		envVars = append(envVars, v1.EnvVar{Name: "LOGICAL_BACKUP_AZ_BUCKET_SCOPE_SUFFIX", Value: getBucketScopeSuffix(string(c.Postgresql.GetUID()))})
+		envVars = append(envVars, v1.EnvVar{Name: "LOGICAL_BACKUP_AZ_STORAGE_ACCOUNT", Value: c.OpConfig.WALAZStorageAccount})
 	}
 
 	if c.OpConfig.LogicalBackup.LogicalBackupS3AccessKeyID != "" {


### PR DESCRIPTION
Per https://github.com/zalando/postgres-operator/issues/1838

Update logical backup environment variables for GCP and Azure.  I've also added [azbak](https://www.npmjs.com/package/azbak) (we've been using in production for 6+ months now) in the example logical-backup image to allow for logical backups within azure, and added azure_upload to dump.sh.