### PR TITLE
reverse membership for additional owner roles

### DIFF
--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -179,12 +179,17 @@ under the `users` key.
 
 * **additional_owner_roles**
   Specifies database roles that will be granted to all database owners. Owners
-  can then use `SET ROLE` to obtain privileges of these roles to e.g.
-  create/update functionality from extensions as part of a migration script.
-  Note, that roles listed here should be preconfigured in the docker image
-  and already exist in the database cluster on startup. One such role can be
-  `cron_admin` which is provided by the Spilo docker image to set up cron
-  jobs inside the `postgres` database. Default is `empty`.
+  can then use `SET ROLE` to obtain privileges of these roles to e.g. create
+  or update functionality from extensions as part of a migration script. One
+  such role can be `cron_admin` which is provided by the Spilo docker image to
+  set up cron jobs inside the `postgres` database. In general, roles listed
+  here should be preconfigured in the docker image and already exist in the
+  database cluster on startup. Otherwise, syncing roles will return an error
+  on each cluster sync process. Alternatively, you have to create the role and
+  do the GRANT manually. Note, the operator will not allow additional owner
+  roles to be members of database owners because it should be vice versa. If
+  the operator cannot set up the correct membership it tries to revoke all
+  additional owner roles from database owners. Default is `empty`.
 
 * **enable_password_rotation**
   For all `LOGIN` roles that are not database owners the operator can rotate

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -178,7 +178,7 @@ under the `users` key.
   `standby`.
 
 * **additional_owner_roles**
-  Specifies database roles that will granted to all database owners. Owners
+  Specifies database roles that will be granted to all database owners. Owners
   can then use `SET ROLE` to obtain privileges of these roles to e.g.
   create/update functionality from extensions as part of a migration script.
   Note, that roles listed here should be preconfigured in the docker image

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -178,8 +178,8 @@ under the `users` key.
   `standby`.
 
 * **additional_owner_roles**
-  Specifies database roles that will become members of all database owners.
-  Then owners can use `SET ROLE` to obtain privileges of these roles to e.g.
+  Specifies database roles that will granted to all database owners. Owners
+  can then use `SET ROLE` to obtain privileges of these roles to e.g.
   create/update functionality from extensions as part of a migration script.
   Note, that roles listed here should be preconfigured in the docker image
   and already exist in the database cluster on startup. One such role can be

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -164,9 +164,13 @@ class EndToEndTestCase(unittest.TestCase):
            Test granting additional roles to existing database owners
         '''
         k8s = self.k8s
+
+        # first test - wait for the operator to get in sync and set everything up
+        self.eventuallyEqual(lambda: k8s.get_operator_state(), {"0": "idle"},
+            "Operator does not get in sync")
         leader = k8s.get_cluster_leader_pod()
 
-        # produce wrong membership from v1.8.0
+        # produce wrong membership for cron_admin
         grant_dbowner = """
             GRANT bar_owner TO cron_admin;
         """

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -161,7 +161,7 @@ class EndToEndTestCase(unittest.TestCase):
     @timeout_decorator.timeout(TEST_TIMEOUT_SEC)
     def test_additional_owner_roles(self):
         '''
-           Test adding additional member roles to existing database owner roles
+           Test granting additional roles to existing database owners
         '''
         k8s = self.k8s
 
@@ -181,10 +181,10 @@ class EndToEndTestCase(unittest.TestCase):
               FROM pg_catalog.pg_authid a
               JOIN pg_catalog.pg_auth_members am
                 ON a.oid = am.member
-               AND a.rolname = 'cron_admin'
+               AND a.rolname IN ('zalando', 'bar_owner', 'bar_data_owner')
               JOIN pg_catalog.pg_authid a2
                 ON a2.oid = am.roleid
-             WHERE a2.rolname IN ('zalando', 'bar_owner', 'bar_data_owner');
+             WHERE a2.rolname = 'cron_admin';
         """
         self.eventuallyEqual(lambda: len(self.query_database(leader.metadata.name, "postgres", owner_query)), 3,
             "Not all additional users found in database", 10, 5)

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -12,8 +12,8 @@ from kubernetes import client
 from tests.k8s_api import K8s
 from kubernetes.client.rest import ApiException
 
-SPILO_CURRENT = "registry.opensource.zalan.do/acid/spilo-14-e2e:0.1"
-SPILO_LAZY = "registry.opensource.zalan.do/acid/spilo-14-e2e:0.2"
+SPILO_CURRENT = "registry.opensource.zalan.do/acid/spilo-14-e2e:0.3"
+SPILO_LAZY = "registry.opensource.zalan.do/acid/spilo-14-e2e:0.4"
 
 
 def to_selector(labels):

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -195,8 +195,6 @@ class EndToEndTestCase(unittest.TestCase):
         self.eventuallyEqual(lambda: len(self.query_database(leader.metadata.name, "postgres", owner_query)), 3,
             "Not all additional users found in database", 10, 5)
 
-        print('Operator log: {}'.format(k8s.get_operator_log()))
-
     @timeout_decorator.timeout(TEST_TIMEOUT_SEC)
     def test_additional_pod_capabilities(self):
         '''

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -133,8 +133,10 @@ func New(cfg Config, kubeClient k8sutil.KubernetesClient, pgSpec acidv1.Postgres
 			Services:  make(map[PostgresRole]*v1.Service),
 			Endpoints: make(map[PostgresRole]*v1.Endpoints)},
 		userSyncStrategy: users.DefaultUserSyncStrategy{
-			PasswordEncryption: passwordEncryption,
-			RoleDeletionSuffix: cfg.OpConfig.RoleDeletionSuffix},
+			PasswordEncryption:   passwordEncryption,
+			RoleDeletionSuffix:   cfg.OpConfig.RoleDeletionSuffix,
+			AdditionalOwnerRoles: cfg.OpConfig.AdditionalOwnerRoles,
+		},
 		deleteOptions:       metav1.DeleteOptions{PropagationPolicy: &deletePropagationPolicy},
 		podEventsQueue:      podEventsQueue,
 		KubeClient:          kubeClient,

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1649,7 +1649,7 @@ func (c *Cluster) generateUserSecrets() map[string]*v1.Secret {
 func (c *Cluster) generateSingleUserSecret(namespace string, pgUser spec.PgUser) *v1.Secret {
 	//Skip users with no password i.e. human users (they'll be authenticated using pam)
 	if pgUser.Password == "" {
-		if pgUser.Origin != spec.RoleOriginTeamsAPI && pgUser.Origin != spec.RoleOriginSpilo {
+		if pgUser.Origin != spec.RoleOriginTeamsAPI {
 			c.logger.Warningf("could not generate secret for a non-teamsAPI role %q: role has no password",
 				pgUser.Name)
 		}

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -657,7 +657,7 @@ func (c *Cluster) syncSecrets() error {
 			return fmt.Errorf("could not init db connection: %v", err)
 		}
 		pgSyncRequests := c.userSyncStrategy.ProduceSyncRequests(spec.PgUserMap{}, rotationUsers)
-		if err = c.userSyncStrategy.ExecuteSyncRequests(pgSyncRequests, c.pgDb); err != nil {
+		if err = c.userSyncStrategy.ExecuteSyncRequests(pgSyncRequests, c.pgDb, c.OpConfig.AdditionalOwnerRoles); err != nil {
 			return fmt.Errorf("error creating database roles for password rotation: %v", err)
 		}
 		if err := c.closeDbConn(); err != nil {
@@ -872,7 +872,7 @@ func (c *Cluster) syncRoles() (err error) {
 	}
 
 	pgSyncRequests := c.userSyncStrategy.ProduceSyncRequests(dbUsers, c.pgUsers)
-	if err = c.userSyncStrategy.ExecuteSyncRequests(pgSyncRequests, c.pgDb); err != nil {
+	if err = c.userSyncStrategy.ExecuteSyncRequests(pgSyncRequests, c.pgDb, c.OpConfig.AdditionalOwnerRoles); err != nil {
 		return fmt.Errorf("error executing sync statements: %v", err)
 	}
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -657,7 +657,7 @@ func (c *Cluster) syncSecrets() error {
 			return fmt.Errorf("could not init db connection: %v", err)
 		}
 		pgSyncRequests := c.userSyncStrategy.ProduceSyncRequests(spec.PgUserMap{}, rotationUsers)
-		if err = c.userSyncStrategy.ExecuteSyncRequests(pgSyncRequests, c.pgDb, c.OpConfig.AdditionalOwnerRoles); err != nil {
+		if err = c.userSyncStrategy.ExecuteSyncRequests(pgSyncRequests, c.pgDb); err != nil {
 			return fmt.Errorf("error creating database roles for password rotation: %v", err)
 		}
 		if err := c.closeDbConn(); err != nil {
@@ -872,7 +872,7 @@ func (c *Cluster) syncRoles() (err error) {
 	}
 
 	pgSyncRequests := c.userSyncStrategy.ProduceSyncRequests(dbUsers, c.pgUsers)
-	if err = c.userSyncStrategy.ExecuteSyncRequests(pgSyncRequests, c.pgDb, c.OpConfig.AdditionalOwnerRoles); err != nil {
+	if err = c.userSyncStrategy.ExecuteSyncRequests(pgSyncRequests, c.pgDb); err != nil {
 		return fmt.Errorf("error executing sync statements: %v", err)
 	}
 

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -75,7 +75,7 @@ type PgSyncUserRequest struct {
 // UserSyncer defines an interface for the implementations to sync users from the manifest to the DB.
 type UserSyncer interface {
 	ProduceSyncRequests(dbUsers PgUserMap, newUsers PgUserMap) (req []PgSyncUserRequest)
-	ExecuteSyncRequests(req []PgSyncUserRequest, db *sql.DB) error
+	ExecuteSyncRequests(req []PgSyncUserRequest, db *sql.DB, additionalOwners []string) error
 }
 
 // LogEntry describes log entry in the RingLogger

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -30,7 +30,6 @@ const (
 	RoleOriginManifest
 	RoleOriginInfrastructure
 	RoleOriginTeamsAPI
-	RoleOriginSpilo
 	RoleOriginSystem
 	RoleOriginBootstrap
 	RoleConnectionPooler

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -75,7 +75,7 @@ type PgSyncUserRequest struct {
 // UserSyncer defines an interface for the implementations to sync users from the manifest to the DB.
 type UserSyncer interface {
 	ProduceSyncRequests(dbUsers PgUserMap, newUsers PgUserMap) (req []PgSyncUserRequest)
-	ExecuteSyncRequests(req []PgSyncUserRequest, db *sql.DB, additionalOwners []string) error
+	ExecuteSyncRequests(req []PgSyncUserRequest, db *sql.DB) error
 }
 
 // LogEntry describes log entry in the RingLogger

--- a/pkg/util/users/users.go
+++ b/pkg/util/users/users.go
@@ -57,15 +57,13 @@ func (strategy DefaultUserSyncStrategy) ProduceSyncRequests(dbUsers spec.PgUserM
 			newMD5Password := util.NewEncryptor(strategy.PasswordEncryption).PGUserPassword(newUser)
 
 			// do not compare for roles coming from docker image
-			if newUser.Origin != spec.RoleOriginSpilo {
-				if dbUser.Password != newMD5Password {
-					r.User.Password = newMD5Password
-					r.Kind = spec.PGsyncUserAlter
-				}
-				if addNewFlags, equal := util.SubstractStringSlices(newUser.Flags, dbUser.Flags); !equal {
-					r.User.Flags = addNewFlags
-					r.Kind = spec.PGsyncUserAlter
-				}
+			if dbUser.Password != newMD5Password {
+				r.User.Password = newMD5Password
+				r.Kind = spec.PGsyncUserAlter
+			}
+			if addNewFlags, equal := util.SubstractStringSlices(newUser.Flags, dbUser.Flags); !equal {
+				r.User.Flags = addNewFlags
+				r.Kind = spec.PGsyncUserAlter
 			}
 			if addNewRoles, equal := util.SubstractStringSlices(newUser.MemberOf, dbUser.MemberOf); !equal {
 				r.User.MemberOf = addNewRoles
@@ -75,8 +73,7 @@ func (strategy DefaultUserSyncStrategy) ProduceSyncRequests(dbUsers spec.PgUserM
 				r.User.Name = newUser.Name
 				reqs = append(reqs, r)
 			}
-			if newUser.Origin != spec.RoleOriginSpilo &&
-				len(newUser.Parameters) > 0 &&
+			if len(newUser.Parameters) > 0 &&
 				!reflect.DeepEqual(dbUser.Parameters, newUser.Parameters) {
 				reqs = append(reqs, spec.PgSyncUserRequest{Kind: spec.PGSyncAlterSet, User: newUser})
 			}


### PR DESCRIPTION
While it can also be useful to grant roles to all database owners our intention with #1805 was actually the opposite.

This PR reverts a couple of changes done in #1805 like introducing a `RoleOriginSpilo` role type. Do not create a pgUser for additional owner roles - it's enough to add them in the `memberOf` field of existing DB owners. In case somebody already started using this feature, the operator will handle the reversed membership and revoke additional roles from database owners again. The latter is implemented as part of `ExecuteSyncRequests`. When altering membership of db owners fails (e.g. because of the wrong membership):

1. check for matches between additional owners and database owner's groups (`memberOf`)
2. try to revoke database owner from additional owner role. The latter is not stored in any pgUser map. So wrong membership cannot be checked - we just try the revoke)