### PR TITLE
bumped to alpine base image 3.15

### DIFF
--- a/docker/DebugDockerfile
+++ b/docker/DebugDockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/library/alpine-3.12:latest
+FROM registry.opensource.zalan.do/library/alpine-3.15:latest
 LABEL maintainer="Team ACID @ Zalando <team-acid@zalando.de>"
 
 # We need root certificates to deal with teams api over https

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/library/alpine-3.13:latest
+FROM registry.opensource.zalan.do/library/alpine-3.15:latest
 LABEL maintainer="Team ACID @ Zalando <team-acid@zalando.de>"
 
 # We need root certificates to deal with teams api over https

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/library/alpine-3.12:latest
+FROM registry.opensource.zalan.do/library/alpine-3.13:latest
 LABEL maintainer="Team ACID @ Zalando <team-acid@zalando.de>"
 
 # We need root certificates to deal with teams api over https

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/library/alpine-3.12:latest
+FROM registry.opensource.zalan.do/library/alpine-3.15:latest
 LABEL maintainer="Team ACID @ Zalando <team-acid@zalando.de>"
 
 EXPOSE 8081


### PR DESCRIPTION
Hello,

our SNYK security scan has found, that the Zalando Postgres Operator image is vulnerable to the following security issue which comes by using the Alpine 3.12 base image.
It should be fixed in Alpine 3.13. I would like to ask you to update the used base image of the Zalando Operator and release a new version.

https://www.cve.org/CVERecord?id=CVE-2022-37434
