### PR TITLE
Use second channel for podSubscribers to trigger its removal by cluster go routine

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1046,8 +1046,8 @@ func (c *Cluster) processPodEvent(obj interface{}) error {
 		select {
 		case <-subscriber.stopEvent:
 			c.unregisterPodSubscriber(podName)
+		case subscriber.podEvents <- event:
 		default:
-			subscriber.podEvents <- event
 		}
 	}
 	// hold lock for the time of processing the event to avoid race condition

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -145,7 +145,11 @@ func (c *Cluster) deletePod(podName spec.NamespacedName) error {
 		return err
 	}
 
-	return c.waitForPodDeletion(subscriber.podEvents)
+	if err := c.waitForPodDeletion(subscriber.podEvents); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *Cluster) unregisterPodSubscriber(podName spec.NamespacedName) {

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -137,7 +137,6 @@ func (c *Cluster) deletePods() error {
 func (c *Cluster) deletePod(podName spec.NamespacedName) error {
 	c.setProcessName("deleting pod %q", podName)
 	subscriber := c.registerPodSubscriber(podName)
-	defer c.unregisterPodSubscriber(podName)
 
 	if err := c.KubeClient.Pods(podName.Namespace).Delete(context.TODO(), podName.Name, c.deleteOptions); err != nil {
 		return err
@@ -406,7 +405,6 @@ func (c *Cluster) getPatroniMemberData(pod *v1.Pod) (patroni.MemberData, error) 
 func (c *Cluster) recreatePod(podName spec.NamespacedName) (*v1.Pod, error) {
 	stopCh := make(chan struct{})
 	subscriber := c.registerPodSubscriber(podName)
-	defer c.unregisterPodSubscriber(podName)
 	defer close(stopCh)
 
 	err := retryutil.Retry(1*time.Second, 5*time.Second,

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -316,20 +316,18 @@ func (c *Cluster) annotationsSet(annotations map[string]string) map[string]strin
 	return nil
 }
 
-func (c *Cluster) waitForPodLabel(subscriber PodSubscriber, stopCh chan struct{}, role *PostgresRole) (*v1.Pod, error) {
+func (c *Cluster) waitForPodLabel(podEvents chan PodEvent, stopCh chan struct{}, role *PostgresRole) (*v1.Pod, error) {
 	timeout := time.After(c.OpConfig.PodLabelWaitTimeout)
 	for {
 		select {
-		case podEvent := <-subscriber.podEvents:
+		case podEvent := <-podEvents:
 			podRole := PostgresRole(podEvent.CurPod.Labels[c.OpConfig.PodRoleLabel])
 
 			if role == nil {
 				if podRole == Master || podRole == Replica {
-					subscriber.stopEvent <- struct{}{}
 					return podEvent.CurPod, nil
 				}
 			} else if *role == podRole {
-				subscriber.stopEvent <- struct{}{}
 				return podEvent.CurPod, nil
 			}
 		case <-timeout:


### PR DESCRIPTION
Another continuation of #1876. It takes the idea of #1888 sending a poison pill to the `processPodEvent` function inside the cluster go routine. But instead of using a podEvent that has to queue up, we are using a second channel next to the podEvents channel of cluster.podSubscribers map. The latter is not a map of channels anymore, but a map of `podSubscriber` struct consisting of two channels.

When `waitForPodLabel` is finished with consuming podEvents it will write on the second channel which will trigger the removal of podSubscribers. So a next podEvent should not find the subscriber anymore and not write on a closed channel.

fixes: #1867
closes #1876
closes #1888