### PR TITLE
switch to policy API v1 for PDBs

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
            curl \
            vim \
     && pip3 install --no-cache-dir -r requirements.txt \
-    && curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.22.0/bin/linux/amd64/kubectl \
+    && curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.24.3/bin/linux/amd64/kubectl \
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin/kubectl \
     && apt-get clean \

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -47,7 +47,7 @@ tools:
 	# install pinned version of 'kind'
 	# go install must run outside of a dir with a (module-based) Go project !
 	# otherwise go install updates project's dependencies and/or behaves differently
-	cd "/tmp" && GO111MODULE=on go install sigs.k8s.io/kind@v0.11.1
+	cd "/tmp" && GO111MODULE=on go install sigs.k8s.io/kind@v0.14.0
 
 e2etest: tools copy clean
 	./run.sh main

--- a/e2e/exec_into_env.sh
+++ b/e2e/exec_into_env.sh
@@ -3,7 +3,7 @@
 export cluster_name="postgres-operator-e2e-tests"
 export kubeconfig_path="/tmp/kind-config-${cluster_name}"
 export operator_image="registry.opensource.zalan.do/acid/postgres-operator:latest"
-export e2e_test_runner_image="registry.opensource.zalan.do/acid/postgres-operator-e2e-tests-runner:0.3"
+export e2e_test_runner_image="registry.opensource.zalan.do/acid/postgres-operator-e2e-tests-runner:0.4"
 
 docker run -it --entrypoint /bin/bash --network=host -e "TERM=xterm-256color" \
     --mount type=bind,source="$(readlink -f ${kubeconfig_path})",target=/root/.kube/config \

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,3 +1,3 @@
-kubernetes==11.0.0
-timeout_decorator==0.4.1
-pyyaml==5.4.1
+kubernetes==24.2.0
+timeout_decorator==0.5.0
+pyyaml==6.0

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -9,7 +9,7 @@ IFS=$'\n\t'
 readonly cluster_name="postgres-operator-e2e-tests"
 readonly kubeconfig_path="/tmp/kind-config-${cluster_name}"
 readonly spilo_image="registry.opensource.zalan.do/acid/spilo-14-e2e:0.1"
-readonly e2e_test_runner_image="registry.opensource.zalan.do/acid/postgres-operator-e2e-tests-runner:0.3"
+readonly e2e_test_runner_image="registry.opensource.zalan.do/acid/postgres-operator-e2e-tests-runner:0.4"
 
 export GOPATH=${GOPATH-~/go}
 export PATH=${GOPATH}/bin:$PATH

--- a/e2e/tests/k8s_api.py
+++ b/e2e/tests/k8s_api.py
@@ -25,7 +25,7 @@ class K8sApi:
         self.apps_v1 = client.AppsV1Api()
         self.batch_v1_beta1 = client.BatchV1beta1Api()
         self.custom_objects_api = client.CustomObjectsApi()
-        self.policy_v1_beta1 = client.PolicyV1beta1Api()
+        self.policy_v1 = client.PolicyV1Api()
         self.storage_v1_api = client.StorageV1Api()
 
 
@@ -179,7 +179,7 @@ class K8s:
         return len(self.api.apps_v1.list_namespaced_deployment(namespace, label_selector=labels).items)
 
     def count_pdbs_with_label(self, labels, namespace='default'):
-        return len(self.api.policy_v1_beta1.list_namespaced_pod_disruption_budget(
+        return len(self.api.policy_v1.list_namespaced_pod_disruption_budget(
             namespace, label_selector=labels).items)
 
     def count_running_pods(self, labels='application=spilo,cluster-name=acid-minimal-cluster', namespace='default'):
@@ -471,7 +471,7 @@ class K8sBase:
         return len(self.api.apps_v1.list_namespaced_deployment(namespace, label_selector=labels).items)
 
     def count_pdbs_with_label(self, labels, namespace='default'):
-        return len(self.api.policy_v1_beta1.list_namespaced_pod_disruption_budget(
+        return len(self.api.policy_v1.list_namespaced_pod_disruption_budget(
             namespace, label_selector=labels).items)
 
     def count_running_pods(self, labels='application=spilo,cluster-name=acid-minimal-cluster', namespace='default'):

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -29,7 +29,7 @@ import (
 	"github.com/zalando/postgres-operator/pkg/util/volumes"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	policybeta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -61,7 +61,7 @@ type kubeResources struct {
 	Endpoints           map[PostgresRole]*v1.Endpoints
 	Secrets             map[types.UID]*v1.Secret
 	Statefulset         *appsv1.StatefulSet
-	PodDisruptionBudget *policybeta1.PodDisruptionBudget
+	PodDisruptionBudget *policyv1.PodDisruptionBudget
 	//Pods are treated separately
 	//PVCs are treated separately
 }

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -13,7 +13,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	policybeta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1985,7 +1985,7 @@ func (c *Cluster) generateStandbyEnvironment(description *acidv1.StandbyDescript
 	return result
 }
 
-func (c *Cluster) generatePodDisruptionBudget() *policybeta1.PodDisruptionBudget {
+func (c *Cluster) generatePodDisruptionBudget() *policyv1.PodDisruptionBudget {
 	minAvailable := intstr.FromInt(1)
 	pdbEnabled := c.OpConfig.EnablePodDisruptionBudget
 
@@ -1994,14 +1994,14 @@ func (c *Cluster) generatePodDisruptionBudget() *policybeta1.PodDisruptionBudget
 		minAvailable = intstr.FromInt(0)
 	}
 
-	return &policybeta1.PodDisruptionBudget{
+	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        c.podDisruptionBudgetName(),
 			Namespace:   c.Namespace,
 			Labels:      c.labelsSet(true),
 			Annotations: c.annotationsSet(nil),
 		},
-		Spec: policybeta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			MinAvailable: &minAvailable,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: c.roleLabelsSet(false, Master),

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -21,7 +21,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1979,7 +1979,7 @@ func TestSidecars(t *testing.T) {
 func TestGeneratePodDisruptionBudget(t *testing.T) {
 	tests := []struct {
 		c   *Cluster
-		out policyv1beta1.PodDisruptionBudget
+		out policyv1.PodDisruptionBudget
 	}{
 		// With multiple instances.
 		{
@@ -1991,13 +1991,13 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 					Spec:       acidv1.PostgresSpec{TeamID: "myapp", NumberOfInstances: 3}},
 				logger,
 				eventRecorder),
-			policyv1beta1.PodDisruptionBudget{
+			policyv1.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "postgres-myapp-database-pdb",
 					Namespace: "myapp",
 					Labels:    map[string]string{"team": "myapp", "cluster-name": "myapp-database"},
 				},
-				Spec: policyv1beta1.PodDisruptionBudgetSpec{
+				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: util.ToIntStr(1),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"spilo-role": "master", "cluster-name": "myapp-database"},
@@ -2015,13 +2015,13 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 					Spec:       acidv1.PostgresSpec{TeamID: "myapp", NumberOfInstances: 0}},
 				logger,
 				eventRecorder),
-			policyv1beta1.PodDisruptionBudget{
+			policyv1.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "postgres-myapp-database-pdb",
 					Namespace: "myapp",
 					Labels:    map[string]string{"team": "myapp", "cluster-name": "myapp-database"},
 				},
-				Spec: policyv1beta1.PodDisruptionBudgetSpec{
+				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: util.ToIntStr(0),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"spilo-role": "master", "cluster-name": "myapp-database"},
@@ -2039,13 +2039,13 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 					Spec:       acidv1.PostgresSpec{TeamID: "myapp", NumberOfInstances: 3}},
 				logger,
 				eventRecorder),
-			policyv1beta1.PodDisruptionBudget{
+			policyv1.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "postgres-myapp-database-pdb",
 					Namespace: "myapp",
 					Labels:    map[string]string{"team": "myapp", "cluster-name": "myapp-database"},
 				},
-				Spec: policyv1beta1.PodDisruptionBudgetSpec{
+				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: util.ToIntStr(0),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"spilo-role": "master", "cluster-name": "myapp-database"},
@@ -2063,13 +2063,13 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 					Spec:       acidv1.PostgresSpec{TeamID: "myapp", NumberOfInstances: 3}},
 				logger,
 				eventRecorder),
-			policyv1beta1.PodDisruptionBudget{
+			policyv1.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "postgres-myapp-database-databass-budget",
 					Namespace: "myapp",
 					Labels:    map[string]string{"team": "myapp", "cluster-name": "myapp-database"},
 				},
-				Spec: policyv1beta1.PodDisruptionBudgetSpec{
+				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: util.ToIntStr(1),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"spilo-role": "master", "cluster-name": "myapp-database"},

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -9,7 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"
-	policybeta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -404,7 +404,7 @@ func (c *Cluster) generateEndpointSubsets(role PostgresRole) []v1.EndpointSubset
 	return result
 }
 
-func (c *Cluster) createPodDisruptionBudget() (*policybeta1.PodDisruptionBudget, error) {
+func (c *Cluster) createPodDisruptionBudget() (*policyv1.PodDisruptionBudget, error) {
 	podDisruptionBudgetSpec := c.generatePodDisruptionBudget()
 	podDisruptionBudget, err := c.KubeClient.
 		PodDisruptionBudgets(podDisruptionBudgetSpec.Namespace).
@@ -418,7 +418,7 @@ func (c *Cluster) createPodDisruptionBudget() (*policybeta1.PodDisruptionBudget,
 	return podDisruptionBudget, nil
 }
 
-func (c *Cluster) updatePodDisruptionBudget(pdb *policybeta1.PodDisruptionBudget) error {
+func (c *Cluster) updatePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget) error {
 	if c.PodDisruptionBudget == nil {
 		return fmt.Errorf("there is no pod disruption budget in the cluster")
 	}
@@ -602,6 +602,6 @@ func (c *Cluster) GetStatefulSet() *appsv1.StatefulSet {
 }
 
 // GetPodDisruptionBudget returns cluster's kubernetes PodDisruptionBudget
-func (c *Cluster) GetPodDisruptionBudget() *policybeta1.PodDisruptionBudget {
+func (c *Cluster) GetPodDisruptionBudget() *policyv1.PodDisruptionBudget {
 	return c.PodDisruptionBudget
 }

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -17,7 +17,7 @@ import (
 	"github.com/zalando/postgres-operator/pkg/util/k8sutil"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"
-	policybeta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -236,7 +236,7 @@ func (c *Cluster) syncEndpoint(role PostgresRole) error {
 
 func (c *Cluster) syncPodDisruptionBudget(isUpdate bool) error {
 	var (
-		pdb *policybeta1.PodDisruptionBudget
+		pdb *policyv1.PodDisruptionBudget
 		err error
 	)
 	if pdb, err = c.KubeClient.PodDisruptionBudgets(c.Namespace).Get(context.TODO(), c.podDisruptionBudgetName(), metav1.GetOptions{}); err == nil {

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -6,7 +6,7 @@ import (
 	acidv1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	policybeta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -64,7 +64,7 @@ type ClusterStatus struct {
 	MasterEndpoint      *v1.Endpoints
 	ReplicaEndpoint     *v1.Endpoints
 	StatefulSet         *appsv1.StatefulSet
-	PodDisruptionBudget *policybeta1.PodDisruptionBudget
+	PodDisruptionBudget *policyv1.PodDisruptionBudget
 
 	CurrentProcess Process
 	Worker         uint32

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -14,7 +14,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	policybeta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -159,7 +159,7 @@ func metaAnnotationsPatch(annotations map[string]string) ([]byte, error) {
 	}{&meta})
 }
 
-func (c *Cluster) logPDBChanges(old, new *policybeta1.PodDisruptionBudget, isUpdate bool, reason string) {
+func (c *Cluster) logPDBChanges(old, new *policyv1.PodDisruptionBudget, isUpdate bool, reason string) {
 	if isUpdate {
 		c.logger.Infof("pod disruption budget %q has been changed", util.NameFromMeta(old.ObjectMeta))
 	} else {

--- a/pkg/cluster/util_test.go
+++ b/pkg/cluster/util_test.go
@@ -19,7 +19,7 @@ func newFakeK8sAnnotationsClient() (k8sutil.KubernetesClient, *k8sFake.Clientset
 	acidClientSet := fakeacidv1.NewSimpleClientset()
 
 	return k8sutil.KubernetesClient{
-		PodDisruptionBudgetsGetter: clientSet.PolicyV1beta1(),
+		PodDisruptionBudgetsGetter: clientSet.PolicyV1(),
 		ServicesGetter:             clientSet.CoreV1(),
 		StatefulSetsGetter:         clientSet.AppsV1(),
 		PostgresqlsGetter:          acidClientSet.AcidV1(),

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -18,7 +18,7 @@ import (
 	"github.com/zalando/postgres-operator/pkg/spec"
 	apiappsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	policybeta1 "k8s.io/api/policy/v1beta1"
+	apipolicyv1 "k8s.io/api/policy/v1"
 	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	policyv1beta1 "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
+	policyv1 "k8s.io/client-go/kubernetes/typed/policy/v1"
 	rbacv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -61,7 +61,7 @@ type KubernetesClient struct {
 	appsv1.StatefulSetsGetter
 	appsv1.DeploymentsGetter
 	rbacv1.RoleBindingsGetter
-	policyv1beta1.PodDisruptionBudgetsGetter
+	policyv1.PodDisruptionBudgetsGetter
 	apiextv1.CustomResourceDefinitionsGetter
 	clientbatchv1beta1.CronJobsGetter
 	acidv1.OperatorConfigurationsGetter
@@ -156,7 +156,7 @@ func NewFromConfig(cfg *rest.Config) (KubernetesClient, error) {
 	kubeClient.NamespacesGetter = client.CoreV1()
 	kubeClient.StatefulSetsGetter = client.AppsV1()
 	kubeClient.DeploymentsGetter = client.AppsV1()
-	kubeClient.PodDisruptionBudgetsGetter = client.PolicyV1beta1()
+	kubeClient.PodDisruptionBudgetsGetter = client.PolicyV1()
 	kubeClient.RESTClient = client.CoreV1().RESTClient()
 	kubeClient.RoleBindingsGetter = client.RbacV1()
 	kubeClient.CronJobsGetter = client.BatchV1beta1()
@@ -214,7 +214,7 @@ func (client *KubernetesClient) SetPostgresCRDStatus(clusterName spec.Namespaced
 }
 
 // SamePDB compares the PodDisruptionBudgets
-func SamePDB(cur, new *policybeta1.PodDisruptionBudget) (match bool, reason string) {
+func SamePDB(cur, new *apipolicyv1.PodDisruptionBudget) (match bool, reason string) {
 	//TODO: improve comparison
 	match = reflect.DeepEqual(new.Spec, cur.Spec)
 	if !match {


### PR DESCRIPTION
PodDisruptionBudget API `v1beta1` is deprecated since K8s v 1.21 and is removed starting from v 1.25.
Note, with this change the Postgres Operator will not work for users on K8s 1.20 and lower.

closes #1999