### PR TITLE
bring back CLONE_WAL_BUCKET_SCOPE_PREFIX

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1867,22 +1867,15 @@ func (c *Cluster) generateCloneEnvironment(description *acidv1.CloneDescription)
 		} else {
 			c.logger.Debugf("use S3WalPath %s from the manifest", description.S3WalPath)
 
-			envs := []v1.EnvVar{
-				{
-					Name:  "CLONE_WALE_S3_PREFIX",
-					Value: description.S3WalPath,
-				},
-				{
-					Name:  "CLONE_WAL_BUCKET_SCOPE_SUFFIX",
-					Value: "",
-				},
-			}
-
-			result = append(result, envs...)
+			result = append(result, v1.EnvVar{
+				Name:  "CLONE_WALE_S3_PREFIX",
+				Value: description.S3WalPath,
+			})
 		}
 
 		result = append(result, v1.EnvVar{Name: "CLONE_METHOD", Value: "CLONE_WITH_WALE"})
 		result = append(result, v1.EnvVar{Name: "CLONE_TARGET_TIME", Value: description.EndTimestamp})
+		result = append(result, v1.EnvVar{Name: "CLONE_WAL_BUCKET_SCOPE_PREFIX", Value: ""})
 
 		if description.S3Endpoint != "" {
 			result = append(result, v1.EnvVar{Name: "CLONE_AWS_ENDPOINT", Value: description.S3Endpoint})

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -550,8 +550,8 @@ func TestGenerateSpiloPodEnvVars(t *testing.T) {
 			envVarValue:    "s3://another-bucket",
 		},
 		{
-			envIndex:       17,
-			envVarConstant: "CLONE_WAL_BUCKET_SCOPE_SUFFIX",
+			envIndex:       19,
+			envVarConstant: "CLONE_WAL_BUCKET_SCOPE_PREFIX",
 			envVarValue:    "",
 		},
 		{
@@ -572,14 +572,14 @@ func TestGenerateSpiloPodEnvVars(t *testing.T) {
 			envVarValue:    fmt.Sprintf("/%s", dummyUUID),
 		},
 		{
-			envIndex:       20,
+			envIndex:       21,
 			envVarConstant: "clone_aws_endpoint",
 			envVarValue:    "s3.eu-west-1.amazonaws.com",
 		},
 	}
 	expectedCloneEnvSecret := []ExpectedValue{
 		{
-			envIndex:       20,
+			envIndex:       21,
 			envVarConstant: "clone_aws_access_key_id",
 			envVarValueRef: &v1.EnvVarSource{
 				SecretKeyRef: &v1.SecretKeySelector{


### PR DESCRIPTION
In #1848 setting the clone bucket prefix env variable was mistakenly removed.