### PR TITLE
Allow drop slots when it gets deleted from the manifest

### DIFF
--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -526,7 +526,7 @@ class EndToEndTestCase(unittest.TestCase):
             """ % (slot_to_remove)
             
             self.eventuallyEqual(lambda: self.query_database(replica.metadata.name, "postgres", deleted_slot_query)[0], 0,
-                "The replication slot cannot be deleted")       
+                "The replication slot cannot be deleted", 10, 5)       
 
         except timeout_decorator.TimeoutError:
             print('Operator log: {}'.format(k8s.get_operator_log()))

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -403,16 +403,12 @@ class EndToEndTestCase(unittest.TestCase):
                     "test_user": []
                 },
                 "databases": {
-                    "foo": "test_user"
+                    "foo": "test_user",
+                    "bar": "test_user"
                 },
                 "patroni": {
                     "slots": {
-                        "test_slot": {
-                            "type": "logical",
-                            "database": "foo",
-                            "plugin": "pgoutput"
-                        },
-                        "test_slot_2": {
+                        "first_slot": {
                             "type": "physical"
                         }
                     },
@@ -449,6 +445,8 @@ class EndToEndTestCase(unittest.TestCase):
                             "synchronous_mode not updated")
                 self.assertEqual(desired_config["failsafe_mode"], effective_config["failsafe_mode"],
                             "failsafe_mode not updated")
+                self.assertEqual(desired_config["slots"], effective_config["slots"],
+                            "slots not updated")
                 return True
 
             # check if Patroni config has been updated
@@ -512,31 +510,63 @@ class EndToEndTestCase(unittest.TestCase):
             # patch new slot via Patroni REST
             patroni_slot = "test_patroni_slot"
             patch_slot_command = """curl -s -XPATCH -d '{"slots": {"test_patroni_slot": {"type": "physical"}}}' localhost:8008/config"""
-            k8s.exec_with_kubectl(leader.metadata.name, patch_slot_command)
+            pg_patch_config["spec"]["patroni"]["slots"][patroni_slot] = {"type": "physical"}
 
+            k8s.exec_with_kubectl(leader.metadata.name, patch_slot_command)
             self.eventuallyEqual(lambda: k8s.get_operator_state(), {"0": "idle"}, "Operator does not get in sync")
             self.eventuallyTrue(compare_config, "Postgres config not applied")
 
-            # delete test_slot_2 from config and change the plugin type for test_slot
-            slot_to_change = "test_slot"
-            slot_to_remove = "test_slot_2"
-            pg_patch_slots = {
+            # test adding new slots
+            pg_add_new_slots_patch = {
                 "spec": {
                     "patroni": {
-                        "slots": {
+                         "slots": {
                             "test_slot": {
                                 "type": "logical",
                                 "database": "foo",
-                                "plugin": "wal2json"
+                                "plugin": "pgoutput"
+                            },
+                            "test_slot_2": {
+                                "type": "physical"
                             }
                         }
                     }
                 }
             }
 
+            for slot_name, slot_details in pg_add_new_slots_patch["spec"]["patroni"]["slots"].items():
+                pg_patch_config["spec"]["patroni"]["slots"][slot_name] = slot_details
+
             k8s.api.custom_objects_api.patch_namespaced_custom_object(
-                "acid.zalan.do", "v1", "default", "postgresqls", "acid-minimal-cluster", pg_patch_slots)
+                "acid.zalan.do", "v1", "default", "postgresqls", "acid-minimal-cluster", pg_add_new_slots_patch)
+
+            self.eventuallyEqual(lambda: k8s.get_operator_state(), {"0": "idle"}, "Operator does not get in sync")
+            self.eventuallyTrue(compare_config, "Postgres config not applied")
+
+            # delete test_slot_2 from config and change the database type for test_slot
+            slot_to_change = "test_slot"
+            slot_to_remove = "test_slot_2"
+            pg_delete_slot_patch = {
+                "spec": {
+                    "patroni": {
+                        "slots": {
+                            "test_slot": {
+                                "type": "logical",
+                                "database": "bar",
+                                "plugin": "pgoutput"
+                            },
+                            "test_slot_2": None
+                        }
+                    }
+                }
+            }
+
+            pg_patch_config["spec"]["patroni"]["slots"][slot_to_change]["database"] = "bar"
+            del pg_patch_config["spec"]["patroni"]["slots"][slot_to_remove]
             
+            k8s.api.custom_objects_api.patch_namespaced_custom_object(
+                "acid.zalan.do", "v1", "default", "postgresqls", "acid-minimal-cluster", pg_delete_slot_patch)
+
             self.eventuallyEqual(lambda: k8s.get_operator_state(), {"0": "idle"}, "Operator does not get in sync")
             self.eventuallyTrue(compare_config, "Postgres config not applied")
 
@@ -550,12 +580,12 @@ class EndToEndTestCase(unittest.TestCase):
                 "The replication slot cannot be deleted", 10, 5)
 
             changed_slot_query = """
-                SELECT plugin
+                SELECT database
                   FROM pg_replication_slots
                  WHERE slot_name = '%s';
             """ % (slot_to_change)
 
-            self.eventuallyEqual(lambda: self.query_database(leader.metadata.name, "postgres", changed_slot_query)[0], "wal2json",
+            self.eventuallyEqual(lambda: self.query_database(leader.metadata.name, "postgres", changed_slot_query)[0], "bar",
                 "The replication slot cannot be updated", 10, 5)
             
             # make sure slot from Patroni didn't get deleted

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -520,12 +520,12 @@ class EndToEndTestCase(unittest.TestCase):
             self.eventuallyEqual(lambda: k8s.get_operator_state(), {"0": "idle"}, "Operator does not get in sync")
 
             deleted_slot_query = """
-                SELECT count(*)
+                SELECT slot_name
                   FROM pg_replication_slots
                  WHERE slot_name = '%s';
             """ % (slot_to_remove)
             
-            self.eventuallyEqual(lambda: self.query_database(replica.metadata.name, "postgres", deleted_slot_query)[0], 0,
+            self.eventuallyEqual(lambda: len(self.query_database(replica.metadata.name, "postgres", deleted_slot_query)), 0,
                 "The replication slot cannot be deleted", 10, 5)       
 
         except timeout_decorator.TimeoutError:

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -399,7 +399,7 @@ class EndToEndTestCase(unittest.TestCase):
                         "wal_level": "logical"
                      }
                  },
-                "patroni": {
+                 "patroni": {
                     "slots": {
                         "first_slot": {
                             "type": "physical"

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -399,13 +399,6 @@ class EndToEndTestCase(unittest.TestCase):
                         "wal_level": "logical"
                      }
                  },
-                "users": {
-                    "test_user": []
-                },
-                "databases": {
-                    "foo": "test_user",
-                    "bar": "test_user"
-                },
                 "patroni": {
                     "slots": {
                         "first_slot": {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -377,10 +377,8 @@ func (c *Cluster) Create() error {
 		}
 	}
 
-	if len(c.Spec.Patroni.Slots) > 0 {
-		for slotName, desiredSlot := range c.Spec.Patroni.Slots {
-			c.replicationSlots[slotName] = desiredSlot
-		}
+	for slotName, desiredSlot := range c.Spec.Patroni.Slots {
+		c.replicationSlots[slotName] = desiredSlot
 	}
 
 	return nil

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -581,13 +581,14 @@ func (c *Cluster) checkAndSetGlobalPostgreSQLConfiguration(pod *v1.Pod, effectiv
 
 	slotsToSet := make(map[string]interface{})
 	// check if there is any slot deletion
-	for slotName, effectiveSlot := range effectivePatroniConfig.Slots {
+	for slotName, effectiveSlot := range c.replicationSlots {
 		if desiredSlot, exists := desiredPatroniConfig.Slots[slotName]; exists {
 			if reflect.DeepEqual(effectiveSlot, desiredSlot) {
 				continue
 			}
 		}
 		slotsToSet[slotName] = nil
+		delete(c.replicationSlots, slotName)
 	}
 	// check if specified slots exist in config and if they differ
 	for slotName, desiredSlot := range desiredPatroniConfig.Slots {
@@ -597,6 +598,7 @@ func (c *Cluster) checkAndSetGlobalPostgreSQLConfiguration(pod *v1.Pod, effectiv
 			}
 		}
 		slotsToSet[slotName] = desiredSlot
+		c.replicationSlots[slotName] = desiredSlot
 	}
 	if len(slotsToSet) > 0 {
 		configToSet["slots"] = slotsToSet

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -625,7 +625,7 @@ func (c *Cluster) checkAndSetGlobalPostgreSQLConfiguration(pod *v1.Pod, effectiv
 	}
 
 	// check if there exist only config updates that require a restart of the primary
-	if !util.SliceContains(restartPrimary, false) && len(configToSet) == 0 {
+	if len(restartPrimary) > 0 && !util.SliceContains(restartPrimary, false) && len(configToSet) == 0 {
 		requiresMasterRestart = true
 	}
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -580,15 +580,6 @@ func (c *Cluster) checkAndSetGlobalPostgreSQLConfiguration(pod *v1.Pod, effectiv
 	}
 
 	slotsToSet := make(map[string]interface{})
-	// check if specified slots exist in config and if they differ
-	for slotName, desiredSlot := range desiredPatroniConfig.Slots {
-		if effectiveSlot, exists := effectivePatroniConfig.Slots[slotName]; exists {
-			if reflect.DeepEqual(desiredSlot, effectiveSlot) {
-				continue
-			}
-		}
-		slotsToSet[slotName] = desiredSlot
-	}
 	// check if there is any slot deletion
 	for slotName, effectiveSlot := range effectivePatroniConfig.Slots {
 		if desiredSlot, exists := desiredPatroniConfig.Slots[slotName]; exists {
@@ -597,6 +588,15 @@ func (c *Cluster) checkAndSetGlobalPostgreSQLConfiguration(pod *v1.Pod, effectiv
 			}
 		}
 		slotsToSet[slotName] = nil
+	}
+	// check if specified slots exist in config and if they differ
+	for slotName, desiredSlot := range desiredPatroniConfig.Slots {
+		if effectiveSlot, exists := effectivePatroniConfig.Slots[slotName]; exists {
+			if reflect.DeepEqual(desiredSlot, effectiveSlot) {
+				continue
+			}
+		}
+		slotsToSet[slotName] = desiredSlot
 	}
 	if len(slotsToSet) > 0 {
 		configToSet["slots"] = slotsToSet

--- a/pkg/util/patroni/patroni.go
+++ b/pkg/util/patroni/patroni.go
@@ -38,7 +38,6 @@ type Interface interface {
 	Restart(server *v1.Pod) error
 	GetConfig(server *v1.Pod) (acidv1.Patroni, map[string]string, error)
 	SetConfig(server *v1.Pod, config map[string]interface{}) error
-	RewriteConfig(server *v1.Pod, config map[string]interface{}) error
 }
 
 // Patroni API client
@@ -79,42 +78,6 @@ func apiURL(masterPod *v1.Pod) (string, error) {
 }
 
 func (p *Patroni) httpPostOrPatch(method string, url string, body *bytes.Buffer) (err error) {
-	request, err := http.NewRequest(method, url, body)
-	if err != nil {
-		return fmt.Errorf("could not create request: %v", err)
-	}
-
-	if p.logger != nil {
-		p.logger.Debugf("making %s http request: %s", method, request.URL.String())
-	}
-
-	resp, err := p.httpClient.Do(request)
-	if err != nil {
-		return fmt.Errorf("could not make request: %v", err)
-	}
-	defer func() {
-		if err2 := resp.Body.Close(); err2 != nil {
-			if err != nil {
-				err = fmt.Errorf("could not close request: %v, prior error: %v", err2, err)
-			} else {
-				err = fmt.Errorf("could not close request: %v", err2)
-			}
-			return
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("could not read response: %v", err)
-		}
-
-		return fmt.Errorf("patroni returned '%s'", string(bodyBytes))
-	}
-	return nil
-}
-
-func (p *Patroni) httpPut(method string, url string, body *bytes.Buffer) (err error) {
 	request, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return fmt.Errorf("could not create request: %v", err)
@@ -213,19 +176,6 @@ func (p *Patroni) SetConfig(server *v1.Pod, config map[string]interface{}) error
 		return err
 	}
 	return p.httpPostOrPatch(http.MethodPatch, apiURLString+configPath, buf)
-}
-
-func (p *Patroni) RewriteConfig(server *v1.Pod, config map[string]interface{}) error {
-	buf := &bytes.Buffer{}
-	err := json.NewEncoder(buf).Encode(config)
-	if err != nil {
-		return fmt.Errorf("could not encode json: %v", err)
-	}
-	apiURLString, err := apiURL(server)
-	if err != nil {
-		return err
-	}
-	return p.httpPut(http.MethodPut, apiURLString+configPath, buf)
 }
 
 // ClusterMembers array of cluster members from Patroni API


### PR DESCRIPTION
### Problem
Users can [specify replication slots](https://github.com/zalando/postgres-operator/blob/master/manifests/complete-postgres-manifest.yaml#L122) in the Postgres manifest and they are [added](https://github.com/zalando/postgres-operator/blob/4786f53f033154009051c2b1dc300be48c55790a/pkg/cluster/sync.go#L572) to the database via [Patroni REST API](https://github.com/zalando/postgres-operator/blob/4786f53f033154009051c2b1dc300be48c55790a/pkg/cluster/sync.go#L628). When the slot is removed from the manifest, it won't get deleted in the database. Here we follow the convention of the operator never dropping database objects because manifest edits could have been wrong accidentally.

However, with logical replication slots the situation is a little different. If they are not used, diskspace will grow until it's exhausted. Our users are mostly not aware of this and think the slot will be gone when it's not desired anymore in the manifest. Some users check the database and still find the slot. So they call `pg_drop_replication_slot` function to drop it only to be surprised seconds later that the slot is recreated. 

### Solution
The operator should drop replication slots when they are removed from the manifest by updating the Patroni config. So far, our code only adds new slots or slots that differ from existing slots to the [configToSet](https://github.com/zalando/postgres-operator/blob/master/pkg/cluster/sync.go#L579). Patroni's config endpoint only merges the patches - it does not override the slots section.

To drop the replication slots that get deleted from the manifest, we can set the unused slots to null in the current Patroni's configuration and using `PATCH /config`.