### PR TITLE
Make teamId in cluster name optional

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -88,6 +88,9 @@ spec:
               enable_spilo_wal_path_compat:
                 type: boolean
                 default: false
+              enable_team_id_clustername:
+                type: boolean
+                default: false
               etcd_host:
                 type: string
                 default: ""

--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -88,7 +88,7 @@ spec:
               enable_spilo_wal_path_compat:
                 type: boolean
                 default: false
-              enable_team_id_clustername:
+              enable_team_id_clustername_prefix:
                 type: boolean
                 default: false
               etcd_host:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -33,6 +33,8 @@ configGeneral:
   enable_shm_volume: true
   # enables backwards compatible path between Spilo 12 and Spilo 13+ images
   enable_spilo_wal_path_compat: false
+  # on cluster creation operator can verify that name starts with teamId
+  enable_team_id_clustername: false
   # etcd connection string for Patroni. Empty uses K8s-native DCS.
   etcd_host: ""
   # Spilo docker image

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -34,7 +34,7 @@ configGeneral:
   # enables backwards compatible path between Spilo 12 and Spilo 13+ images
   enable_spilo_wal_path_compat: false
   # on cluster creation operator can verify that name starts with teamId
-  enable_team_id_clustername: false
+  enable_team_id_clustername_prefix: false
   # etcd connection string for Patroni. Empty uses K8s-native DCS.
   etcd_host: ""
   # Spilo docker image

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -33,7 +33,7 @@ configGeneral:
   enable_shm_volume: true
   # enables backwards compatible path between Spilo 12 and Spilo 13+ images
   enable_spilo_wal_path_compat: false
-  # on cluster creation operator can verify that name starts with teamId
+  # operator will sync only clusters where name starts with teamId prefix
   enable_team_id_clustername_prefix: false
   # etcd connection string for Patroni. Empty uses K8s-native DCS.
   etcd_host: ""

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -53,8 +53,7 @@ Those parameters are grouped under the `metadata` top-level key.
 These parameters are grouped directly under  the `spec` key in the manifest.
 
 * **teamId**
-  name of the team the cluster belongs to. Changing it after the cluster
-  creation is not supported. Required field.
+  name of the team the cluster belongs to. Required field.
 
 * **numberOfInstances**
   total number of  instances for a given cluster. The operator parameters

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -94,8 +94,8 @@ Those are top-level keys, containing both leaf keys and groups.
 
 * **enable_team_id_clustername_prefix**
   To lower the risk of name clashes between clusters of different teams you
-  can turn on this flag and the operator will only allow new clusters that start
-  with the `teamId` (from `spec`) plus `-`. Default is `false`.
+  can turn on this flag and the operator will sync only clusters where the
+  name starts with the `teamId` (from `spec`) plus `-`. Default is `false`.
 
 * **etcd_host**
   Etcd connection string for Patroni defined as `host:port`. Not required when

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -92,7 +92,7 @@ Those are top-level keys, containing both leaf keys and groups.
 * **enable_spilo_wal_path_compat**
   enables backwards compatible path between Spilo 12 and Spilo 13+ images. The default is `false`.
 
-* **enable_team_id_clustername**
+* **enable_team_id_clustername_prefix**
   To lower the risk of name clashes between clusters of different teams you
   can turn on this flag and the operator will only allow new clusters that start
   with the `teamId` (from `spec`) plus `-`. Default is `false`.

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -92,6 +92,11 @@ Those are top-level keys, containing both leaf keys and groups.
 * **enable_spilo_wal_path_compat**
   enables backwards compatible path between Spilo 12 and Spilo 13+ images. The default is `false`.
 
+* **enable_team_id_clustername**
+  To lower the risk of name clashes between clusters of different teams you
+  can turn on this flag and the operator will only allow new clusters that start
+  with the `teamId` (from `spec`) plus `-`. Default is `false`.
+
 * **etcd_host**
   Etcd connection string for Patroni defined as `host:port`. Not required when
   Patroni native Kubernetes support is used. The default is empty (use

--- a/docs/user.md
+++ b/docs/user.md
@@ -45,8 +45,8 @@ Make sure, the `spec` section of the manifest contains at least a `teamId`, the
 The minimum volume size to run the `postgresql` resource on Elastic Block
 Storage (EBS) is `1Gi`.
 
-Note, that when `enable_team_id_clustername` is set to `true` the name of the
-cluster must start with the `teamId` and `-`. At Zalando we use team IDs
+Note, that when `enable_team_id_clustername_prefix` is set to `true` the name
+of the cluster must start with the `teamId` and `-`. At Zalando we use team IDs
 (nicknames) to lower chances of duplicate cluster names and colliding entities.
 The team ID would also be used to query an API to get all members of a team
 and create [database roles](#teams-api-roles) for them. Besides, the maximum

--- a/docs/user.md
+++ b/docs/user.md
@@ -45,11 +45,12 @@ Make sure, the `spec` section of the manifest contains at least a `teamId`, the
 The minimum volume size to run the `postgresql` resource on Elastic Block
 Storage (EBS) is `1Gi`.
 
-Note, that the name of the cluster must start with the `teamId` and `-`. At
-Zalando we use team IDs (nicknames) to lower the chance of duplicate cluster
-names and colliding entities. The team ID would also be used to query an API to
-get all members of a team and create [database roles](#teams-api-roles) for
-them. Besides, the maximum cluster name length is 53 characters.
+Note, that when `enable_team_id_clustername` is set to `true` the name of the
+cluster must start with the `teamId` and `-`. At Zalando we use team IDs
+(nicknames) to lower chances of duplicate cluster names and colliding entities.
+The team ID would also be used to query an API to get all members of a team
+and create [database roles](#teams-api-roles) for them. Besides, the maximum
+cluster name length is 53 characters.
 
 ## Watch pods being created
 

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -57,6 +57,7 @@ data:
   # enable_shm_volume: "true"
   # enable_sidecars: "true"
   enable_spilo_wal_path_compat: "true"
+  enable_team_id_clustername: "false"
   enable_team_member_deprecation: "false"
   # enable_team_superuser: "false"
   enable_teams_api: "false"

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -57,7 +57,7 @@ data:
   # enable_shm_volume: "true"
   # enable_sidecars: "true"
   enable_spilo_wal_path_compat: "true"
-  enable_team_id_clustername: "false"
+  enable_team_id_clustername_prefix: "false"
   enable_team_member_deprecation: "false"
   # enable_team_superuser: "false"
   enable_teams_api: "false"

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -86,7 +86,7 @@ spec:
               enable_spilo_wal_path_compat:
                 type: boolean
                 default: false
-              enable_team_id_clustername:
+              enable_team_id_clustername_prefix:
                 type: boolean
                 default: false
               etcd_host:

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -86,6 +86,9 @@ spec:
               enable_spilo_wal_path_compat:
                 type: boolean
                 default: false
+              enable_team_id_clustername:
+                type: boolean
+                default: false
               etcd_host:
                 type: string
                 default: ""

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -11,6 +11,7 @@ configuration:
   enable_pgversion_env_var: true
   # enable_shm_volume: true
   enable_spilo_wal_path_compat: false
+  enable_team_id_clustername: false
   etcd_host: ""
   # ignore_instance_limits_annotation_key: ""
   # kubernetes_use_configmaps: false

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -11,7 +11,7 @@ configuration:
   enable_pgversion_env_var: true
   # enable_shm_volume: true
   enable_spilo_wal_path_compat: false
-  enable_team_id_clustername: false
+  enable_team_id_clustername_prefix: false
   etcd_host: ""
   # ignore_instance_limits_annotation_key: ""
   # kubernetes_use_configmaps: false

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1112,7 +1112,7 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 					"enable_spilo_wal_path_compat": {
 						Type: "boolean",
 					},
-					"enable_team_id_clustername": {
+					"enable_team_id_clustername_prefix": {
 						Type: "boolean",
 					},
 					"etcd_host": {

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1112,6 +1112,9 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 					"enable_spilo_wal_path_compat": {
 						Type: "boolean",
 					},
+					"enable_team_id_clustername": {
+						Type: "boolean",
+					},
 					"etcd_host": {
 						Type: "string",
 					},

--- a/pkg/apis/acid.zalan.do/v1/marshal.go
+++ b/pkg/apis/acid.zalan.do/v1/marshal.go
@@ -110,15 +110,9 @@ func (p *Postgresql) UnmarshalJSON(data []byte) error {
 	}
 	tmp2 := Postgresql(tmp)
 
-	if clusterName, err := extractClusterName(tmp2.ObjectMeta.Name, tmp2.Spec.TeamID); err != nil {
-		tmp2.Error = err.Error()
-		tmp2.Status = PostgresStatus{PostgresClusterStatus: ClusterStatusInvalid}
-	} else if err := validateCloneClusterDescription(tmp2.Spec.Clone); err != nil {
-
+	if err := validateCloneClusterDescription(tmp2.Spec.Clone); err != nil {
 		tmp2.Error = err.Error()
 		tmp2.Status.PostgresClusterStatus = ClusterStatusInvalid
-	} else {
-		tmp2.Spec.ClusterName = clusterName
 	}
 
 	*p = tmp2

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -234,6 +234,7 @@ type OperatorConfigurationData struct {
 	EnableLazySpiloUpgrade     bool                               `json:"enable_lazy_spilo_upgrade,omitempty"`
 	EnablePgVersionEnvVar      bool                               `json:"enable_pgversion_env_var,omitempty"`
 	EnableSpiloWalPathCompat   bool                               `json:"enable_spilo_wal_path_compat,omitempty"`
+	EnableTeamIdClustername    bool                               `json:"enable_team_id_clustername,omitempty"`
 	EtcdHost                   string                             `json:"etcd_host,omitempty"`
 	KubernetesUseConfigMaps    bool                               `json:"kubernetes_use_configmaps,omitempty"`
 	DockerImage                string                             `json:"docker_image,omitempty"`

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -228,36 +228,36 @@ type OperatorLogicalBackupConfiguration struct {
 
 // OperatorConfigurationData defines the operation config
 type OperatorConfigurationData struct {
-	EnableCRDRegistration      *bool                              `json:"enable_crd_registration,omitempty"`
-	EnableCRDValidation        *bool                              `json:"enable_crd_validation,omitempty"`
-	CRDCategories              []string                           `json:"crd_categories,omitempty"`
-	EnableLazySpiloUpgrade     bool                               `json:"enable_lazy_spilo_upgrade,omitempty"`
-	EnablePgVersionEnvVar      bool                               `json:"enable_pgversion_env_var,omitempty"`
-	EnableSpiloWalPathCompat   bool                               `json:"enable_spilo_wal_path_compat,omitempty"`
-	EnableTeamIdClustername    bool                               `json:"enable_team_id_clustername,omitempty"`
-	EtcdHost                   string                             `json:"etcd_host,omitempty"`
-	KubernetesUseConfigMaps    bool                               `json:"kubernetes_use_configmaps,omitempty"`
-	DockerImage                string                             `json:"docker_image,omitempty"`
-	Workers                    uint32                             `json:"workers,omitempty"`
-	ResyncPeriod               Duration                           `json:"resync_period,omitempty"`
-	RepairPeriod               Duration                           `json:"repair_period,omitempty"`
-	SetMemoryRequestToLimit    bool                               `json:"set_memory_request_to_limit,omitempty"`
-	ShmVolume                  *bool                              `json:"enable_shm_volume,omitempty"`
-	SidecarImages              map[string]string                  `json:"sidecar_docker_images,omitempty"` // deprecated in favour of SidecarContainers
-	SidecarContainers          []v1.Container                     `json:"sidecars,omitempty"`
-	PostgresUsersConfiguration PostgresUsersConfiguration         `json:"users"`
-	MajorVersionUpgrade        MajorVersionUpgradeConfiguration   `json:"major_version_upgrade"`
-	Kubernetes                 KubernetesMetaConfiguration        `json:"kubernetes"`
-	PostgresPodResources       PostgresPodResourcesDefaults       `json:"postgres_pod_resources"`
-	Timeouts                   OperatorTimeouts                   `json:"timeouts"`
-	LoadBalancer               LoadBalancerConfiguration          `json:"load_balancer"`
-	AWSGCP                     AWSGCPConfiguration                `json:"aws_or_gcp"`
-	OperatorDebug              OperatorDebugConfiguration         `json:"debug"`
-	TeamsAPI                   TeamsAPIConfiguration              `json:"teams_api"`
-	LoggingRESTAPI             LoggingRESTAPIConfiguration        `json:"logging_rest_api"`
-	Scalyr                     ScalyrConfiguration                `json:"scalyr"`
-	LogicalBackup              OperatorLogicalBackupConfiguration `json:"logical_backup"`
-	ConnectionPooler           ConnectionPoolerConfiguration      `json:"connection_pooler"`
+	EnableCRDRegistration         *bool                              `json:"enable_crd_registration,omitempty"`
+	EnableCRDValidation           *bool                              `json:"enable_crd_validation,omitempty"`
+	CRDCategories                 []string                           `json:"crd_categories,omitempty"`
+	EnableLazySpiloUpgrade        bool                               `json:"enable_lazy_spilo_upgrade,omitempty"`
+	EnablePgVersionEnvVar         bool                               `json:"enable_pgversion_env_var,omitempty"`
+	EnableSpiloWalPathCompat      bool                               `json:"enable_spilo_wal_path_compat,omitempty"`
+	EnableTeamIdClusternamePrefix bool                               `json:"enable_team_id_clustername_prefix,omitempty"`
+	EtcdHost                      string                             `json:"etcd_host,omitempty"`
+	KubernetesUseConfigMaps       bool                               `json:"kubernetes_use_configmaps,omitempty"`
+	DockerImage                   string                             `json:"docker_image,omitempty"`
+	Workers                       uint32                             `json:"workers,omitempty"`
+	ResyncPeriod                  Duration                           `json:"resync_period,omitempty"`
+	RepairPeriod                  Duration                           `json:"repair_period,omitempty"`
+	SetMemoryRequestToLimit       bool                               `json:"set_memory_request_to_limit,omitempty"`
+	ShmVolume                     *bool                              `json:"enable_shm_volume,omitempty"`
+	SidecarImages                 map[string]string                  `json:"sidecar_docker_images,omitempty"` // deprecated in favour of SidecarContainers
+	SidecarContainers             []v1.Container                     `json:"sidecars,omitempty"`
+	PostgresUsersConfiguration    PostgresUsersConfiguration         `json:"users"`
+	MajorVersionUpgrade           MajorVersionUpgradeConfiguration   `json:"major_version_upgrade"`
+	Kubernetes                    KubernetesMetaConfiguration        `json:"kubernetes"`
+	PostgresPodResources          PostgresPodResourcesDefaults       `json:"postgres_pod_resources"`
+	Timeouts                      OperatorTimeouts                   `json:"timeouts"`
+	LoadBalancer                  LoadBalancerConfiguration          `json:"load_balancer"`
+	AWSGCP                        AWSGCPConfiguration                `json:"aws_or_gcp"`
+	OperatorDebug                 OperatorDebugConfiguration         `json:"debug"`
+	TeamsAPI                      TeamsAPIConfiguration              `json:"teams_api"`
+	LoggingRESTAPI                LoggingRESTAPIConfiguration        `json:"logging_rest_api"`
+	Scalyr                        ScalyrConfiguration                `json:"scalyr"`
+	LogicalBackup                 OperatorLogicalBackupConfiguration `json:"logical_backup"`
+	ConnectionPooler              ConnectionPoolerConfiguration      `json:"connection_pooler"`
 
 	MinInstances                      int32  `json:"min_instances,omitempty"`
 	MaxInstances                      int32  `json:"max_instances,omitempty"`

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -214,7 +214,7 @@ type UserFlags []string
 
 // PostgresStatus contains status of the PostgreSQL cluster (running, creation failed etc.)
 type PostgresStatus struct {
-	PostgresClusterStatus string `json:"PostgresClusterStatus,omitempty"`
+	PostgresClusterStatus string `json:"PostgresClusterStatus"`
 }
 
 // ConnectionPooler Options for connection pooler

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -214,7 +214,7 @@ type UserFlags []string
 
 // PostgresStatus contains status of the PostgreSQL cluster (running, creation failed etc.)
 type PostgresStatus struct {
-	PostgresClusterStatus string `json:"PostgresClusterStatus"`
+	PostgresClusterStatus string `json:"PostgresClusterStatus,omitempty"`
 }
 
 // ConnectionPooler Options for connection pooler

--- a/pkg/apis/acid.zalan.do/v1/util.go
+++ b/pkg/apis/acid.zalan.do/v1/util.go
@@ -46,7 +46,7 @@ func parseWeekday(s string) (time.Weekday, error) {
 	return time.Weekday(weekday), nil
 }
 
-func extractClusterName(clusterName string, teamName string) (string, error) {
+func ExtractClusterName(clusterName string, teamName string) (string, error) {
 	teamNameLen := len(teamName)
 	if len(clusterName) < teamNameLen+2 {
 		return "", fmt.Errorf("cluster name must match {TEAM}-{NAME} format. Got cluster name '%v', team name '%v'", clusterName, teamName)

--- a/pkg/apis/acid.zalan.do/v1/util_test.go
+++ b/pkg/apis/acid.zalan.do/v1/util_test.go
@@ -628,10 +628,10 @@ func TestServiceAnnotations(t *testing.T) {
 func TestClusterName(t *testing.T) {
 	for _, tt := range clusterNames {
 		t.Run(tt.about, func(t *testing.T) {
-			name, err := extractClusterName(tt.in, tt.inTeam)
+			name, err := ExtractClusterName(tt.in, tt.inTeam)
 			if err != nil {
 				if tt.err == nil || err.Error() != tt.err.Error() {
-					t.Errorf("extractClusterName expected error: %v, got: %v", tt.err, err)
+					t.Errorf("ExtractClusterName expected error: %v, got: %v", tt.err, err)
 				}
 				return
 			} else if tt.err != nil {

--- a/pkg/apis/acid.zalan.do/v1/util_test.go
+++ b/pkg/apis/acid.zalan.do/v1/util_test.go
@@ -330,28 +330,10 @@ var unmarshalCluster = []struct {
 				Clone: &CloneDescription{
 					ClusterName: "acid-batman",
 				},
-				ClusterName: "testcluster1",
 			},
 			Error: "",
 		},
 		marshal: []byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"acid-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"9.6","parameters":{"log_statement":"all","max_connections":"10","shared_buffers":"32MB"}},"pod_priority_class_name":"spilo-pod-priority","volume":{"size":"5Gi","storageClass":"SSD", "subPath": "subdir"},"enableShmVolume":false,"patroni":{"initdb":{"data-checksums":"true","encoding":"UTF8","locale":"en_US.UTF-8"},"pg_hba":["hostssl all all 0.0.0.0/0 md5","host    all all 0.0.0.0/0 md5"],"ttl":30,"loop_wait":10,"retry_timeout":10,"maximum_lag_on_failover":33554432,"slots":{"permanent_logical_1":{"database":"foo","plugin":"pgoutput","type":"logical"}}},"resources":{"requests":{"cpu":"10m","memory":"50Mi"},"limits":{"cpu":"300m","memory":"3000Mi"}},"teamId":"acid","allowedSourceRanges":["127.0.0.1/32"],"numberOfInstances":2,"users":{"zalando":["superuser","createdb"]},"maintenanceWindows":["Mon:01:00-06:00","Sat:00:00-04:00","05:00-05:15"],"clone":{"cluster":"acid-batman"}},"status":{"PostgresClusterStatus":""}}`),
-		err:     nil},
-	{
-		about: "example with teamId set in input",
-		in:    []byte(`{"kind": "Postgresql","apiVersion": "acid.zalan.do/v1","metadata": {"name": "teapot-testcluster1"}, "spec": {"teamId": "acid"}}`),
-		out: Postgresql{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Postgresql",
-				APIVersion: "acid.zalan.do/v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "teapot-testcluster1",
-			},
-			Spec:   PostgresSpec{TeamID: "acid"},
-			Status: PostgresStatus{PostgresClusterStatus: ClusterStatusInvalid},
-			Error:  errors.New("name must match {TEAM}-{NAME} format").Error(),
-		},
-		marshal: []byte(`{"kind":"Postgresql","apiVersion":"acid.zalan.do/v1","metadata":{"name":"teapot-testcluster1","creationTimestamp":null},"spec":{"postgresql":{"version":"","parameters":null},"volume":{"size":"","storageClass":""},"patroni":{"initdb":null,"pg_hba":null,"ttl":0,"loop_wait":0,"retry_timeout":0,"maximum_lag_on_failover":0,"slots":null},"teamId":"acid","allowedSourceRanges":null,"numberOfInstances":0,"users":null,"clone":null},"status":{"PostgresClusterStatus":"Invalid"}}`),
 		err:     nil},
 	{
 		about: "example with clone",
@@ -369,7 +351,6 @@ var unmarshalCluster = []struct {
 				Clone: &CloneDescription{
 					ClusterName: "team-batman",
 				},
-				ClusterName: "testcluster1",
 			},
 			Error: "",
 		},
@@ -391,7 +372,6 @@ var unmarshalCluster = []struct {
 				StandbyCluster: &StandbyDescription{
 					S3WalPath: "s3://custom/path/to/bucket/",
 				},
-				ClusterName: "testcluster1",
 			},
 			Error: "",
 		},

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -244,7 +244,12 @@ func getPostgresContainer(podSpec *v1.PodSpec) (pgContainer v1.Container) {
 func (c *Cluster) getTeamMembers(teamID string) ([]string, error) {
 
 	if teamID == "" {
-		return nil, fmt.Errorf("no teamId specified")
+		msg := "no teamId specified"
+		if c.OpConfig.EnableTeamIdClustername {
+			return nil, fmt.Errorf(msg)
+		}
+		c.logger.Warnf(msg)
+		return nil, nil
 	}
 
 	members := []string{}

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -245,7 +245,7 @@ func (c *Cluster) getTeamMembers(teamID string) ([]string, error) {
 
 	if teamID == "" {
 		msg := "no teamId specified"
-		if c.OpConfig.EnableTeamIdClustername {
+		if c.OpConfig.EnableTeamIdClusternamePrefix {
 			return nil, fmt.Errorf(msg)
 		}
 		c.logger.Warnf(msg)

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -36,7 +36,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.EnableLazySpiloUpgrade = fromCRD.EnableLazySpiloUpgrade
 	result.EnablePgVersionEnvVar = fromCRD.EnablePgVersionEnvVar
 	result.EnableSpiloWalPathCompat = fromCRD.EnableSpiloWalPathCompat
-	result.EnableTeamIdClustername = fromCRD.EnableTeamIdClustername
+	result.EnableTeamIdClusternamePrefix = fromCRD.EnableTeamIdClusternamePrefix
 	result.EtcdHost = fromCRD.EtcdHost
 	result.KubernetesUseConfigMaps = fromCRD.KubernetesUseConfigMaps
 	result.DockerImage = util.Coalesce(fromCRD.DockerImage, "registry.opensource.zalan.do/acid/spilo-14:2.1-p6")

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -36,6 +36,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.EnableLazySpiloUpgrade = fromCRD.EnableLazySpiloUpgrade
 	result.EnablePgVersionEnvVar = fromCRD.EnablePgVersionEnvVar
 	result.EnableSpiloWalPathCompat = fromCRD.EnableSpiloWalPathCompat
+	result.EnableTeamIdClustername = fromCRD.EnableTeamIdClustername
 	result.EtcdHost = fromCRD.EtcdHost
 	result.KubernetesUseConfigMaps = fromCRD.KubernetesUseConfigMaps
 	result.DockerImage = util.Coalesce(fromCRD.DockerImage, "registry.opensource.zalan.do/acid/spilo-14:2.1-p6")

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -226,7 +226,7 @@ type Config struct {
 	EnableCrossNamespaceSecret             bool              `name:"enable_cross_namespace_secret" default:"false"`
 	EnablePgVersionEnvVar                  bool              `name:"enable_pgversion_env_var" default:"true"`
 	EnableSpiloWalPathCompat               bool              `name:"enable_spilo_wal_path_compat" default:"false"`
-	EnableTeamIdClustername                bool              `name:"enable_team_id_clustername" default:"false"`
+	EnableTeamIdClusternamePrefix          bool              `name:"enable_team_id_clustername_prefix" default:"false"`
 	MajorVersionUpgradeMode                string            `name:"major_version_upgrade_mode" default:"off"`
 	MajorVersionUpgradeTeamAllowList       []string          `name:"major_version_upgrade_team_allow_list" default:""`
 	MinimalMajorVersion                    string            `name:"minimal_major_version" default:"9.6"`

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -226,6 +226,7 @@ type Config struct {
 	EnableCrossNamespaceSecret             bool              `name:"enable_cross_namespace_secret" default:"false"`
 	EnablePgVersionEnvVar                  bool              `name:"enable_pgversion_env_var" default:"true"`
 	EnableSpiloWalPathCompat               bool              `name:"enable_spilo_wal_path_compat" default:"false"`
+	EnableTeamIdClustername                bool              `name:"enable_team_id_clustername" default:"false"`
 	MajorVersionUpgradeMode                string            `name:"major_version_upgrade_mode" default:"off"`
 	MajorVersionUpgradeTeamAllowList       []string          `name:"major_version_upgrade_team_allow_list" default:""`
 	MinimalMajorVersion                    string            `name:"minimal_major_version" default:"9.6"`


### PR DESCRIPTION
Teams of cluster change. Although the name of the cluster is immutable, it would still be helpful to change teamId field without the need to create a PostgresTeam resource.

On start up the operator calls `add_cluster` for all Postgresql resource it finds. When the new `enable_team_id_clustername_prefix` is enabled and cluster name does not start with team ID, `add_cluster` will return an error message and the cluster is not added to the operator's internal cluster list.

The Postgresql resource itself still gets created via K8s API. We have no controller in between to block this. Because the resource is there we can patch it's `PostgresClusterStatus` field in status subresource to `invalid`. Each sync on the cluster will try to call add_cluster again because it does not exist in the operator#s internal list. When the option is turned off and operator is restarted, the cluster is synced like very other cluster.

This PR keeps `teamId` as an `required` field of the cluster manifest (because we want to keep cluster ownership from teams) and it deprecates the cluster's internal `ClusterName` field which used to store the cluster name without the `teamId` prefix. We did not use the `ClusterName` anywhere else.