### PR TITLE
Fix a typo in the CRD yaml files.

### DIFF
--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -620,7 +620,7 @@ spec:
                             operator:
                               type: string
                               enum:
-                                - DoesNotExists
+                                - DoesNotExist
                                 - Exists
                                 - In
                                 - NotIn

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -618,7 +618,7 @@ spec:
                             operator:
                               type: string
                               enum:
-                                - DoesNotExists
+                                - DoesNotExist
                                 - Exists
                                 - In
                                 - NotIn


### PR DESCRIPTION
Replaces 'DoesNotExists' with 'DoesNotExist'. Fixes #1868.