### PR TITLE
docs: fix code block rendering

### DIFF
--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -28,6 +28,7 @@ configuration.
   and change it.
 
   To test the CRD-based configuration locally, use the following
+
   ```bash
   kubectl create -f manifests/operatorconfiguration.crd.yaml # registers the CRD
   kubectl create -f manifests/postgresql-operator-default-configuration.yaml


### PR DESCRIPTION
This code block was wrongly rendered in docs:

![imagen](https://user-images.githubusercontent.com/973709/190355398-749e29b7-6d5c-46a1-a065-8f6f8ff25657.png)

@moduon MT-1248