### PR TITLE
fix team member deprecation

### DIFF
--- a/.github/workflows/run_e2e.yaml
+++ b/.github/workflows/run_e2e.yaml
@@ -17,6 +17,8 @@ jobs:
           go-version: "^1.17.4"
     - name: Make dependencies
       run: make deps mocks
+    - name: Code generation
+      run: make codegen
     - name: Compile
       run: make linux
     - name: Run unit tests

--- a/pkg/cluster/database.go
+++ b/pkg/cluster/database.go
@@ -231,7 +231,8 @@ func (c *Cluster) readPgUsersFromDatabase(userNames []string) (users spec.PgUser
 			parameters[fields[0]] = fields[1]
 		}
 
-		if strings.HasSuffix(rolname, c.OpConfig.RoleDeletionSuffix) {
+		// consider NOLOGIN roles with deleted suffix as deprecated users
+		if strings.HasSuffix(rolname, c.OpConfig.RoleDeletionSuffix) && !rolcanlogin {
 			roldeleted = true
 		}
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -62,6 +62,8 @@ var substractTest = []struct {
 }{
 	{[]string{"a", "b", "c", "d"}, []string{"a", "b", "c", "d"}, []string{}, true},
 	{[]string{"a", "b", "c", "d"}, []string{"a", "bb", "c", "d"}, []string{"b"}, false},
+	{[]string{""}, []string{"b"}, []string{""}, false},
+	{[]string{"a"}, []string{""}, []string{"a"}, false},
 }
 
 var sliceContaintsTest = []struct {


### PR DESCRIPTION
#1953 introduced a bug in the user sync code. An extra pgUserMap [newUsers](https://github.com/zalando/postgres-operator/blob/master/pkg/cluster/sync.go#L942) was added to include systemUsers when passed to ProduceSyncRequests function. The info if a user is deprecated is overridden after newUsers variable is created, but only stored in the cluster's pgUsers variable.

Thus, ProduceSyncRequests does not know which users can be considered deprecated. The following bug can now happen:
1. Team members are marked as deprecated when they appear in the [pgUsersCache](https://github.com/zalando/postgres-operator/blob/master/pkg/cluster/sync.go#L932) but do not exist in desired c.pgUsers. This works.
2. Team members can re-join the team and the operator should rename the user back and grant LOGIN again. But it creates a new users.
2.1. [readPgUsersFromDatabase](https://github.com/zalando/postgres-operator/blob/84fe38a06908aa8adbe580041c133db84faf7121/pkg/cluster/database.go#L235) finds the deprecated user counterpart to a user that is desired in c.pgUsers. 
2.2. c.pgUsers is [updated](https://github.com/zalando/postgres-operator/blob/master/pkg/cluster/sync.go#L955) based on this finding, but not newUsers variable which is passed to ProduceSyncRequests.
2.3. ProduceSyncRequests [skips users marked as deleted](https://github.com/zalando/postgres-operator/blob/84fe38a06908aa8adbe580041c133db84faf7121/pkg/util/users/users.go#L47), but the info isn't found.
2.4. Since the new desired user does not exist in the database it is [created](https://github.com/zalando/postgres-operator/blob/84fe38a06908aa8adbe580041c133db84faf7121/pkg/util/users/users.go#L52).

Both the LOGIN team user and its deprecated NOLOGIN counterpart now exist in the database. The next time the member moves the operator will fail to rename the user because either of its versions already exist.

This PR fixes the bug and also enables the operator to deal with the erroneous setup of "redundant" roles. If rename requests fails the operator will only log the error but will not fail the sync. 