### PR TITLE
Add securityContext runAsNonRoot on Postgres Statefullset 

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -731,7 +731,9 @@ func (c *Cluster) generatePodTemplate(
 	securityContext := v1.PodSecurityContext{}
 
 	if spiloRunAsUser != nil {
+		var isNoRootPid = (*spiloRunAsUser > int64(0))
 		securityContext.RunAsUser = spiloRunAsUser
+		securityContext.RunAsNonRoot = &isNoRootPid
 	}
 
 	if spiloRunAsGroup != nil {

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -2837,3 +2837,100 @@ func TestGenerateCapabilities(t *testing.T) {
 		}
 	}
 }
+
+
+func TestRunPids(t *testing.T) {
+	client, _ := newFakeK8sTestClient()
+	clusterName := "acid-test-cluster"
+	namespace := "default"
+	spiloRunAsUser := int64(999)
+	spiloRunAsGroup := int64(100)
+	spiloFSGroup := int64(200)
+
+	pg := acidv1.Postgresql{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: namespace,
+		},
+		Spec: acidv1.PostgresSpec{
+			TeamID: "myapp", NumberOfInstances: 1,
+			Resources: &acidv1.Resources{
+				ResourceRequests: acidv1.ResourceDescription{CPU: "1", Memory: "10"},
+				ResourceLimits:   acidv1.ResourceDescription{CPU: "1", Memory: "10"},
+			},
+			Volume: acidv1.Volume{
+				Size: "1G",
+			},
+		},
+	}
+
+	var cluster = New(
+		Config{
+			OpConfig: config.Config{
+				PodManagementPolicy: "ordered_ready",
+				ProtectedRoles:      []string{"admin"},
+				Resources: config.Resources{
+					SpiloRunAsUser:  &spiloRunAsUser,
+					SpiloRunAsGroup: &spiloRunAsGroup,
+					SpiloFSGroup:    &spiloFSGroup,
+				},
+			},
+		}, client, pg, logger, eventRecorder)
+
+	// create a statefulset
+	sts, err := cluster.createStatefulSet()
+	assert.NoError(t, err)
+
+	assert.Equal(t, &spiloRunAsUser, sts.Spec.Template.Spec.SecurityContext.RunAsUser, "has a RunAsUser assigned")
+	assert.Equal(t, &spiloRunAsGroup, sts.Spec.Template.Spec.SecurityContext.RunAsGroup, "has a RunAsGroup assigned")
+	assert.Equal(t, &spiloFSGroup, sts.Spec.Template.Spec.SecurityContext.FSGroup, "has a FSGroup assigned")
+	assert.Equal(t, true, *sts.Spec.Template.Spec.SecurityContext.RunAsNonRoot, "has the flag RunAsNonRoot")
+}
+
+func TestRunRootPids(t *testing.T) {
+	client, _ := newFakeK8sTestClient()
+	clusterName := "acid-test-cluster"
+	namespace := "default"
+	spiloRunAsUser := int64(0)
+	spiloRunAsGroup := int64(100)
+	spiloFSGroup := int64(200)
+
+	pg := acidv1.Postgresql{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: namespace,
+		},
+		Spec: acidv1.PostgresSpec{
+			TeamID: "myapp", NumberOfInstances: 1,
+			Resources: &acidv1.Resources{
+				ResourceRequests: acidv1.ResourceDescription{CPU: "1", Memory: "10"},
+				ResourceLimits:   acidv1.ResourceDescription{CPU: "1", Memory: "10"},
+			},
+			Volume: acidv1.Volume{
+				Size: "1G",
+			},
+		},
+	}
+
+	var cluster = New(
+		Config{
+			OpConfig: config.Config{
+				PodManagementPolicy: "ordered_ready",
+				ProtectedRoles:      []string{"admin"},
+				Resources: config.Resources{
+					SpiloRunAsUser:  &spiloRunAsUser,
+					SpiloRunAsGroup: &spiloRunAsGroup,
+					SpiloFSGroup:    &spiloFSGroup,
+				},
+			},
+		}, client, pg, logger, eventRecorder)
+
+	// create a statefulset
+	sts, err := cluster.createStatefulSet()
+	assert.NoError(t, err)
+
+	assert.Equal(t, &spiloRunAsUser, sts.Spec.Template.Spec.SecurityContext.RunAsUser, "has a RunAsUser assigned")
+	assert.Equal(t, &spiloRunAsGroup, sts.Spec.Template.Spec.SecurityContext.RunAsGroup, "has a RunAsGroup assigned")
+	assert.Equal(t, &spiloFSGroup, sts.Spec.Template.Spec.SecurityContext.FSGroup, "has a FSGroup assigned")
+	assert.Equal(t, false, *sts.Spec.Template.Spec.SecurityContext.RunAsNonRoot, "has the flag RunAsNonRoot")
+}


### PR DESCRIPTION
Set RunAsNonRoot on securityContext of Postgres statfullset

Fix [(#2081)](https://github.com/zalando/postgres-operator/issues/2081)