### PR TITLE
add storage_resize_mode mixed to opConfig CRD

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -321,6 +321,7 @@ spec:
                     type: string
                     enum:
                       - "ebs"
+                      - "mixed"
                       - "pvc"
                       - "off"
                     default: "pvc"

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -196,7 +196,7 @@ configKubernetes:
   # whether the Spilo container should run with additional permissions other than parent.
   # required by cron which needs setuid
   spilo_allow_privilege_escalation: true
-  # storage resize strategy, available options are: ebs, pvc, off
+  # storage resize strategy, available options are: ebs, pvc, off or mixed
   storage_resize_mode: pvc
   # pod toleration assigned to instances of every Postgres cluster
   # toleration:

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -486,10 +486,10 @@ configuration they are grouped under the `kubernetes` key.
 * **storage_resize_mode**
   defines how operator handles the difference between the requested volume size and
     the actual size. Available options are:
-    1. `ebs` : operator resizes EBS volumes directly and executes `resizefs` within a pod
-    2. `pvc` : operator only changes PVC definition
-    3. `off` : disables resize of the volumes.
-    4. `mixed` :operator  uses AWS API to adjust size, throughput, and IOPS, and calls pvc change for file system resize
+    1. `ebs`   : operator resizes EBS volumes directly and executes `resizefs` within a pod
+    2. `pvc`   : operator only changes PVC definition
+    3. `off`   : disables resize of the volumes.
+    4. `mixed` : operator uses AWS API to adjust size, throughput, and IOPS, and calls pvc change for file system resize
     Default is "pvc".
 
 ## Kubernetes resource requests

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -319,6 +319,7 @@ spec:
                     type: string
                     enum:
                       - "ebs"
+                      - "mixed"
                       - "pvc"
                       - "off"
                     default: "pvc"

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1429,6 +1429,9 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 										Raw: []byte(`"ebs"`),
 									},
 									{
+										Raw: []byte(`"mixed"`),
+									},
+									{
 										Raw: []byte(`"pvc"`),
 									},
 									{


### PR DESCRIPTION
We have forgotten to introduce the `mixed` storage resize mode in the OperatorConfiguration CRD. The docs on volume resizing were also a bit outdated.

Fixes #1946