### PR TITLE
Fix password rotation

### DIFF
--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -638,7 +638,6 @@ func (c *Cluster) syncSecrets() error {
 	c.logger.Info("syncing secrets")
 	c.setProcessName("syncing secrets")
 	generatedSecrets := c.generateUserSecrets()
-	rotationUsers := make(spec.PgUserMap)
 	retentionUsers := make([]string, 0)
 	currentTime := time.Now()
 
@@ -650,26 +649,11 @@ func (c *Cluster) syncSecrets() error {
 			continue
 		}
 		if k8sutil.ResourceAlreadyExists(err) {
-			if err = c.updateSecret(secretUsername, generatedSecret, &rotationUsers, &retentionUsers, currentTime); err != nil {
+			if err = c.updateSecret(secretUsername, generatedSecret, &retentionUsers, currentTime); err != nil {
 				c.logger.Warningf("syncing secret %s failed: %v", util.NameFromMeta(secret.ObjectMeta), err)
 			}
 		} else {
 			return fmt.Errorf("could not create secret for user %s: in namespace %s: %v", secretUsername, generatedSecret.Namespace, err)
-		}
-	}
-
-	// add new user with date suffix and use it in the secret of the original user
-	if len(rotationUsers) > 0 {
-		err := c.initDbConn()
-		if err != nil {
-			return fmt.Errorf("could not init db connection: %v", err)
-		}
-		pgSyncRequests := c.userSyncStrategy.ProduceSyncRequests(spec.PgUserMap{}, rotationUsers)
-		if err = c.userSyncStrategy.ExecuteSyncRequests(pgSyncRequests, c.pgDb); err != nil {
-			return fmt.Errorf("error creating database roles for password rotation: %v", err)
-		}
-		if err := c.closeDbConn(); err != nil {
-			c.logger.Errorf("could not close database connection after creating users for password rotation: %v", err)
 		}
 	}
 
@@ -698,7 +682,6 @@ func (c *Cluster) getNextRotationDate(currentDate time.Time) (time.Time, string)
 func (c *Cluster) updateSecret(
 	secretUsername string,
 	generatedSecret *v1.Secret,
-	rotationUsers *spec.PgUserMap,
 	retentionUsers *[]string,
 	currentTime time.Time) error {
 	var (
@@ -757,7 +740,7 @@ func (c *Cluster) updateSecret(
 	rotationAllowed := !pwdUser.IsDbOwner && util.SliceContains(allowedRoleTypes, pwdUser.Origin)
 
 	if (c.OpConfig.EnablePasswordRotation && rotationAllowed) || rotationEnabledInManifest {
-		updateSecretMsg, err = c.rotatePasswordInSecret(secret, pwdUser, secretUsername, currentTime, rotationUsers, retentionUsers)
+		updateSecretMsg, err = c.rotatePasswordInSecret(secret, secretUsername, pwdUser.Origin, currentTime, retentionUsers)
 		if err != nil {
 			c.logger.Warnf("password rotation failed for user %s: %v", secretUsername, err)
 		}
@@ -782,8 +765,13 @@ func (c *Cluster) updateSecret(
 		updateSecret = true
 		updateSecretMsg = fmt.Sprintf("updating the secret %s from the infrastructure roles", secretName)
 	} else {
-		// for non-infrastructure role - update the role with the password from the secret
+		// for non-infrastructure role - update the role with username and password from secret
+		pwdUser.Name = string(secret.Data["username"])
 		pwdUser.Password = string(secret.Data["password"])
+		// update membership if we deal with a rotation user
+		if secretUsername != pwdUser.Name {
+			pwdUser.MemberOf = []string{secretUsername}
+		}
 		userMap[userKey] = pwdUser
 	}
 
@@ -800,10 +788,9 @@ func (c *Cluster) updateSecret(
 
 func (c *Cluster) rotatePasswordInSecret(
 	secret *v1.Secret,
-	secretPgUser spec.PgUser,
 	secretUsername string,
+	roleOrigin spec.RoleOrigin,
 	currentTime time.Time,
-	rotationUsers *spec.PgUserMap,
 	retentionUsers *[]string) (string, error) {
 	var (
 		err                 error
@@ -831,20 +818,15 @@ func (c *Cluster) rotatePasswordInSecret(
 
 	// update password and next rotation date if configured interval has passed
 	if currentTime.After(nextRotationDate) {
+		newPassword := []byte(util.RandomPassword(constants.PasswordLength))
 		// create rotation user if role is not listed for in-place password update
 		if !util.SliceContains(c.Spec.UsersWithInPlaceSecretRotation, secretUsername) {
-			rotationUser := secretPgUser
-			newRotationUsername := fmt.Sprintf("%s%s", secretUsername, currentTime.Format("060102"))
-			rotationUser.Name = newRotationUsername
-			rotationUser.MemberOf = []string{secretUsername}
-			(*rotationUsers)[newRotationUsername] = rotationUser
-			secret.Data["username"] = []byte(newRotationUsername)
-
+			secret.Data["username"] = []byte(fmt.Sprintf("%s%s", secretUsername, currentTime.Format("060102")))
 			// whenever there is a rotation, check if old rotation users can be deleted
 			*retentionUsers = append(*retentionUsers, secretUsername)
 		} else {
 			// when passwords of system users are rotated in place, pods have to be replaced
-			if secretPgUser.Origin == spec.RoleOriginSystem {
+			if roleOrigin == spec.RoleOriginSystem {
 				pods, err := c.listPods()
 				if err != nil {
 					return "", fmt.Errorf("could not list pods of the statefulset: %v", err)
@@ -858,7 +840,7 @@ func (c *Cluster) rotatePasswordInSecret(
 			}
 
 			// when password of connection pooler is rotated in place, pooler pods have to be replaced
-			if secretPgUser.Origin == spec.RoleOriginConnectionPooler {
+			if roleOrigin == spec.RoleOriginConnectionPooler {
 				listOptions := metav1.ListOptions{
 					LabelSelector: c.poolerLabelsSet(true).String(),
 				}
@@ -875,11 +857,11 @@ func (c *Cluster) rotatePasswordInSecret(
 			}
 
 			// when password of stream user is rotated in place, it should trigger rolling update in FES deployment
-			if secretPgUser.Origin == spec.RoleOriginStream {
+			if roleOrigin == spec.RoleOriginStream {
 				c.logger.Warnf("secret of stream user %s changed", constants.EventStreamSourceSlotPrefix+constants.UserRoleNameSuffix)
 			}
 		}
-		secret.Data["password"] = []byte(util.RandomPassword(constants.PasswordLength))
+		secret.Data["password"] = newPassword
 		secret.Data["nextRotation"] = []byte(nextRotationDateStr)
 		updateSecretMsg = fmt.Sprintf("updating secret %s due to password rotation - next rotation date: %s", secretName, nextRotationDateStr)
 	}


### PR DESCRIPTION
### Current user and secret generation flow

How it looks like without rotation

1. [initUsers](https://github.com/zalando/postgres-operator/blob/d209612b18122ae42250bd0517533fd7cbad5c66/pkg/cluster/cluster.go#L196): Generates list of desired users (manifest roles, system users, team members etc.) with new [random passwords](https://github.com/zalando/postgres-operator/blob/d209612b18122ae42250bd0517533fd7cbad5c66/pkg/cluster/cluster.go#L1302)
2. [syncSecrets](https://github.com/zalando/postgres-operator/blob/d209612b18122ae42250bd0517533fd7cbad5c66/pkg/cluster/sync.go#L628)
a. [generateUserSecrets](https://github.com/zalando/postgres-operator/blob/d209612b18122ae42250bd0517533fd7cbad5c66/pkg/cluster/k8sres.go#L1669): Generates a list of secrets where `username` and `password` in secret are taken from the [pgUser](https://github.com/zalando/postgres-operator/blob/d209612b18122ae42250bd0517533fd7cbad5c66/pkg/cluster/k8sres.go#L1724) generated in 1.
b. Operator tries to create the secret or calls `updateSecret` when it already exists (although an actual update might not happen when there are no changes).
3. Inside [updateSecrets](https://github.com/zalando/postgres-operator/blob/d209612b18122ae42250bd0517533fd7cbad5c66/pkg/cluster/sync.go#L690)
a. query K8s API using the names of generates secrets to retrieve the real username and password values
<--- rotation disabled, it would otherwise happen here --->
b. In the PgUser list [override](https://github.com/zalando/postgres-operator/blob/d209612b18122ae42250bd0517533fd7cbad5c66/pkg/cluster/sync.go#L778) the random password from 1. with the actual password found in the secret
4. [syncRoles](https://github.com/zalando/postgres-operator/blob/d209612b18122ae42250bd0517533fd7cbad5c66/pkg/cluster/sync.go#L882):
a. Takes the PgUser list from 1 and [queries](https://github.com/zalando/postgres-operator/blob/d209612b18122ae42250bd0517533fd7cbad5c66/pkg/cluster/sync.go#L938) the database to compare later.
b. [Compares password](https://github.com/zalando/postgres-operator/blob/d209612b18122ae42250bd0517533fd7cbad5c66/pkg/util/users/users.go#L61) of pgUser with password found in database and triggers an ALTER statement on diff.
c. All accumulated ALTER requests are executed

### Bug report

What happens when password rotation is enabled:

Everything except an extra step between 3a and 3b is the same. When rotation is enabled the operator will try to find a rotation date in the secret and sets one if it does not exist. When the rotation interval has passed a new rotation user will specified under the `username` key and a new `nextRotation` date is set.

:lady_beetle: : All other PgUser fields for the rotation users are [copied](https://github.com/zalando/postgres-operator/blob/d209612b18122ae42250bd0517533fd7cbad5c66/pkg/cluster/sync.go#L828) from the unrotated user incl. the current password. A few lines later a new password is introduced for the secret struct.

:lady_beetle::lady_beetle: : As step 3b always overrides the generated password with the value from the secret, the rotation will result in a new password in the PgUser struct of the unrotated user. Thus, its password is updated in the database in 4c.

This makes the secret useless as it contains credentials that will not work for new pods. Running pods will also fail connecting to the database because the password of the used DB user has changed.

Fyi: Rotation users are added [straight from the `syncSecrets` ](https://github.com/zalando/postgres-operator/blob/d209612b18122ae42250bd0517533fd7cbad5c66/pkg/cluster/sync.go#L659) method. We do not wait until syncRoles, because rotation users are not part of the PgUser list generated in 1.

### Possible solutions

The PR suggest to override the username in step 3b [like it's done with the password](https://github.com/zalando/postgres-operator/blob/d209612b18122ae42250bd0517533fd7cbad5c66/pkg/cluster/sync.go#L778). Like this we could also remove code from `syncSecrets` to create rotation users. `syncRoles` would take care of it because it will find the rotation users in the PgUser list and incl. them in the database query. Thus creation would then be triggered [here](https://github.com/zalando/postgres-operator/blob/d209612b18122ae42250bd0517533fd7cbad5c66/pkg/util/users/users.go#L52).

