### PR TITLE
fetch pooler and fes_user system user only when corresponding features are used

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1136,8 +1136,8 @@ func (c *Cluster) initSystemUsers() {
 			Password:  util.RandomPassword(constants.PasswordLength),
 		}
 
-		if _, exists := c.systemUsers[username]; !exists {
-			c.systemUsers[username] = streamUser
+		if _, exists := c.systemUsers[constants.EventStreamUserKeyName]; !exists {
+			c.systemUsers[constants.EventStreamUserKeyName] = streamUser
 		}
 	}
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1127,7 +1127,7 @@ func (c *Cluster) initSystemUsers() {
 	// replication users for event streams are another exception
 	// the operator will create one replication user for all streams
 	if len(c.Spec.Streams) > 0 {
-		username := constants.EventStreamSourceSlotPrefix + constants.UserRoleNameSuffix
+		username := fmt.Sprintf("%s%s", constants.EventStreamSourceSlotPrefix, constants.UserRoleNameSuffix)
 		streamUser := spec.PgUser{
 			Origin:    spec.RoleOriginStream,
 			Name:      username,
@@ -1155,9 +1155,9 @@ func (c *Cluster) initPreparedDatabaseRoles() error {
 		constants.WriterRoleNameSuffix: constants.ReaderRoleNameSuffix,
 	}
 	defaultUsers := map[string]string{
-		constants.OwnerRoleNameSuffix + constants.UserRoleNameSuffix:  constants.OwnerRoleNameSuffix,
-		constants.ReaderRoleNameSuffix + constants.UserRoleNameSuffix: constants.ReaderRoleNameSuffix,
-		constants.WriterRoleNameSuffix + constants.UserRoleNameSuffix: constants.WriterRoleNameSuffix,
+		fmt.Sprintf("%s%s", constants.OwnerRoleNameSuffix, constants.UserRoleNameSuffix):  constants.OwnerRoleNameSuffix,
+		fmt.Sprintf("%s%s", constants.ReaderRoleNameSuffix, constants.UserRoleNameSuffix): constants.ReaderRoleNameSuffix,
+		fmt.Sprintf("%s%s", constants.WriterRoleNameSuffix, constants.UserRoleNameSuffix): constants.WriterRoleNameSuffix,
 	}
 
 	for preparedDbName, preparedDB := range c.Spec.PreparedDatabases {
@@ -1218,7 +1218,7 @@ func (c *Cluster) initDefaultRoles(defaultRoles map[string]string, admin, prefix
 				c.logger.Warn("secretNamespace ignored because enable_cross_namespace_secret set to false. Creating secrets in cluster namespace.")
 			}
 		}
-		roleName := prefix + defaultRole
+		roleName := fmt.Sprintf("%s%s", prefix, defaultRole)
 
 		flags := []string{constants.RoleFlagNoLogin}
 		if defaultRole[len(defaultRole)-5:] == constants.UserRoleNameSuffix {
@@ -1236,7 +1236,7 @@ func (c *Cluster) initDefaultRoles(defaultRoles map[string]string, admin, prefix
 			adminRole = admin
 			isOwner = true
 		} else {
-			adminRole = prefix + constants.OwnerRoleNameSuffix
+			adminRole = fmt.Sprintf("%s%s", prefix, constants.OwnerRoleNameSuffix)
 		}
 
 		newRole := spec.PgUser{

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -759,10 +759,13 @@ func TestServiceAnnotations(t *testing.T) {
 func TestInitSystemUsers(t *testing.T) {
 	testName := "Test system users initialization"
 
-	// default cluster without connection pooler
+	// default cluster without connection pooler and event streams
 	cl.initSystemUsers()
 	if _, exist := cl.systemUsers[constants.ConnectionPoolerUserKeyName]; exist {
 		t.Errorf("%s, connection pooler user is present", testName)
+	}
+	if _, exist := cl.systemUsers[constants.EventStreamUserKeyName]; exist {
+		t.Errorf("%s, stream user is present", testName)
 	}
 
 	// cluster with connection pooler
@@ -804,6 +807,23 @@ func TestInitSystemUsers(t *testing.T) {
 	cl.initSystemUsers()
 	if _, exist := cl.systemUsers["pooler"]; !exist {
 		t.Errorf("%s, System users are not allowed to be a connection pool user", testName)
+	}
+
+	// cluster with streams
+	cl.Spec.Streams = []acidv1.Stream{
+		{
+			ApplicationId: "test-app",
+			Database:      "test_db",
+			Tables: map[string]acidv1.StreamTable{
+				"data.test_table": acidv1.StreamTable{
+					EventType: "test_event",
+				},
+			},
+		},
+	}
+	cl.initSystemUsers()
+	if _, exist := cl.systemUsers[constants.EventStreamUserKeyName]; !exist {
+		t.Errorf("%s, stream user is not present", testName)
 	}
 }
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -810,7 +810,8 @@ func TestInitSystemUsers(t *testing.T) {
 	}
 
 	// using stream user in manifest but no streams defined should be treated like normal robot user
-	cl.Spec.Users = map[string]acidv1.UserFlags{"fes_user": []string{}}
+	streamUser := fmt.Sprintf("%s%s", constants.EventStreamSourceSlotPrefix, constants.UserRoleNameSuffix)
+	cl.Spec.Users = map[string]acidv1.UserFlags{streamUser: []string{}}
 	cl.initSystemUsers()
 	if _, exist := cl.systemUsers[constants.EventStreamUserKeyName]; exist {
 		t.Errorf("%s, stream user is present", testName)

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -809,6 +809,13 @@ func TestInitSystemUsers(t *testing.T) {
 		t.Errorf("%s, System users are not allowed to be a connection pool user", testName)
 	}
 
+	// using stream user in manifest but no streams defined should be treated like normal robot user
+	cl.Spec.Users = map[string]acidv1.UserFlags{"fes_user": []string{}}
+	cl.initSystemUsers()
+	if _, exist := cl.systemUsers[constants.EventStreamUserKeyName]; exist {
+		t.Errorf("%s, stream user is present", testName)
+	}
+
 	// cluster with streams
 	cl.Spec.Streams = []acidv1.Stream{
 		{

--- a/pkg/cluster/connection_pooler.go
+++ b/pkg/cluster/connection_pooler.go
@@ -46,7 +46,7 @@ type ConnectionPoolerObjects struct {
 func (c *Cluster) connectionPoolerName(role PostgresRole) string {
 	name := c.Name + "-pooler"
 	if role == Replica {
-		name = name + "-repl"
+		name = fmt.Sprintf("%s-%s", name, "repl")
 	}
 	return name
 }

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -80,7 +80,7 @@ func (c *Cluster) statefulSetName() string {
 func (c *Cluster) endpointName(role PostgresRole) string {
 	name := c.Name
 	if role == Replica {
-		name = name + "-repl"
+		name = fmt.Sprintf("%s-%s", name, "repl")
 	}
 
 	return name
@@ -89,7 +89,7 @@ func (c *Cluster) endpointName(role PostgresRole) string {
 func (c *Cluster) serviceName(role PostgresRole) string {
 	name := c.Name
 	if role == Replica {
-		name = name + "-repl"
+		name = fmt.Sprintf("%s-%s", name, "repl")
 	}
 
 	return name
@@ -2238,7 +2238,7 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 
 // getLogicalBackupJobName returns the name; the job itself may not exists
 func (c *Cluster) getLogicalBackupJobName() (jobName string) {
-	return trimCronjobName(c.OpConfig.LogicalBackupJobPrefix + c.clusterName().Name)
+	return trimCronjobName(fmt.Sprintf("%s%s", c.OpConfig.LogicalBackupJobPrefix, c.clusterName().Name))
 }
 
 // Return an array of ownerReferences to make an arbitraty object dependent on

--- a/pkg/cluster/streams_test.go
+++ b/pkg/cluster/streams_test.go
@@ -40,7 +40,7 @@ var (
 	namespace   string = "default"
 	appId       string = "test-app"
 	dbName      string = "foo"
-	fesUser     string = constants.EventStreamSourceSlotPrefix + constants.UserRoleNameSuffix
+	fesUser     string = fmt.Sprintf("%s%s", constants.EventStreamSourceSlotPrefix, constants.UserRoleNameSuffix)
 	fesName     string = fmt.Sprintf("%s-%s", clusterName, appId)
 	slotName    string = fmt.Sprintf("%s_%s_%s", constants.EventStreamSourceSlotPrefix, dbName, strings.Replace(appId, "-", "_", -1))
 
@@ -55,7 +55,7 @@ var (
 		},
 		Spec: acidv1.PostgresSpec{
 			Databases: map[string]string{
-				dbName: dbName + constants.UserRoleNameSuffix,
+				dbName: fmt.Sprintf("%s%s", dbName, constants.UserRoleNameSuffix),
 			},
 			Streams: []acidv1.Stream{
 				{

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -715,12 +715,16 @@ func (c *Cluster) updateSecret(
 	} else if secretUsername == c.systemUsers[constants.ReplicationUserKeyName].Name {
 		userKey = constants.ReplicationUserKeyName
 		userMap = c.systemUsers
-	} else if secretUsername == constants.ConnectionPoolerUserName {
-		userKey = constants.ConnectionPoolerUserName
-		userMap = c.systemUsers
-	} else if secretUsername == constants.EventStreamSourceSlotPrefix+constants.UserRoleNameSuffix {
-		userKey = constants.EventStreamSourceSlotPrefix + constants.UserRoleNameSuffix
-		userMap = c.systemUsers
+	} else if _, exists := c.systemUsers[constants.ConnectionPoolerUserKeyName]; !exists {
+		if secretUsername == c.systemUsers[constants.ConnectionPoolerUserKeyName].Name {
+			userKey = constants.ConnectionPoolerUserName
+			userMap = c.systemUsers
+		}
+	} else if _, exists := c.systemUsers[constants.EventStreamUserKeyName]; !exists {
+		if secretUsername == c.systemUsers[constants.EventStreamUserKeyName].Name {
+			userKey = constants.EventStreamSourceSlotPrefix + constants.UserRoleNameSuffix
+			userMap = c.systemUsers
+		}
 	} else {
 		userKey = secretUsername
 		userMap = c.pgUsers

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -715,12 +715,12 @@ func (c *Cluster) updateSecret(
 	} else if secretUsername == c.systemUsers[constants.ReplicationUserKeyName].Name {
 		userKey = constants.ReplicationUserKeyName
 		userMap = c.systemUsers
-	} else if _, exists := c.systemUsers[constants.ConnectionPoolerUserKeyName]; !exists {
+	} else if _, exists := c.systemUsers[constants.ConnectionPoolerUserKeyName]; exists {
 		if secretUsername == c.systemUsers[constants.ConnectionPoolerUserKeyName].Name {
 			userKey = constants.ConnectionPoolerUserName
 			userMap = c.systemUsers
 		}
-	} else if _, exists := c.systemUsers[constants.EventStreamUserKeyName]; !exists {
+	} else if _, exists := c.systemUsers[constants.EventStreamUserKeyName]; exists {
 		if secretUsername == c.systemUsers[constants.EventStreamUserKeyName].Name {
 			userKey = constants.EventStreamSourceSlotPrefix + constants.UserRoleNameSuffix
 			userMap = c.systemUsers

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -722,7 +722,7 @@ func (c *Cluster) updateSecret(
 		}
 	} else if _, exists := c.systemUsers[constants.EventStreamUserKeyName]; exists {
 		if secretUsername == c.systemUsers[constants.EventStreamUserKeyName].Name {
-			userKey = constants.EventStreamSourceSlotPrefix + constants.UserRoleNameSuffix
+			userKey = fmt.Sprintf("%s%s", constants.EventStreamSourceSlotPrefix, constants.UserRoleNameSuffix)
 			userMap = c.systemUsers
 		}
 	} else {
@@ -820,7 +820,7 @@ func (c *Cluster) rotatePasswordInSecret(
 		// create rotation user if role is not listed for in-place password update
 		if !util.SliceContains(c.Spec.UsersWithInPlaceSecretRotation, secretUsername) {
 			rotationUser := secretPgUser
-			newRotationUsername := secretUsername + currentTime.Format("060102")
+			newRotationUsername := fmt.Sprintf("%s%s", secretUsername, currentTime.Format("060102"))
 			rotationUser.Name = newRotationUsername
 			rotationUser.MemberOf = []string{secretUsername}
 			(*rotationUsers)[newRotationUsername] = rotationUser
@@ -980,7 +980,7 @@ func (c *Cluster) syncDatabases() error {
 	for preparedDatabaseName := range c.Spec.PreparedDatabases {
 		_, exists := currentDatabases[preparedDatabaseName]
 		if !exists {
-			createDatabases[preparedDatabaseName] = preparedDatabaseName + constants.OwnerRoleNameSuffix
+			createDatabases[preparedDatabaseName] = fmt.Sprintf("%s%s", preparedDatabaseName, constants.OwnerRoleNameSuffix)
 			preparedDatabases = append(preparedDatabases, preparedDatabaseName)
 		}
 	}
@@ -1081,9 +1081,9 @@ func (c *Cluster) syncPreparedSchemas(databaseName string, preparedSchemas map[s
 	if createPreparedSchemas, equal := util.SubstractStringSlices(schemas, currentSchemas); !equal {
 		for _, schemaName := range createPreparedSchemas {
 			owner := constants.OwnerRoleNameSuffix
-			dbOwner := databaseName + owner
+			dbOwner := fmt.Sprintf("%s%s", databaseName, owner)
 			if preparedSchemas[schemaName].DefaultRoles == nil || *preparedSchemas[schemaName].DefaultRoles {
-				owner = databaseName + "_" + schemaName + owner
+				owner = fmt.Sprintf("%s_%s%s", databaseName, schemaName, owner)
 			} else {
 				owner = dbOwner
 			}

--- a/pkg/util/constants/roles.go
+++ b/pkg/util/constants/roles.go
@@ -4,8 +4,9 @@ package constants
 const (
 	PasswordLength              = 64
 	SuperuserKeyName            = "superuser"
-	ConnectionPoolerUserKeyName = "pooler"
 	ReplicationUserKeyName      = "replication"
+	ConnectionPoolerUserKeyName = "pooler"
+	EventStreamUserKeyName      = "streamer"
 	RoleFlagSuperuser           = "SUPERUSER"
 	RoleFlagInherit             = "INHERIT"
 	RoleFlagLogin               = "LOGIN"


### PR DESCRIPTION
If somebody unintentionally defines reserved system users `pooler` or `fes_user` in the manifest, the [updateSecret](https://github.com/zalando/postgres-operator/blob/e11edcdcde897ec16e6a9903f97a6cad2e96eee2/pkg/cluster/sync.go#L720) function will use the systemUsers map. But if the pooler or stream feature are not used, no corresponding PgUser object will exist in that map. The PgUser used in password rotation will be empty ultimatly leading to this error:

```
could not sync roles: error executing sync statements: could not execute sync requests for users: could not create user "": pq: zero-length delimited identifier at or near """"
```

The bug was introduced with #1953 .

