### PR TITLE
return error when Kube API is down during statefulset sync

### DIFF
--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -841,7 +841,8 @@ func TestGenerateSpiloPodEnvVars(t *testing.T) {
 		pgsql.Spec.StandbyCluster = tt.standbyDescription
 		c.Postgresql = pgsql
 
-		actualEnvs := c.generateSpiloPodEnvVars(&pgsql.Spec, types.UID(dummyUUID), exampleSpiloConfig)
+		actualEnvs, err := c.generateSpiloPodEnvVars(&pgsql.Spec, types.UID(dummyUUID), exampleSpiloConfig)
+		assert.NoError(t, err)
 
 		for _, ev := range tt.expectedValues {
 			env := actualEnvs[ev.envIndex]


### PR DESCRIPTION
fixes #2031

I think the refactor in https://github.com/zalando/postgres-operator/pull/1848 has introduced this regression, do you think it was intended?

Before the refactor,  `getPodEnvironmentSecretVariables` and `getPodEnvironmentConfigMapVariables` were called directly in `generateStatefulSet` and we used to return an error (and halt the sync) instead of just logging the error and continue sync with missing data.

Maybe add a test and adjust documentation somewhere.
