### PR TITLE
Add support for SecurityContext in sidecar containers

### DIFF
--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -464,6 +464,10 @@ defined in the sidecar dictionary:
   [CPU and memory requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container)
   for each sidecar container. Optional.
 
+* **securityContext**
+  a [Kubernetes SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+  for each sidecar container. Optional.
+
 ### Requests
 
 CPU and memory requests for the sidecar container.

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -204,11 +204,12 @@ type CloneDescription struct {
 
 // Sidecar defines a container to be run in the same pod as the Postgres container.
 type Sidecar struct {
-	*Resources  `json:"resources,omitempty"`
-	Name        string             `json:"name,omitempty"`
-	DockerImage string             `json:"image,omitempty"`
-	Ports       []v1.ContainerPort `json:"ports,omitempty"`
-	Env         []v1.EnvVar        `json:"env,omitempty"`
+	*Resources      `json:"resources,omitempty"`
+	Name            string              `json:"name,omitempty"`
+	DockerImage     string              `json:"image,omitempty"`
+	Ports           []v1.ContainerPort  `json:"ports,omitempty"`
+	Env             []v1.EnvVar         `json:"env,omitempty"`
+	SecurityContext *v1.SecurityContext `json:"securityContext,omitempty"`
 }
 
 // UserFlags defines flags (such as superuser, nologin) that could be assigned to individual users

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1083,6 +1083,7 @@ func getSidecarContainer(sidecar acidv1.Sidecar, index int, resources *v1.Resour
 		Resources:       *resources,
 		Env:             sidecar.Env,
 		Ports:           sidecar.Ports,
+		SecurityContext: sidecar.SecurityContext,
 	}
 }
 

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -1801,6 +1801,8 @@ func TestSidecars(t *testing.T) {
 		}
 	}
 
+	trueValue := true
+
 	spec = acidv1.PostgresSpec{
 		PostgresqlParam: acidv1.PostgresqlParam{
 			PgVersion: "12.1",
@@ -1830,6 +1832,10 @@ func TestSidecars(t *testing.T) {
 			acidv1.Sidecar{
 				Name:        "replace-sidecar",
 				DockerImage: "override-image",
+			},
+			acidv1.Sidecar{
+				Name:            "security-context-sidecar",
+				SecurityContext: &v1.SecurityContext{AllowPrivilegeEscalation: &trueValue},
 			},
 		},
 	}
@@ -1921,7 +1927,7 @@ func TestSidecars(t *testing.T) {
 	}
 
 	// deduplicated sidecars and Patroni
-	assert.Equal(t, 7, len(s.Spec.Template.Spec.Containers), "wrong number of containers")
+	assert.Equal(t, 8, len(s.Spec.Template.Spec.Containers), "wrong number of containers")
 
 	// cluster specific sidecar
 	assert.Contains(t, s.Spec.Template.Spec.Containers, v1.Container{
@@ -1976,6 +1982,16 @@ func TestSidecars(t *testing.T) {
 		ImagePullPolicy: v1.PullIfNotPresent,
 		Env:             scalyrEnv,
 		VolumeMounts:    mounts,
+	})
+
+	// securityContext sidecar
+	assert.Contains(t, s.Spec.Template.Spec.Containers, v1.Container{
+		Name:            "security-context-sidecar",
+		Env:             env,
+		Resources:       generateKubernetesResources("200m", "500m", "0.7Gi", "1.3Gi"),
+		ImagePullPolicy: v1.PullIfNotPresent,
+		VolumeMounts:    mounts,
+		SecurityContext: &v1.SecurityContext{AllowPrivilegeEscalation: &trueValue},
 	})
 
 }


### PR DESCRIPTION
Adding support for SecurityContext in sidecar containers.
Doc updated.
Unit Tests updated.
Validated on a test cluster. the SecurityContext is forwarded to the container specs.