### PR TITLE
[UI] use safe defaults for fetching cluster logs

### DIFF
--- a/ui/operator_ui/main.py
+++ b/ui/operator_ui/main.py
@@ -961,6 +961,8 @@ def get_operator_get_logs(worker: int):
 @app.route('/operator/clusters/<namespace>/<cluster>/logs')
 @authorize
 def get_operator_get_logs_per_cluster(namespace: str, cluster: str):
+    team, cluster_name = cluster.split('-', 1)
+    # team id might contain hivens, try to find correct team name
     user_teams = get_teams_for_user(session.get('user_name', ''))
     for user_team in user_teams:
         if cluster.find(user_team) == 0:

--- a/ui/operator_ui/main.py
+++ b/ui/operator_ui/main.py
@@ -962,12 +962,12 @@ def get_operator_get_logs(worker: int):
 @authorize
 def get_operator_get_logs_per_cluster(namespace: str, cluster: str):
     team, cluster_name = cluster.split('-', 1)
-    # team id might contain hivens, try to find correct team name
+    # team id might contain hyphens, try to find correct team name
     user_teams = get_teams_for_user(session.get('user_name', ''))
     for user_team in user_teams:
-        if cluster.find(user_team) == 0:
+        if cluster.find(user_team + '-') == 0:
             team = cluster[:len(user_team)]
-            cluster_name = cluster[len(user_team)+1:]
+            cluster_name = cluster[len(user_team + '-'):]
             break
     return proxy_operator(f'/clusters/{team}/{namespace}/{cluster_name}/logs/')
 


### PR DESCRIPTION
get_teams_for_user might return an empty list which would leave team and cluster_name unbound:

```
2022-04-28 07:38:23,972 ERROR: Exception on /operator/clusters/default/foobar-minimal-cluster/logs [GET]
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/flask/app.py", line 2077, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/lib/python3.8/site-packages/flask/app.py", line 1525, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/lib/python3.8/site-packages/flask/app.py", line 1523, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python3.8/site-packages/flask/app.py", line 1509, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/operator_ui/main.py", line 207, in wrapper
    return f(*args, **kwargs)
  File "/operator_ui/main.py", line 975, in get_operator_get_logs_per_cluster
    return proxy_operator(f'/clusters/{team}/{namespace}/{cluster_name}/logs/')
UnboundLocalError: local variable 'team' referenced before assignment
```