### PR TITLE
use old LB DNS format when teamId prefix is disabled

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -424,10 +424,10 @@ spec:
                     default: "Cluster"
                   master_dns_name_format:
                     type: string
-                    default: "{cluster}.{team}.{hostedzone}"
+                    default: "{cluster}.{namespace}.{hostedzone}"
                   replica_dns_name_format:
                     type: string
-                    default: "{cluster}-repl.{team}.{hostedzone}"
+                    default: "{cluster}-repl.{namespace}.{hostedzone}"
               aws_or_gcp:
                 type: object
                 properties:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -269,9 +269,9 @@ configLoadBalancer:
   # define external traffic policy for the load balancer
   external_traffic_policy: "Cluster"
   # defines the DNS name string template for the master load balancer cluster
-  master_dns_name_format: "{cluster}.{team}.{hostedzone}"
+  master_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
   # defines the DNS name string template for the replica load balancer cluster
-  replica_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
+  replica_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
 
 # options to aid debugging of the operator itself
 configDebug:

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -617,15 +617,15 @@ In the CRD-based configuration they are grouped under the `load_balancer` key.
 
 * **master_dns_name_format** defines the DNS name string template for the
   master load balancer cluster.  The default is
-  `{cluster}.{team}.{hostedzone}`, where `{cluster}` is replaced by the cluster
-  name, `{team}` is replaced with the team name and `{hostedzone}` is replaced
+  `{cluster}.{namespace}.{hostedzone}`, where `{cluster}` is replaced by the cluster
+  name, `{namespace}` is replaced with the namespace and `{hostedzone}` is replaced
   with the hosted zone (the value of the `db_hosted_zone` parameter). No other
   placeholders are allowed.
 
 * **replica_dns_name_format** defines the DNS name string template for the
   replica load balancer cluster.  The default is
-  `{cluster}-repl.{team}.{hostedzone}`, where `{cluster}` is replaced by the
-  cluster name, `{team}` is replaced with the team name and `{hostedzone}` is
+  `{cluster}-repl.{namespace}.{hostedzone}`, where `{cluster}` is replaced by the
+  cluster name, `{namespace}` is replaced with the namespace and `{hostedzone}` is
   replaced with the hosted zone (the value of the `db_hosted_zone` parameter).
   No other placeholders are allowed.
 

--- a/docs/user.md
+++ b/docs/user.md
@@ -152,7 +152,7 @@ specified explicitly.
 
 The operator automatically generates a password for each manifest role and
 places it in the secret named
-`{username}.{team}-{clustername}.credentials.postgresql.acid.zalan.do` in the
+`{username}.{clustername}.credentials.postgresql.acid.zalan.do` in the
 same namespace as the cluster. This way, the application running in the
 K8s cluster and connecting to Postgres can obtain the password right from the
 secret, without ever sharing it outside of the cluster.
@@ -182,7 +182,7 @@ be in the form of `namespace.username`.
 
 For such usernames, the secret is created in the given namespace and its name is
 of the following form,
-`{namespace}.{username}.{team}-{clustername}.credentials.postgresql.acid.zalan.do`
+`{namespace}.{username}.{clustername}.credentials.postgresql.acid.zalan.do`
 
 ### Infrastructure roles
 

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -87,7 +87,7 @@ data:
   logical_backup_schedule: "30 00 * * *"
   major_version_upgrade_mode: "manual"
   # major_version_upgrade_team_allow_list: ""
-  master_dns_name_format: "{cluster}.{team}.{hostedzone}"
+  master_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
   # master_pod_move_timeout: 20m
   # max_instances: "-1"
   # min_instances: "-1"
@@ -124,7 +124,7 @@ data:
   ready_wait_interval: 3s
   ready_wait_timeout: 30s
   repair_period: 5m
-  replica_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
+  replica_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
   replication_username: standby
   resource_check_interval: 3s
   resource_check_timeout: 10m

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -422,10 +422,10 @@ spec:
                     default: "Cluster"
                   master_dns_name_format:
                     type: string
-                    default: "{cluster}.{team}.{hostedzone}"
+                    default: "{cluster}.{namespace}.{hostedzone}"
                   replica_dns_name_format:
                     type: string
-                    default: "{cluster}-repl.{team}.{hostedzone}"
+                    default: "{cluster}-repl.{namespace}.{hostedzone}"
               aws_or_gcp:
                 type: object
                 properties:

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -133,8 +133,8 @@ configuration:
     enable_replica_load_balancer: false
     enable_replica_pooler_load_balancer: false
     external_traffic_policy: "Cluster"
-    master_dns_name_format: "{cluster}.{team}.{hostedzone}"
-    replica_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
+    master_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
+    replica_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
   aws_or_gcp:
     # additional_secret_mount: "some-secret-name"
     # additional_secret_mount_path: "/some/dir"

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -475,7 +475,7 @@ func TestServiceAnnotations(t *testing.T) {
 			operatorAnnotations:          make(map[string]string),
 			clusterAnnotations:           make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.acid.db.example.com,test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.test.db.example.com,test.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -497,7 +497,7 @@ func TestServiceAnnotations(t *testing.T) {
 			operatorAnnotations:        make(map[string]string),
 			clusterAnnotations:         make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.acid.db.example.com,test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.test.db.example.com,test.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -509,7 +509,7 @@ func TestServiceAnnotations(t *testing.T) {
 			operatorAnnotations:        make(map[string]string),
 			clusterAnnotations:         map[string]string{"foo": "bar"},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.acid.db.example.com,test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.test.db.example.com,test.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 				"foo": "bar",
 			},
@@ -532,7 +532,7 @@ func TestServiceAnnotations(t *testing.T) {
 			operatorAnnotations:        map[string]string{"foo": "bar"},
 			clusterAnnotations:         make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.acid.db.example.com,test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.test.db.example.com,test.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 				"foo": "bar",
 			},
@@ -547,7 +547,7 @@ func TestServiceAnnotations(t *testing.T) {
 			},
 			clusterAnnotations: make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.acid.db.example.com,test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.test.db.example.com,test.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 		},
@@ -561,7 +561,7 @@ func TestServiceAnnotations(t *testing.T) {
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.acid.db.example.com,test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.test.db.example.com,test.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 		},
@@ -575,7 +575,7 @@ func TestServiceAnnotations(t *testing.T) {
 				"external-dns.alpha.kubernetes.io/hostname": "wrong.external-dns-name.example.com",
 			},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.acid.db.example.com,test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.test.db.example.com,test.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -587,7 +587,7 @@ func TestServiceAnnotations(t *testing.T) {
 			clusterAnnotations:         make(map[string]string),
 			operatorAnnotations:        make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "test.test.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -611,7 +611,7 @@ func TestServiceAnnotations(t *testing.T) {
 			operatorAnnotations:           make(map[string]string),
 			clusterAnnotations:            make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.acid.db.example.com,test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.test.db.example.com,test-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -633,7 +633,7 @@ func TestServiceAnnotations(t *testing.T) {
 			operatorAnnotations:         make(map[string]string),
 			clusterAnnotations:          make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.acid.db.example.com,test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.test.db.example.com,test-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -645,7 +645,7 @@ func TestServiceAnnotations(t *testing.T) {
 			operatorAnnotations:         make(map[string]string),
 			clusterAnnotations:          map[string]string{"foo": "bar"},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.acid.db.example.com,test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.test.db.example.com,test-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 				"foo": "bar",
 			},
@@ -668,7 +668,7 @@ func TestServiceAnnotations(t *testing.T) {
 			operatorAnnotations:         map[string]string{"foo": "bar"},
 			clusterAnnotations:          make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.acid.db.example.com,test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.test.db.example.com,test-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 				"foo": "bar",
 			},
@@ -683,7 +683,7 @@ func TestServiceAnnotations(t *testing.T) {
 			},
 			clusterAnnotations: make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.acid.db.example.com,test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.test.db.example.com,test-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 		},
@@ -697,7 +697,7 @@ func TestServiceAnnotations(t *testing.T) {
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.acid.db.example.com,test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.test.db.example.com,test-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 		},
@@ -711,7 +711,7 @@ func TestServiceAnnotations(t *testing.T) {
 				"external-dns.alpha.kubernetes.io/hostname": "wrong.external-dns-name.example.com",
 			},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.acid.db.example.com,test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.test.db.example.com,test-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -723,7 +723,7 @@ func TestServiceAnnotations(t *testing.T) {
 			clusterAnnotations:          make(map[string]string),
 			operatorAnnotations:         make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "test-repl.test.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -760,8 +760,8 @@ func TestServiceAnnotations(t *testing.T) {
 			cl.OpConfig.CustomServiceAnnotations = tt.operatorAnnotations
 			cl.OpConfig.EnableMasterLoadBalancer = tt.enableMasterLoadBalancerOC
 			cl.OpConfig.EnableReplicaLoadBalancer = tt.enableReplicaLoadBalancerOC
-			cl.OpConfig.MasterDNSNameFormat = "{cluster}.{team}.{hostedzone}"
-			cl.OpConfig.ReplicaDNSNameFormat = "{cluster}-repl.{team}.{hostedzone}"
+			cl.OpConfig.MasterDNSNameFormat = "{cluster}.{namespace}.{hostedzone}"
+			cl.OpConfig.ReplicaDNSNameFormat = "{cluster}-repl.{namespace}.{hostedzone}"
 			cl.OpConfig.DbHostedZone = "db.example.com"
 
 			cl.Postgresql.Spec.TeamID = "acid"

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -450,6 +450,7 @@ func TestServiceAnnotations(t *testing.T) {
 		enableMasterLoadBalancerOC    bool
 		enableReplicaLoadBalancerSpec *bool
 		enableReplicaLoadBalancerOC   bool
+		enableTeamIdClusterPrefix     bool
 		operatorAnnotations           map[string]string
 		clusterAnnotations            map[string]string
 		expect                        map[string]string
@@ -460,6 +461,7 @@ func TestServiceAnnotations(t *testing.T) {
 			role:                         "master",
 			enableMasterLoadBalancerSpec: &disabled,
 			enableMasterLoadBalancerOC:   false,
+			enableTeamIdClusterPrefix:    false,
 			operatorAnnotations:          make(map[string]string),
 			clusterAnnotations:           make(map[string]string),
 			expect:                       make(map[string]string),
@@ -469,10 +471,11 @@ func TestServiceAnnotations(t *testing.T) {
 			role:                         "master",
 			enableMasterLoadBalancerSpec: &enabled,
 			enableMasterLoadBalancerOC:   false,
+			enableTeamIdClusterPrefix:    false,
 			operatorAnnotations:          make(map[string]string),
 			clusterAnnotations:           make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.acid.db.example.com,test.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -481,6 +484,7 @@ func TestServiceAnnotations(t *testing.T) {
 			role:                         "master",
 			enableMasterLoadBalancerSpec: &disabled,
 			enableMasterLoadBalancerOC:   true,
+			enableTeamIdClusterPrefix:    false,
 			operatorAnnotations:          make(map[string]string),
 			clusterAnnotations:           make(map[string]string),
 			expect:                       make(map[string]string),
@@ -489,10 +493,11 @@ func TestServiceAnnotations(t *testing.T) {
 			about:                      "Master with no annotations and EnableMasterLoadBalancer defined only on operator config",
 			role:                       "master",
 			enableMasterLoadBalancerOC: true,
+			enableTeamIdClusterPrefix:  false,
 			operatorAnnotations:        make(map[string]string),
 			clusterAnnotations:         make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.acid.db.example.com,test.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -500,10 +505,11 @@ func TestServiceAnnotations(t *testing.T) {
 			about:                      "Master with cluster annotations and load balancer enabled",
 			role:                       "master",
 			enableMasterLoadBalancerOC: true,
+			enableTeamIdClusterPrefix:  false,
 			operatorAnnotations:        make(map[string]string),
 			clusterAnnotations:         map[string]string{"foo": "bar"},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.acid.db.example.com,test.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 				"foo": "bar",
 			},
@@ -513,6 +519,7 @@ func TestServiceAnnotations(t *testing.T) {
 			role:                         "master",
 			enableMasterLoadBalancerSpec: &disabled,
 			enableMasterLoadBalancerOC:   true,
+			enableTeamIdClusterPrefix:    false,
 			operatorAnnotations:          make(map[string]string),
 			clusterAnnotations:           map[string]string{"foo": "bar"},
 			expect:                       map[string]string{"foo": "bar"},
@@ -521,10 +528,11 @@ func TestServiceAnnotations(t *testing.T) {
 			about:                      "Master with operator annotations and load balancer enabled",
 			role:                       "master",
 			enableMasterLoadBalancerOC: true,
+			enableTeamIdClusterPrefix:  false,
 			operatorAnnotations:        map[string]string{"foo": "bar"},
 			clusterAnnotations:         make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.acid.db.example.com,test.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 				"foo": "bar",
 			},
@@ -533,12 +541,13 @@ func TestServiceAnnotations(t *testing.T) {
 			about:                      "Master with operator annotations override default annotations",
 			role:                       "master",
 			enableMasterLoadBalancerOC: true,
+			enableTeamIdClusterPrefix:  false,
 			operatorAnnotations: map[string]string{
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 			clusterAnnotations: make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.acid.db.example.com,test.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 		},
@@ -546,12 +555,13 @@ func TestServiceAnnotations(t *testing.T) {
 			about:                      "Master with cluster annotations override default annotations",
 			role:                       "master",
 			enableMasterLoadBalancerOC: true,
+			enableTeamIdClusterPrefix:  false,
 			operatorAnnotations:        make(map[string]string),
 			clusterAnnotations: map[string]string{
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.acid.db.example.com,test.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 		},
@@ -559,23 +569,23 @@ func TestServiceAnnotations(t *testing.T) {
 			about:                      "Master with cluster annotations do not override external-dns annotations",
 			role:                       "master",
 			enableMasterLoadBalancerOC: true,
+			enableTeamIdClusterPrefix:  false,
 			operatorAnnotations:        make(map[string]string),
 			clusterAnnotations: map[string]string{
 				"external-dns.alpha.kubernetes.io/hostname": "wrong.external-dns-name.example.com",
 			},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.acid.db.example.com,test.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
 		{
-			about:                      "Master with operator annotations do not override external-dns annotations",
+			about:                      "Master with cluster name teamId prefix enabled",
 			role:                       "master",
 			enableMasterLoadBalancerOC: true,
+			enableTeamIdClusterPrefix:  true,
 			clusterAnnotations:         make(map[string]string),
-			operatorAnnotations: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname": "wrong.external-dns-name.example.com",
-			},
+			operatorAnnotations:        make(map[string]string),
 			expect: map[string]string{
 				"external-dns.alpha.kubernetes.io/hostname":                            "test.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
@@ -587,6 +597,7 @@ func TestServiceAnnotations(t *testing.T) {
 			role:                          "replica",
 			enableReplicaLoadBalancerSpec: &disabled,
 			enableReplicaLoadBalancerOC:   false,
+			enableTeamIdClusterPrefix:     false,
 			operatorAnnotations:           make(map[string]string),
 			clusterAnnotations:            make(map[string]string),
 			expect:                        make(map[string]string),
@@ -596,10 +607,11 @@ func TestServiceAnnotations(t *testing.T) {
 			role:                          "replica",
 			enableReplicaLoadBalancerSpec: &enabled,
 			enableReplicaLoadBalancerOC:   false,
+			enableTeamIdClusterPrefix:     false,
 			operatorAnnotations:           make(map[string]string),
 			clusterAnnotations:            make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.acid.db.example.com,test-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -608,6 +620,7 @@ func TestServiceAnnotations(t *testing.T) {
 			role:                          "replica",
 			enableReplicaLoadBalancerSpec: &disabled,
 			enableReplicaLoadBalancerOC:   true,
+			enableTeamIdClusterPrefix:     false,
 			operatorAnnotations:           make(map[string]string),
 			clusterAnnotations:            make(map[string]string),
 			expect:                        make(map[string]string),
@@ -616,10 +629,11 @@ func TestServiceAnnotations(t *testing.T) {
 			about:                       "Replica with no annotations and EnableReplicaLoadBalancer defined only on operator config",
 			role:                        "replica",
 			enableReplicaLoadBalancerOC: true,
+			enableTeamIdClusterPrefix:   false,
 			operatorAnnotations:         make(map[string]string),
 			clusterAnnotations:          make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.acid.db.example.com,test-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -627,10 +641,11 @@ func TestServiceAnnotations(t *testing.T) {
 			about:                       "Replica with cluster annotations and load balancer enabled",
 			role:                        "replica",
 			enableReplicaLoadBalancerOC: true,
+			enableTeamIdClusterPrefix:   false,
 			operatorAnnotations:         make(map[string]string),
 			clusterAnnotations:          map[string]string{"foo": "bar"},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.acid.db.example.com,test-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 				"foo": "bar",
 			},
@@ -640,6 +655,7 @@ func TestServiceAnnotations(t *testing.T) {
 			role:                          "replica",
 			enableReplicaLoadBalancerSpec: &disabled,
 			enableReplicaLoadBalancerOC:   true,
+			enableTeamIdClusterPrefix:     false,
 			operatorAnnotations:           make(map[string]string),
 			clusterAnnotations:            map[string]string{"foo": "bar"},
 			expect:                        map[string]string{"foo": "bar"},
@@ -648,10 +664,11 @@ func TestServiceAnnotations(t *testing.T) {
 			about:                       "Replica with operator annotations and load balancer enabled",
 			role:                        "replica",
 			enableReplicaLoadBalancerOC: true,
+			enableTeamIdClusterPrefix:   false,
 			operatorAnnotations:         map[string]string{"foo": "bar"},
 			clusterAnnotations:          make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.acid.db.example.com,test-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 				"foo": "bar",
 			},
@@ -660,12 +677,13 @@ func TestServiceAnnotations(t *testing.T) {
 			about:                       "Replica with operator annotations override default annotations",
 			role:                        "replica",
 			enableReplicaLoadBalancerOC: true,
+			enableTeamIdClusterPrefix:   false,
 			operatorAnnotations: map[string]string{
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 			clusterAnnotations: make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.acid.db.example.com,test-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 		},
@@ -673,12 +691,13 @@ func TestServiceAnnotations(t *testing.T) {
 			about:                       "Replica with cluster annotations override default annotations",
 			role:                        "replica",
 			enableReplicaLoadBalancerOC: true,
+			enableTeamIdClusterPrefix:   false,
 			operatorAnnotations:         make(map[string]string),
 			clusterAnnotations: map[string]string{
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.acid.db.example.com,test-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 		},
@@ -686,23 +705,23 @@ func TestServiceAnnotations(t *testing.T) {
 			about:                       "Replica with cluster annotations do not override external-dns annotations",
 			role:                        "replica",
 			enableReplicaLoadBalancerOC: true,
+			enableTeamIdClusterPrefix:   false,
 			operatorAnnotations:         make(map[string]string),
 			clusterAnnotations: map[string]string{
 				"external-dns.alpha.kubernetes.io/hostname": "wrong.external-dns-name.example.com",
 			},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.acid.db.example.com,test-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
 		{
-			about:                       "Replica with operator annotations do not override external-dns annotations",
+			about:                       "Replica with cluster name teamId prefix enabled",
 			role:                        "replica",
 			enableReplicaLoadBalancerOC: true,
+			enableTeamIdClusterPrefix:   true,
 			clusterAnnotations:          make(map[string]string),
-			operatorAnnotations: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname": "wrong.external-dns-name.example.com",
-			},
+			operatorAnnotations:         make(map[string]string),
 			expect: map[string]string{
 				"external-dns.alpha.kubernetes.io/hostname":                            "test-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
@@ -713,6 +732,7 @@ func TestServiceAnnotations(t *testing.T) {
 			about:                       "cluster annotations append to operator annotations",
 			role:                        "replica",
 			enableReplicaLoadBalancerOC: false,
+			enableTeamIdClusterPrefix:   false,
 			operatorAnnotations:         map[string]string{"foo": "bar"},
 			clusterAnnotations:          map[string]string{"post": "gres"},
 			expect:                      map[string]string{"foo": "bar", "post": "gres"},
@@ -721,6 +741,7 @@ func TestServiceAnnotations(t *testing.T) {
 			about:                       "cluster annotations override operator annotations",
 			role:                        "replica",
 			enableReplicaLoadBalancerOC: false,
+			enableTeamIdClusterPrefix:   false,
 			operatorAnnotations:         map[string]string{"foo": "bar", "post": "gres"},
 			clusterAnnotations:          map[string]string{"post": "greSQL"},
 			expect:                      map[string]string{"foo": "bar", "post": "greSQL"},
@@ -729,6 +750,13 @@ func TestServiceAnnotations(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.about, func(t *testing.T) {
+			cl.OpConfig.EnableTeamIdClusternamePrefix = tt.enableTeamIdClusterPrefix
+			if tt.enableTeamIdClusterPrefix {
+				cl.Postgresql.Spec.ClusterName = "test"
+			} else {
+				cl.Postgresql.Spec.ClusterName = "acid-test"
+			}
+
 			cl.OpConfig.CustomServiceAnnotations = tt.operatorAnnotations
 			cl.OpConfig.EnableMasterLoadBalancer = tt.enableMasterLoadBalancerOC
 			cl.OpConfig.EnableReplicaLoadBalancer = tt.enableReplicaLoadBalancerOC
@@ -736,7 +764,6 @@ func TestServiceAnnotations(t *testing.T) {
 			cl.OpConfig.ReplicaDNSNameFormat = "{cluster}-repl.{team}.{hostedzone}"
 			cl.OpConfig.DbHostedZone = "db.example.com"
 
-			cl.Postgresql.Spec.ClusterName = "test"
 			cl.Postgresql.Spec.TeamID = "acid"
 			cl.Postgresql.Spec.ServiceAnnotations = tt.clusterAnnotations
 			cl.Postgresql.Spec.EnableMasterLoadBalancer = tt.enableMasterLoadBalancerSpec

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1814,12 +1814,7 @@ func (c *Cluster) generateServiceAnnotations(role PostgresRole, spec *acidv1.Pos
 	}
 
 	if c.shouldCreateLoadBalancerForService(role, spec) {
-		var dnsName string
-		if role == Master {
-			dnsName = c.masterDNSName()
-		} else {
-			dnsName = c.replicaDNSName()
-		}
+		dnsName := c.dnsName(role)
 
 		// Just set ELB Timeout annotation with default value, if it does not
 		// have a cutom value

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -507,12 +507,10 @@ func (c *Cluster) roleLabelsSet(shouldAddExtraLabels bool, role PostgresRole) la
 
 func (c *Cluster) dnsName(role PostgresRole) string {
 	var dnsString string
-	clusterName := c.Spec.ClusterName
-
 	if role == Master {
-		dnsString = c.masterDNSName(clusterName)
+		dnsString = c.masterDNSName()
 	} else {
-		dnsString = c.replicaDNSName(clusterName)
+		dnsString = c.replicaDNSName()
 	}
 
 	// when cluster name starts with teamId prefix create an extra DNS entry
@@ -530,16 +528,16 @@ func (c *Cluster) dnsName(role PostgresRole) string {
 	return dnsString
 }
 
-func (c *Cluster) masterDNSName(clusterName string) string {
+func (c *Cluster) masterDNSName() string {
 	return strings.ToLower(c.OpConfig.MasterDNSNameFormat.Format(
-		"cluster", clusterName,
+		"cluster", c.Spec.ClusterName,
 		"namespace", c.Namespace,
 		"hostedzone", c.OpConfig.DbHostedZone))
 }
 
-func (c *Cluster) replicaDNSName(clusterName string) string {
+func (c *Cluster) replicaDNSName() string {
 	return strings.ToLower(c.OpConfig.ReplicaDNSNameFormat.Format(
-		"cluster", clusterName,
+		"cluster", c.Spec.ClusterName,
 		"namespace", c.Namespace,
 		"hostedzone", c.OpConfig.DbHostedZone))
 }

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -505,16 +505,32 @@ func (c *Cluster) roleLabelsSet(shouldAddExtraLabels bool, role PostgresRole) la
 	return lbls
 }
 
-func (c *Cluster) masterDNSName() string {
+func (c *Cluster) dnsName(role PostgresRole) string {
+	var dnsName string
+	clusterName := c.Name
+	clusterNameWithoutTeamPrefix, _ := acidv1.ExtractClusterName(c.Name, c.Spec.TeamID)
+	if clusterNameWithoutTeamPrefix != "" {
+		clusterName = clusterNameWithoutTeamPrefix
+	}
+	if role == Master {
+		dnsName = c.masterDNSName(clusterName)
+	} else {
+		dnsName = c.replicaDNSName(clusterName)
+	}
+
+	return dnsName
+}
+
+func (c *Cluster) masterDNSName(clusterName string) string {
 	return strings.ToLower(c.OpConfig.MasterDNSNameFormat.Format(
-		"cluster", c.Spec.ClusterName,
+		"cluster", clusterName,
 		"team", c.teamName(),
 		"hostedzone", c.OpConfig.DbHostedZone))
 }
 
-func (c *Cluster) replicaDNSName() string {
+func (c *Cluster) replicaDNSName(clusterName string) string {
 	return strings.ToLower(c.OpConfig.ReplicaDNSNameFormat.Format(
-		"cluster", c.Spec.ClusterName,
+		"cluster", clusterName,
 		"team", c.teamName(),
 		"hostedzone", c.OpConfig.DbHostedZone))
 }

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -159,17 +159,24 @@ func (c *Controller) acquireInitialListOfClusters() error {
 }
 
 func (c *Controller) addCluster(lg *logrus.Entry, clusterName spec.NamespacedName, pgSpec *acidv1.Postgresql) (*cluster.Cluster, error) {
+	var (
+		extractedClusterName string
+		err                  error
+	)
 
 	if c.opConfig.EnableTeamIdClusternamePrefix {
-		if _, err := acidv1.ExtractClusterName(clusterName.Name, pgSpec.Spec.TeamID); err != nil {
+		if extractedClusterName, err = acidv1.ExtractClusterName(clusterName.Name, pgSpec.Spec.TeamID); err != nil {
 			c.KubeClient.SetPostgresCRDStatus(clusterName, acidv1.ClusterStatusInvalid)
 			return nil, err
 		}
+	} else {
+		extractedClusterName = clusterName.Name
 	}
 
 	cl := cluster.New(c.makeClusterConfig(), c.KubeClient, *pgSpec, lg, c.eventRecorder)
 	cl.Run(c.stopCh)
 	teamName := strings.ToLower(cl.Spec.TeamID)
+	cl.ClusterName = extractedClusterName
 
 	defer c.clustersMu.Unlock()
 	c.clustersMu.Lock()

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -206,8 +206,8 @@ type Config struct {
 	StorageResizeMode                      string            `name:"storage_resize_mode" default:"pvc"`
 	EnableLoadBalancer                     *bool             `name:"enable_load_balancer"` // deprecated and kept for backward compatibility
 	ExternalTrafficPolicy                  string            `name:"external_traffic_policy" default:"Cluster"`
-	MasterDNSNameFormat                    StringTemplate    `name:"master_dns_name_format" default:"{cluster}.{team}.{hostedzone}"`
-	ReplicaDNSNameFormat                   StringTemplate    `name:"replica_dns_name_format" default:"{cluster}-repl.{team}.{hostedzone}"`
+	MasterDNSNameFormat                    StringTemplate    `name:"master_dns_name_format" default:"{cluster}.{namespace}.{hostedzone}"`
+	ReplicaDNSNameFormat                   StringTemplate    `name:"replica_dns_name_format" default:"{cluster}-repl.{namespace}.{hostedzone}"`
 	PDBNameFormat                          StringTemplate    `name:"pdb_name_format" default:"postgres-{cluster}-pdb"`
 	EnablePodDisruptionBudget              *bool             `name:"enable_pod_disruption_budget" default:"true"`
 	EnableInitContainers                   *bool             `name:"enable_init_containers" default:"true"`


### PR DESCRIPTION
With #2001 merged we dropped the teamId prefix constraint for cluster names and deprecated the `ClusterName` field of the `Postgresql` type assuming it was not used somewhere else. Turns out, it is used for LoadBalancer service's external DNS name and ClusterStatus API.

This PR will set this field again when clusters are added to the operator's internal cluster list.

If we would continue to use the Spec.ClusterName for the LB DNS names they would break when disabling the team Id constraint. Therefore, we should continue to use old format when the cluster name starts with the team ID. external-dns supports multiple names per annotation, separated by comma.