### PR TITLE
DCS - Etcd version customisation

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -91,6 +91,12 @@ spec:
               etcd_host:
                 type: string
                 default: ""
+              etcd_host_version:
+                type: string
+                default: "v2"
+                enum:
+                  - "v2"
+                  - "v3"
               ignore_instance_limits_annotation_key:
                 type: string
               kubernetes_use_configmaps:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -35,6 +35,8 @@ configGeneral:
   enable_spilo_wal_path_compat: false
   # etcd connection string for Patroni. Empty uses K8s-native DCS.
   etcd_host: ""
+  # etcd version v2 (default) or v3
+  etcd_host_version: v2
   # Spilo docker image
   docker_image: registry.opensource.zalan.do/acid/spilo-14:2.1-p6
 

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -97,6 +97,11 @@ Those are top-level keys, containing both leaf keys and groups.
   Patroni native Kubernetes support is used. The default is empty (use
   Kubernetes-native DCS).
 
+* **etcd_host_version**
+  Etcd version string for Patroni. Available versions are `v2` (default) or `v3`.
+  See [Patroni documentation](https://patroni.readthedocs.io/en/latest/SETTINGS.html#etcd)
+  for more information.
+
 * **kubernetes_use_configmaps**
   Select if setup uses endpoints (default), or configmaps to manage leader when
   DCS is kubernetes (not etcd or similar). In OpenShift it is not possible to

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -61,6 +61,7 @@ data:
   # enable_team_superuser: "false"
   enable_teams_api: "false"
   # etcd_host: ""
+  # etcd_host_version: "v2"
   external_traffic_policy: "Cluster"
   # gcp_credentials: ""
   # ignored_annotations: ""

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -89,6 +89,12 @@ spec:
               etcd_host:
                 type: string
                 default: ""
+              etcd_host_version:
+                type: string
+                default: "v2"
+                enum:
+                  - "v2"
+                  - "v3"
               ignore_instance_limits_annotation_key:
                 type: string
               kubernetes_use_configmaps:

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -12,6 +12,7 @@ configuration:
   # enable_shm_volume: true
   enable_spilo_wal_path_compat: false
   etcd_host: ""
+  # etcd_host_version: "v2"
   # ignore_instance_limits_annotation_key: ""
   # kubernetes_use_configmaps: false
   max_instances: -1

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1115,6 +1115,17 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 					"etcd_host": {
 						Type: "string",
 					},
+					"etcd_host_version": {
+						Type: "string",
+						Enum: []apiextv1.JSON{
+							{
+								Raw: []byte(`"v2"`),
+							},
+							{
+								Raw: []byte(`"v3"`),
+							},
+						},
+					},
 					"ignore_instance_limits_annotation_key": {
 						Type: "string",
 					},

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -235,6 +235,7 @@ type OperatorConfigurationData struct {
 	EnablePgVersionEnvVar      bool                               `json:"enable_pgversion_env_var,omitempty"`
 	EnableSpiloWalPathCompat   bool                               `json:"enable_spilo_wal_path_compat,omitempty"`
 	EtcdHost                   string                             `json:"etcd_host,omitempty"`
+	EtcdHostVersion            string                             `json:"etcd_host_version,omitempty"`
 	KubernetesUseConfigMaps    bool                               `json:"kubernetes_use_configmaps,omitempty"`
 	DockerImage                string                             `json:"docker_image,omitempty"`
 	Workers                    uint32                             `json:"workers,omitempty"`

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -899,7 +899,13 @@ func (c *Cluster) generateSpiloPodEnvVars(
 	if c.patroniUsesKubernetes() {
 		envVars = append(envVars, v1.EnvVar{Name: "DCS_ENABLE_KUBERNETES_API", Value: "true"})
 	} else {
-		envVars = append(envVars, v1.EnvVar{Name: "ETCD_HOST", Value: c.OpConfig.EtcdHost})
+		switch c.OpConfig.EtcdHostVersion {
+		// Select etcd version to use. See "Patroni - ETCD" for more information
+		case "v3":
+			envVars = append(envVars, v1.EnvVar{Name: "ETCD3_HOST", Value: c.OpConfig.EtcdHost})
+		default: // v2
+			envVars = append(envVars, v1.EnvVar{Name: "ETCD_HOST", Value: c.OpConfig.EtcdHost})
+		}
 	}
 
 	if c.patroniKubernetesUseConfigMaps() {

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -37,6 +37,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.EnablePgVersionEnvVar = fromCRD.EnablePgVersionEnvVar
 	result.EnableSpiloWalPathCompat = fromCRD.EnableSpiloWalPathCompat
 	result.EtcdHost = fromCRD.EtcdHost
+	result.EtcdHostVersion = fromCRD.EtcdHostVersion
 	result.KubernetesUseConfigMaps = fromCRD.KubernetesUseConfigMaps
 	result.DockerImage = util.Coalesce(fromCRD.DockerImage, "registry.opensource.zalan.do/acid/spilo-14:2.1-p6")
 	result.Workers = util.CoalesceUInt32(fromCRD.Workers, 8)

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -165,6 +165,7 @@ type Config struct {
 	WatchedNamespace        string            `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
 	KubernetesUseConfigMaps bool              `name:"kubernetes_use_configmaps" default:"false"`
 	EtcdHost                string            `name:"etcd_host" default:""` // special values: the empty string "" means Patroni will use K8s as a DCS
+	EtcdHostVersion         string            `name:"etcd_host_version" default:"v2"`
 	DockerImage             string            `name:"docker_image" default:"registry.opensource.zalan.do/acid/spilo-14:2.1-p6"`
 	SidecarImages           map[string]string `name:"sidecar_docker_images"` // deprecated in favour of SidecarContainers
 	SidecarContainers       []v1.Container    `name:"sidecars"`


### PR DESCRIPTION
Hello,

Similar to #1849 
Allow change etcd version. 
Allow `v2` (default) and `v3` (which are currently supported by Patroni) 

I'm not agree with the author (of #1849) to bring username and password at operator level. (they should be defined through Postgres CR)