### PR TITLE
issue 1247: added ref to existing secret for logical backup s3

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -472,6 +472,8 @@ spec:
                     type: string
                   logical_backup_s3_secret_access_key:
                     type: string
+                  logical_backup_s3_access_secret_name:
+                    type: string
                   logical_backup_s3_sse:
                     type: string
                   logical_backup_s3_retention_time:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -336,6 +336,8 @@ configLogicalBackup:
   logical_backup_s3_endpoint: ""
   # S3 Secret Access Key
   logical_backup_s3_secret_access_key: ""
+  # S3 Secret Access Key from an existing secret containing the access key. The secret must contain the key "password"
+  logical_backup_s3_access_secret_name: ""
   # S3 server side encryption
   logical_backup_s3_sse: "AES256"
   # S3 retention time for stored backups for example "2 week" or "7 days"

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -724,6 +724,9 @@ grouped under the `logical_backup` key.
 * **logical_backup_s3_secret_access_key**
   When set, value will be in AWS_SECRET_ACCESS_KEY env variable. The Default is empty.
 
+**logical_backup_s3_access_secret_name**
+  When set, value is taken from the secret and set as AWS_SECRET_ACCESS_KEY env variable. The existing secret must contain the key "password". The Default is empty.
+
 * **logical_backup_s3_sse**
   Specify server side encryption that S3 storage is using. If empty string
   is specified, no argument will be passed to `aws s3` command. Default: "AES256".

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -81,6 +81,7 @@ data:
   # logical_backup_s3_region: ""
   # logical_backup_s3_endpoint: ""
   # logical_backup_s3_secret_access_key: ""
+  # logical_backup_s3_access_secret_name: ""
   logical_backup_s3_sse: "AES256"
   # logical_backup_s3_retention_time: ""
   logical_backup_schedule: "30 00 * * *"

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -470,6 +470,8 @@ spec:
                     type: string
                   logical_backup_s3_secret_access_key:
                     type: string
+                  logical_backup_s3_access_secret_name:
+                    type: string
                   logical_backup_s3_sse:
                     type: string
                   logical_backup_s3_retention_time:

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -154,6 +154,7 @@ configuration:
     # logical_backup_s3_endpoint: ""
     # logical_backup_s3_region: ""
     # logical_backup_s3_secret_access_key: ""
+    # logical_backup_s3_access_secret_name: ""
     logical_backup_s3_sse: "AES256"
     # logical_backup_s3_retention_time: ""
     logical_backup_schedule: "30 00 * * *"

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1617,6 +1617,9 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 							"logical_backup_s3_secret_access_key": {
 								Type: "string",
 							},
+							"logical_backup_s3_access_secret_name": {
+								Type: "string",
+							},
 							"logical_backup_s3_sse": {
 								Type: "string",
 							},

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -218,6 +218,7 @@ type OperatorLogicalBackupConfiguration struct {
 	S3Endpoint                   string `json:"logical_backup_s3_endpoint,omitempty"`
 	S3AccessKeyID                string `json:"logical_backup_s3_access_key_id,omitempty"`
 	S3SecretAccessKey            string `json:"logical_backup_s3_secret_access_key,omitempty"`
+	S3AccessSecretName           string `json:"logical_backup_s3_access_secret_name,omitempty"`
 	S3SSE                        string `json:"logical_backup_s3_sse,omitempty"`
 	RetentionTime                string `json:"logical_backup_s3_retention_time,omitempty"`
 	GoogleApplicationCredentials string `json:"logical_backup_google_application_credentials,omitempty"`

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -197,6 +197,7 @@ type CloneDescription struct {
 	S3Endpoint        string `json:"s3_endpoint,omitempty"`
 	S3AccessKeyId     string `json:"s3_access_key_id,omitempty"`
 	S3SecretAccessKey string `json:"s3_secret_access_key,omitempty"`
+	S3AccessSecretName string `json:"s3_access_secret_name,omitempty"`
 	S3ForcePathStyle  *bool  `json:"s3_force_path_style,omitempty" defaults:"false"`
 }
 

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1896,7 +1896,19 @@ func (c *Cluster) generateCloneEnvironment(description *acidv1.CloneDescription)
 
 		if description.S3SecretAccessKey != "" {
 			result = append(result, v1.EnvVar{Name: "CLONE_AWS_SECRET_ACCESS_KEY", Value: description.S3SecretAccessKey})
-		}
+		} else if description.S3AccessSecretName != "" {
+			result = append(result, v1.EnvVar{
+					Name: "CLONE_AWS_SECRET_ACCESS_KEY",
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name:description.S3AccessSecretName,
+							},
+							Key: "password",
+						},
+					},
+				})
+			}
 
 		if description.S3ForcePathStyle != nil {
 			s3ForcePathStyle := "0"
@@ -2195,7 +2207,21 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 
 	if c.OpConfig.LogicalBackup.LogicalBackupS3SecretAccessKey != "" {
 		envVars = append(envVars, v1.EnvVar{Name: "AWS_SECRET_ACCESS_KEY", Value: c.OpConfig.LogicalBackup.LogicalBackupS3SecretAccessKey})
+	} else if c.OpConfig.LogicalBackup.LogicalBackupS3AccessSecretName != "" {
+		envVars = append(envVars, v1.EnvVar{
+			Name: "AWS_SECRET_ACCESS_KEY",
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: c.OpConfig.LogicalBackup.LogicalBackupS3AccessSecretName,
+					},
+					Key: "password",
+				},
+			},
+		})
 	}
+
+
 
 	c.logger.Debugf("Generated logical backup env vars")
 	c.logger.Debugf("%v", envVars)

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -173,6 +173,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.LogicalBackupS3Endpoint = fromCRD.LogicalBackup.S3Endpoint
 	result.LogicalBackupS3AccessKeyID = fromCRD.LogicalBackup.S3AccessKeyID
 	result.LogicalBackupS3SecretAccessKey = fromCRD.LogicalBackup.S3SecretAccessKey
+	result.LogicalBackupS3AccessSecretName = fromCRD.LogicalBackup.S3AccessSecretName
 	result.LogicalBackupS3SSE = fromCRD.LogicalBackup.S3SSE
 	result.LogicalBackupS3RetentionTime = fromCRD.LogicalBackup.RetentionTime
 	result.LogicalBackupGoogleApplicationCredentials = fromCRD.LogicalBackup.GoogleApplicationCredentials

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -131,6 +131,7 @@ type LogicalBackup struct {
 	LogicalBackupS3Endpoint                   string `name:"logical_backup_s3_endpoint" default:""`
 	LogicalBackupS3AccessKeyID                string `name:"logical_backup_s3_access_key_id" default:""`
 	LogicalBackupS3SecretAccessKey            string `name:"logical_backup_s3_secret_access_key" default:""`
+	LogicalBackupS3AccessSecretName           string `name:"logical_backup_s3_access_secret_name" default:""`
 	LogicalBackupS3SSE                        string `name:"logical_backup_s3_sse" default:""`
 	LogicalBackupS3RetentionTime              string `name:"logical_backup_s3_retention_time" default:""`
 	LogicalBackupGoogleApplicationCredentials string `name:"logical_backup_google_application_credentials" default:""`


### PR DESCRIPTION
Added new parameter for logicalbackup configuration:
`logical_backup_s3_access_secret_name` to solve #1247 

The CRD for the operator is updated with new parameter.
Documentation updated.

Note, I have updated the setting of "CLONE_AWS_SECRET_ACCESS_KEY" to be symmetric with the setting of AWS_SECRET_ACCESS_KEY.
