### PR TITLE
removing inner goroutine in cluster.Switchover

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1033,11 +1033,12 @@ func (c *Cluster) processPodEvent(obj interface{}) error {
 	}
 
 	c.podSubscribersMu.RLock()
+	defer c.podSubscribersMu.RUnlock()
+
 	subscriber, ok := c.podSubscribers[spec.NamespacedName(event.PodName)]
 	if ok {
 		subscriber <- event
 	}
-	c.podSubscribersMu.RUnlock()
 
 	return nil
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1033,9 +1033,8 @@ func (c *Cluster) processPodEvent(obj interface{}) error {
 	}
 
 	c.podSubscribersMu.RLock()
-	defer c.podSubscribersMu.RUnlock()
-
 	subscriber, ok := c.podSubscribers[spec.NamespacedName(event.PodName)]
+	c.podSubscribersMu.RUnlock()
 	if ok {
 		subscriber <- event
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1034,10 +1034,10 @@ func (c *Cluster) processPodEvent(obj interface{}) error {
 
 	c.podSubscribersMu.RLock()
 	subscriber, ok := c.podSubscribers[spec.NamespacedName(event.PodName)]
-	c.podSubscribersMu.RUnlock()
 	if ok {
 		subscriber <- event
 	}
+	c.podSubscribersMu.RUnlock()
 
 	return nil
 }
@@ -1501,48 +1501,22 @@ func (c *Cluster) Switchover(curMaster *v1.Pod, candidate spec.NamespacedName) e
 	var err error
 	c.logger.Debugf("switching over from %q to %q", curMaster.Name, candidate)
 	c.eventRecorder.Eventf(c.GetReference(), v1.EventTypeNormal, "Switchover", "Switching over from %q to %q", curMaster.Name, candidate)
-
-	var wg sync.WaitGroup
-
-	podLabelErr := make(chan error)
 	stopCh := make(chan struct{})
-
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-		ch := c.registerPodSubscriber(candidate)
-		defer c.unregisterPodSubscriber(candidate)
-
-		role := Master
-
-		select {
-		case <-stopCh:
-		case podLabelErr <- func() (err2 error) {
-			_, err2 = c.waitForPodLabel(ch, stopCh, &role)
-			return
-		}():
-		}
-	}()
+	ch := c.registerPodSubscriber(candidate)
+	defer c.unregisterPodSubscriber(candidate)
+	defer close(stopCh)
 
 	if err = c.patroni.Switchover(curMaster, candidate.Name); err == nil {
 		c.logger.Debugf("successfully switched over from %q to %q", curMaster.Name, candidate)
 		c.eventRecorder.Eventf(c.GetReference(), v1.EventTypeNormal, "Switchover", "Successfully switched over from %q to %q", curMaster.Name, candidate)
-		if err = <-podLabelErr; err != nil {
+		_, err = c.waitForPodLabel(ch, stopCh, nil)
+		if err != nil {
 			err = fmt.Errorf("could not get master pod label: %v", err)
 		}
 	} else {
 		err = fmt.Errorf("could not switch over from %q to %q: %v", curMaster.Name, candidate, err)
 		c.eventRecorder.Eventf(c.GetReference(), v1.EventTypeNormal, "Switchover", "Switchover from %q to %q FAILED: %v", curMaster.Name, candidate, err)
 	}
-
-	// signal the role label waiting goroutine to close the shop and go home
-	close(stopCh)
-	// wait until the goroutine terminates, since unregisterPodSubscriber
-	// must be called before the outer return; otherwise we risk subscribing to the same pod twice.
-	wg.Wait()
-	// close the label waiting channel no sooner than the waiting goroutine terminates.
-	close(podLabelErr)
 
 	return err
 }

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -149,13 +149,14 @@ func (c *Cluster) deletePod(podName spec.NamespacedName) error {
 func (c *Cluster) unregisterPodSubscriber(podName spec.NamespacedName) {
 	c.logger.Debugf("unsubscribing from pod %q events", podName)
 	c.podSubscribersMu.Lock()
+	defer c.podSubscribersMu.Unlock()
+
 	ch, ok := c.podSubscribers[podName]
 	if !ok {
 		panic("subscriber for pod '" + podName.String() + "' is not found")
 	}
 
 	delete(c.podSubscribers, podName)
-	c.podSubscribersMu.Unlock()
 	close(ch)
 }
 

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -67,7 +67,7 @@ func (c *Cluster) markRollingUpdateFlagForPod(pod *v1.Pod, msg string) error {
 		return fmt.Errorf("could not form patch for pod's rolling update flag: %v", err)
 	}
 
-	err = retryutil.Retry(c.OpConfig.PatroniAPICheckInterval, c.OpConfig.PatroniAPICheckTimeout,
+	err = retryutil.Retry(c.OpConfig.ResourceCheckInterval, c.OpConfig.ResourceCheckTimeout,
 		func() (bool, error) {
 			_, err2 := c.KubeClient.Pods(pod.Namespace).Patch(
 				context.TODO(),
@@ -149,14 +149,14 @@ func (c *Cluster) deletePod(podName spec.NamespacedName) error {
 func (c *Cluster) unregisterPodSubscriber(podName spec.NamespacedName) {
 	c.logger.Debugf("unsubscribing from pod %q events", podName)
 	c.podSubscribersMu.Lock()
-	defer c.podSubscribersMu.Unlock()
-
-	if _, ok := c.podSubscribers[podName]; !ok {
+	ch, ok := c.podSubscribers[podName]
+	if !ok {
 		panic("subscriber for pod '" + podName.String() + "' is not found")
 	}
 
-	close(c.podSubscribers[podName])
 	delete(c.podSubscribers, podName)
+	c.podSubscribersMu.Unlock()
+	close(ch)
 }
 
 func (c *Cluster) registerPodSubscriber(podName spec.NamespacedName) chan PodEvent {
@@ -399,11 +399,12 @@ func (c *Cluster) getPatroniMemberData(pod *v1.Pod) (patroni.MemberData, error) 
 }
 
 func (c *Cluster) recreatePod(podName spec.NamespacedName) (*v1.Pod, error) {
+	stopCh := make(chan struct{})
 	ch := c.registerPodSubscriber(podName)
 	defer c.unregisterPodSubscriber(podName)
-	stopChan := make(chan struct{})
+	defer close(stopCh)
 
-	err := retryutil.Retry(c.OpConfig.PatroniAPICheckInterval, c.OpConfig.PatroniAPICheckTimeout,
+	err := retryutil.Retry(c.OpConfig.ResourceCheckInterval, c.OpConfig.PodDeletionWaitTimeout,
 		func() (bool, error) {
 			err2 := c.KubeClient.Pods(podName.Namespace).Delete(
 				context.TODO(),
@@ -421,7 +422,7 @@ func (c *Cluster) recreatePod(podName spec.NamespacedName) (*v1.Pod, error) {
 	if err := c.waitForPodDeletion(ch); err != nil {
 		return nil, err
 	}
-	pod, err := c.waitForPodLabel(ch, stopChan, nil)
+	pod, err := c.waitForPodLabel(ch, stopCh, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -446,7 +447,7 @@ func (c *Cluster) recreatePods(pods []v1.Pod, switchoverCandidates []spec.Namesp
 			continue
 		}
 
-		podName := util.NameFromMeta(pod.ObjectMeta)
+		podName := util.NameFromMeta(pods[i].ObjectMeta)
 		newPod, err := c.recreatePod(podName)
 		if err != nil {
 			return fmt.Errorf("could not recreate replica pod %q: %v", util.NameFromMeta(pod.ObjectMeta), err)

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -67,7 +67,7 @@ func (c *Cluster) markRollingUpdateFlagForPod(pod *v1.Pod, msg string) error {
 		return fmt.Errorf("could not form patch for pod's rolling update flag: %v", err)
 	}
 
-	err = retryutil.Retry(c.OpConfig.ResourceCheckInterval, c.OpConfig.ResourceCheckTimeout,
+	err = retryutil.Retry(1*time.Second, 5*time.Second,
 		func() (bool, error) {
 			_, err2 := c.KubeClient.Pods(pod.Namespace).Patch(
 				context.TODO(),
@@ -405,7 +405,7 @@ func (c *Cluster) recreatePod(podName spec.NamespacedName) (*v1.Pod, error) {
 	defer c.unregisterPodSubscriber(podName)
 	defer close(stopCh)
 
-	err := retryutil.Retry(c.OpConfig.ResourceCheckInterval, c.OpConfig.PodDeletionWaitTimeout,
+	err := retryutil.Retry(1*time.Second, 5*time.Second,
 		func() (bool, error) {
 			err2 := c.KubeClient.Pods(podName.Namespace).Delete(
 				context.TODO(),

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -316,7 +316,7 @@ func (c *Cluster) annotationsSet(annotations map[string]string) map[string]strin
 	return nil
 }
 
-func (c *Cluster) waitForPodLabel(podEvents chan PodEvent, stopChan chan struct{}, role *PostgresRole) (*v1.Pod, error) {
+func (c *Cluster) waitForPodLabel(podEvents chan PodEvent, stopCh chan struct{}, role *PostgresRole) (*v1.Pod, error) {
 	timeout := time.After(c.OpConfig.PodLabelWaitTimeout)
 	for {
 		select {
@@ -332,7 +332,7 @@ func (c *Cluster) waitForPodLabel(podEvents chan PodEvent, stopChan chan struct{
 			}
 		case <-timeout:
 			return nil, fmt.Errorf("pod label wait timeout")
-		case <-stopChan:
+		case <-stopCh:
 			return nil, fmt.Errorf("pod label wait cancelled")
 		}
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -451,16 +451,17 @@ func (c *Controller) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
 		panic("could not acquire initial list of clusters")
 	}
 
-	wg.Add(5)
+	wg.Add(5 + util.Bool2Int(c.opConfig.EnablePostgresTeamCRD))
 	go c.runPodInformer(stopCh, wg)
 	go c.runPostgresqlInformer(stopCh, wg)
 	go c.clusterResync(stopCh, wg)
-	go c.apiserver.Run(stopCh, wg)
 	go c.kubeNodesInformer(stopCh, wg)
 
 	if c.opConfig.EnablePostgresTeamCRD {
 		go c.runPostgresTeamInformer(stopCh, wg)
 	}
+
+	go c.apiserver.Run(stopCh, wg)
 
 	c.logger.Info("started working in background")
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -455,13 +455,12 @@ func (c *Controller) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
 	go c.runPodInformer(stopCh, wg)
 	go c.runPostgresqlInformer(stopCh, wg)
 	go c.clusterResync(stopCh, wg)
+	go c.apiserver.Run(stopCh, wg)
 	go c.kubeNodesInformer(stopCh, wg)
 
 	if c.opConfig.EnablePostgresTeamCRD {
 		go c.runPostgresTeamInformer(stopCh, wg)
 	}
-
-	go c.apiserver.Run(stopCh, wg)
 
 	c.logger.Info("started working in background")
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -324,10 +324,18 @@ func testNil(values ...*int32) bool {
 	return false
 }
 
-// Convert int to IntOrString type
+// ToIntStr convert int to IntOrString type
 func ToIntStr(val int) *intstr.IntOrString {
 	b := intstr.FromInt(val)
 	return &b
+}
+
+// Bool2Int converts bool to int
+func Bool2Int(flag bool) int {
+	if flag {
+		return 1
+	}
+	return 0
 }
 
 // Get int from IntOrString and return max int if string

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -324,7 +324,7 @@ func testNil(values ...*int32) bool {
 	return false
 }
 
-// ToIntStr convert int to IntOrString type
+// ToIntStr converts int to IntOrString type
 func ToIntStr(val int) *intstr.IntOrString {
 	b := intstr.FromInt(val)
 	return &b


### PR DESCRIPTION
fixes #1867

Switchover function has this inner go routine which is not need. I guess, it was once introduced with the idea to have two go routines that wait for each other when sending and consuming evens on the podEvent channels. But even with a WaitGroup added later, changes for a race condition between closing the channel (consumer side) and sending events were still high as the operator did panic in most of my tests. And because of the fact that we wait anyway for the go routine to [finish](https://github.com/zalando/postgres-operator/blob/master/pkg/cluster/cluster.go#L1513) the need concurrency in this part of the code looks questionable. 

With the go routine removed from Switchover, chances for hitting the race condition are already a lot lower. To fully eliminate the possibility of running into it, the PR moves c.podSubscribersMu.RUnlock() after the event handling. Thus, it will always send on the channel first before [unregisterPodSubscriber called from Switchover](https://github.com/zalando/postgres-operator/blob/264e66d0a1ef35f194ccd1fcaac48d069656b04f/pkg/cluster/cluster.go#L1511) can close it. Since unbuffered channels are usually blocking when there's no receiver (Switchover might already be done), a select block with a do nothing default case has to be provided. See this [go example](https://gobyexample.com/non-blocking-channel-operations).

The PR changes the check and timeout setting for deleting and patching Pods. `PatroniAPICheck*` config values are used because their defaults correspond to the hard coded values of 1s and 5s that we used before. But `PatroniAPICheck*` constants should only be used when calling the Patroni REST API instead.

The PR also fixes WaitGroup when PostgresTeam informer is enabled. Thanks @dmvolod for the hint in #1874 .