### PR TITLE
signal processPodEvent routine to close PodEvent channel

### DIFF
--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -32,6 +32,7 @@ const (
 	PodEventAdd    PodEventType = "ADD"
 	PodEventUpdate PodEventType = "UPDATE"
 	PodEventDelete PodEventType = "DELETE"
+	PodEventEnd    PodEventType = "END"
 )
 
 // PodEvent describes the event for a single Pod


### PR DESCRIPTION
This is a continuation of #1876 that already improved on the situation that operator runs into a panic during switchover. However, there's still no guarantee that `Switchover` closes the PodEvent channel when calling `unregisterPodSubscriber` while the `processPodEvent` routine still sends something.

The idea of this PR is to send a new PodEvent type to the `processPodEvent` routine and make it responsible for closing the channel. Unfortunately, the race condition remains the same, but instead of a panic we will face a deadlock. Switchover method can send the special END event which will be added to [processPodEventQueue](https://github.com/zalando/postgres-operator/blob/a77d5df158593ce1f10afec5de3caec5698422f7/pkg/cluster/cluster.go#L1050), but there might still be more events in the queue that will then be send to the channel. However, the consumer (in this case waitForPodLabel) is already finished. Now the go routine is blocked and will no proceed.

One solution could be to define a buffered channel when we do the switchover. Buffered channels do not block go routines when events sent to a channel are not consumed. However, using the correct size for a channel might be a challenge, since it's not known how long the actual switchover will take and how many events are really sent during one second. And when the channel is full we have a deadlock again.