### PR TITLE
Add pes to backupjob

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2230,7 +2230,7 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 	// that will override all subsequent global variables
 	secretEnvVarsList, err := c.getPodEnvironmentSecretVariables()
 	if err != nil {
-		return nil, err
+		return nil
 	}
 	envVars = appendEnvVars(envVars, secretEnvVarsList...)
 
@@ -2238,7 +2238,7 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 	// that will override all subsequent global variables
 	configMapEnvVarsList, err := c.getPodEnvironmentConfigMapVariables()
 	if err != nil {
-		return nil, err
+		return nil
 	}
 	envVars = appendEnvVars(envVars, configMapEnvVarsList...)
 

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2226,6 +2226,22 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 		envVars = append(envVars, v1.EnvVar{Name: "AWS_SECRET_ACCESS_KEY", Value: c.OpConfig.LogicalBackup.LogicalBackupS3SecretAccessKey})
 	}
 
+	// fetch variables from custom environment Secret
+	// that will override all subsequent global variables
+	secretEnvVarsList, err := c.getPodEnvironmentSecretVariables()
+	if err != nil {
+		return nil, err
+	}
+	envVars = appendEnvVars(envVars, secretEnvVarsList...)
+
+	// fetch variables from custom environment ConfigMap
+	// that will override all subsequent global variables
+	configMapEnvVarsList, err := c.getPodEnvironmentConfigMapVariables()
+	if err != nil {
+		return nil, err
+	}
+	envVars = appendEnvVars(envVars, configMapEnvVarsList...)
+
 	c.logger.Debugf("Generated logical backup env vars")
 	c.logger.Debugf("%v", envVars)
 	return envVars


### PR DESCRIPTION
Added support for the pod_environment_secret and pod_environment_configmap settings to the logical backup job to support credentials and custom S3 buckets per db.