### PR TITLE
use correct keys in updateSecret

### DIFF
--- a/manifests/fake-teams-api.yaml
+++ b/manifests/fake-teams-api.yaml
@@ -4,6 +4,9 @@ metadata:
   name: fake-teams-api
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: fake-teams-api
   template:
     metadata:
       labels:

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -723,14 +723,14 @@ func (c *Cluster) updateSecret(
 	// use system user when pooler is enabled and pooler user is specfied in manifest
 	if _, exists := c.systemUsers[constants.ConnectionPoolerUserKeyName]; exists {
 		if secretUsername == c.systemUsers[constants.ConnectionPoolerUserKeyName].Name {
-			userKey = constants.ConnectionPoolerUserName
+			userKey = constants.ConnectionPoolerUserKeyName
 			userMap = c.systemUsers
 		}
 	}
 	// use system user when streams are defined and fes_user is specfied in manifest
 	if _, exists := c.systemUsers[constants.EventStreamUserKeyName]; exists {
 		if secretUsername == c.systemUsers[constants.EventStreamUserKeyName].Name {
-			userKey = fmt.Sprintf("%s%s", constants.EventStreamSourceSlotPrefix, constants.UserRoleNameSuffix)
+			userKey = constants.EventStreamUserKeyName
 			userMap = c.systemUsers
 		}
 	}


### PR DESCRIPTION
The `updateSecret` code was using wrong keys when treating pooler and FES users accidentally adding more empty `cluster.systemUsers` leading to a similar error like in #2009 

I have extended the unit test for `updateSecret` to cover it.