### PR TITLE
bump pooler image to use new alpine base image

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -597,7 +597,7 @@ spec:
                     default: "pooler"
                   connection_pooler_image:
                     type: string
-                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-22"
+                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-24"
                   connection_pooler_max_db_connections:
                     type: integer
                     default: 60

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -392,7 +392,7 @@ configConnectionPooler:
   # db user for pooler to use
   connection_pooler_user: "pooler"
   # docker image
-  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-22"
+  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-24"
   # max db connections the pooler should hold
   connection_pooler_max_db_connections: 60
   # default pooling mode

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -17,7 +17,7 @@ data:
   # connection_pooler_default_cpu_request: "500m"
   # connection_pooler_default_memory_limit: 100Mi
   # connection_pooler_default_memory_request: 100Mi
-  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-22"
+  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-24"
   # connection_pooler_max_db_connections: 60
   # connection_pooler_mode: "transaction"
   # connection_pooler_number_of_instances: 2

--- a/manifests/minimal-fake-pooler-deployment.yaml
+++ b/manifests/minimal-fake-pooler-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: postgres-operator
       containers:
       - name: postgres-operator
-        image: registry.opensource.zalan.do/acid/pgbouncer:master-22
+        image: registry.opensource.zalan.do/acid/pgbouncer:master-24
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -595,7 +595,7 @@ spec:
                     default: "pooler"
                   connection_pooler_image:
                     type: string
-                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-22"
+                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-24"
                   connection_pooler_max_db_connections:
                     type: integer
                     default: 60

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -190,7 +190,7 @@ configuration:
     connection_pooler_default_cpu_request: "500m"
     connection_pooler_default_memory_limit: 100Mi
     connection_pooler_default_memory_request: 100Mi
-    connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-22"
+    connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-24"
     # connection_pooler_max_db_connections: 60
     connection_pooler_mode: "transaction"
     connection_pooler_number_of_instances: 2

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -102,8 +102,9 @@ func (c *Cluster) serviceAddress(role PostgresRole) string {
 		return service.ObjectMeta.Name
 	}
 
-	c.logger.Warningf("No service for role %s", role)
-	return ""
+	defaultAddress := c.serviceName(role)
+	c.logger.Warningf("No service for role %s - defaulting to %s", role, defaultAddress)
+	return defaultAddress
 }
 
 func (c *Cluster) servicePort(role PostgresRole) int32 {


### PR DESCRIPTION
fixes #1511 

master-24 comes with alpine 3.15 base image

The PR also sets a safe default for PGHOST env variable in case serviceAddress does not find a service. When the deployment is created with empty PGHOST, connections will not work (`WARNING DNS lookup failed` and `pooler error: server login has been failing, try again later (server_login_retry)`) and the operator has no sync code to repair it because the pod template is not compared.