### PR TITLE
feat: add image pull secret to service account

### DIFF
--- a/charts/postgres-operator/templates/serviceaccount.yaml
+++ b/charts/postgres-operator/templates/serviceaccount.yaml
@@ -9,4 +9,8 @@ metadata:
     helm.sh/chart: {{ template "postgres-operator.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{ if .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{ toYaml .Values.imagePullSecrets }}
+{{ end }}
 {{ end }}


### PR DESCRIPTION
This allows hosting of all chart dependencies (e.g. spilo) in a private registry.

Signed-off-by: Jacob Lorenzen <jacob@lorenzen.me>