### PR TITLE
use tpl in value objects containing arrays

### DIFF
--- a/charts/postgres-operator/templates/operatorconfiguration.yaml
+++ b/charts/postgres-operator/templates/operatorconfiguration.yaml
@@ -12,7 +12,7 @@ metadata:
 configuration:
 {{ toYaml .Values.configGeneral | indent 2 }}
   users:
-{{ toYaml .Values.configUsers | indent 4 }}
+{{ tpl (toYaml .Values.configUsers) . | indent 4 }}
   major_version_upgrade:
 {{ toYaml .Values.configMajorVersionUpgrade | indent 4 }}
   kubernetes:
@@ -21,7 +21,7 @@ configuration:
     {{- end }}
     pod_service_account_name: {{ include "postgres-pod.serviceAccountName" . }}
     oauth_token_secret_name: {{ template "postgres-operator.fullname" . }}
-{{ toYaml .Values.configKubernetes | indent 4 }}
+{{ tpl (toYaml .Values.configKubernetes) . | indent 4 }}
   postgres_pod_resources:
 {{ toYaml .Values.configPostgresPodResources | indent 4 }}
   timeouts:
@@ -35,7 +35,7 @@ configuration:
   debug:
 {{ toYaml .Values.configDebug | indent 4 }}
   teams_api:
-{{ toYaml .Values.configTeamsApi | indent 4 }}
+{{ tpl (toYaml .Values.configTeamsApi) . | indent 4 }}
   logging_rest_api:
 {{ toYaml .Values.configLoggingRestApi | indent 4 }}
   connection_pooler:


### PR DESCRIPTION
using tpl in value objects containing arrays allows us to override objects in arrays. This is not possible via helm --set due to limitations in helm

fixes #2114 together with #1986