### PR TITLE
Feature/timelineid in clone section

### DIFF
--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -211,6 +211,9 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 								Type:   "string",
 								Format: "uuid",
 							},
+							"clone_target_timeline": {
+								Type: "string",
+							},
 						},
 					},
 					"connectionPooler": {

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -197,7 +197,8 @@ type CloneDescription struct {
 	S3Endpoint        string `json:"s3_endpoint,omitempty"`
 	S3AccessKeyId     string `json:"s3_access_key_id,omitempty"`
 	S3SecretAccessKey string `json:"s3_secret_access_key,omitempty"`
-	S3ForcePathStyle  *bool  `json:"s3_force_path_style,omitempty" defaults:"false"`
+	S3ForcePathStyle  *bool  `json:"s3_force_path_style,omitempty" defaults:"false"`	
+	TimelineID 		  string `json:"clone_target_timeline" defaults:"latest"`
 }
 
 // Sidecar defines a container to be run in the same pod as the Postgres container.

--- a/pkg/apis/acid.zalan.do/v1/util_test.go
+++ b/pkg/apis/acid.zalan.do/v1/util_test.go
@@ -66,12 +66,12 @@ var cloneClusterDescriptions = []struct {
 	in    *CloneDescription
 	err   error
 }{
-	{"cluster name invalid but EndTimeSet is not empty", &CloneDescription{"foo+bar", "", "NotEmpty", "", "", "", "", nil}, nil},
-	{"expect error as cluster name does not match DNS-1035", &CloneDescription{"foo+bar", "", "", "", "", "", "", nil},
+	{"cluster name invalid but EndTimeSet is not empty", &CloneDescription{"foo+bar", "", "NotEmpty", "", "", "", "", nil, 0}, nil},
+	{"expect error as cluster name does not match DNS-1035", &CloneDescription{"foo+bar", "", "", "", "", "", "", nil, 0},
 		errors.New(`clone cluster name must confirm to DNS-1035, regex used for validation is "^[a-z]([-a-z0-9]*[a-z0-9])?$"`)},
-	{"expect error as cluster name is too long", &CloneDescription{"foobar123456789012345678901234567890123456789012345678901234567890", "", "", "", "", "", "", nil},
+	{"expect error as cluster name is too long", &CloneDescription{"foobar123456789012345678901234567890123456789012345678901234567890", "", "", "", "", "", "", nil, 0},
 		errors.New("clone cluster name must be no longer than 63 characters")},
-	{"common cluster name", &CloneDescription{"foobar", "", "", "", "", "", "", nil}, nil},
+	{"common cluster name", &CloneDescription{"foobar", "", "", "", "", "", "", nil, 0}, nil},
 }
 
 var maintenanceWindows = []struct {

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1907,6 +1907,10 @@ func (c *Cluster) generateCloneEnvironment(description *acidv1.CloneDescription)
 
 			result = append(result, v1.EnvVar{Name: "CLONE_AWS_S3_FORCE_PATH_STYLE", Value: s3ForcePathStyle})
 		}
+
+		if description.TimelineID != "" {
+			result = append(result, v1.EnvVar{Name: "CLONE_TARGET_TIMELINE", Value: description.TimelineID})
+		}
 	}
 
 	return result


### PR DESCRIPTION
Add timelineid in clone section in the cluster CRD. 

In the cluster config we need timeline_id along with the existing possibility of timestamp and cluster name such as for eg:

`clone: 
    cluster: my-cluster-xyz # original cluster
    timestamp: "2022-07-11T12:19:35+00:00"   
    clone_target_timeline: "2" `