### PR TITLE
first sync wal_level then publications

### DIFF
--- a/pkg/cluster/database.go
+++ b/pkg/cluster/database.go
@@ -48,7 +48,7 @@ const (
 
 	getPublicationsSQL = `SELECT p.pubname, string_agg(pt.schemaname || '.' || pt.tablename, ', ' ORDER BY pt.schemaname, pt.tablename)
 	        FROM pg_publication p
-			JOIN pg_publication_tables pt ON pt.pubname = p.pubname
+			LEFT JOIN pg_publication_tables pt ON pt.pubname = p.pubname
 			GROUP BY p.pubname;`
 	createPublicationSQL = `CREATE PUBLICATION "%s" FOR TABLE %s WITH (publish = 'insert, update');`
 	alterPublicationSQL  = `ALTER PUBLICATION "%s" SET TABLE %s;`


### PR DESCRIPTION
Right now, the operator tries to change wal_level and adding extra slots in one config sync. However, publications cannot be created correctly until wal_level is switched. The publication will be "empty", meaning there's no entry in `publication_tables` catalog.

On subsequent sync cycles the operator cannot find the created publications because it uses a JOIN with `publication_tables`. With a LEFT JOIN it would find the empty state and fix it with ALTER PUBLICATION.

To avoid this situation in the first place, the PR suggests to do two config syncs. After changing the wal_level we need to wait for a Postgres restart on the next sync. After that creating publication, replication slots and stream resources should work in one go.