### PR TITLE
Remove namespace and fix errors in example manifests files

### DIFF
--- a/manifests/e2e-storage-class.yaml
+++ b/manifests/e2e-storage-class.yaml
@@ -1,7 +1,6 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  namespace: kube-system
   name: standard
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"

--- a/manifests/fake-teams-api.yaml
+++ b/manifests/fake-teams-api.yaml
@@ -41,7 +41,5 @@ metadata:
   namespace: default
 type: Opaque
 data:
-apiVersion: v1
-data:
   read-only-token-secret: dGVzdHRva2Vu
   read-only-token-type: QmVhcmVy

--- a/manifests/infrastructure-roles-new.yaml
+++ b/manifests/infrastructure-roles-new.yaml
@@ -8,5 +8,4 @@ data:
 kind: Secret
 metadata:
   name: postgresql-infrastructure-roles-new
-  namespace: default
 type: Opaque

--- a/manifests/infrastructure-roles.yaml
+++ b/manifests/infrastructure-roles.yaml
@@ -21,5 +21,4 @@ data:
 kind: Secret
 metadata:
   name: postgresql-infrastructure-roles
-  namespace: default
 type: Opaque

--- a/manifests/minimal-postgres-manifest-12.yaml
+++ b/manifests/minimal-postgres-manifest-12.yaml
@@ -2,7 +2,6 @@ apiVersion: "acid.zalan.do/v1"
 kind: postgresql
 metadata:
   name: acid-upgrade-test
-  namespace: default
 spec:
   teamId: "acid"
   volume:

--- a/manifests/minimal-postgres-manifest.yaml
+++ b/manifests/minimal-postgres-manifest.yaml
@@ -2,7 +2,6 @@ apiVersion: "acid.zalan.do/v1"
 kind: postgresql
 metadata:
   name: acid-minimal-cluster
-  namespace: default
 spec:
   teamId: "acid"
   volume:

--- a/manifests/platform-credentials.yaml
+++ b/manifests/platform-credentials.yaml
@@ -2,7 +2,6 @@ apiVersion: "zalando.org/v1"
 kind: PlatformCredentialsSet
 metadata:
   name: postgresql-operator
-  namespace: acid
 spec:
   application: postgresql-operator
   tokens:

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -198,5 +198,5 @@ configuration:
     connection_pooler_number_of_instances: 2
     # connection_pooler_schema: "pooler"
     # connection_pooler_user: "pooler"
-  patroni:
+  # patroni:
     # failsafe_mode: "false"

--- a/manifests/standby-manifest.yaml
+++ b/manifests/standby-manifest.yaml
@@ -2,7 +2,6 @@ apiVersion: "acid.zalan.do/v1"
 kind: postgresql
 metadata:
   name: acid-standby-cluster
-  namespace: default
 spec:
   teamId: "acid"
   volume:


### PR DESCRIPTION
This PR fix some typos and remove predefined namespaces from the example manifests:
- Remove ns from the `StorageClass` (cluster wide resource)
- Fix duplicating `apiVersion` and `data` sections for `ConfigMap`
- Remove `default` ns from the CR's to allows deployment to any ns without modificatios
- Comment `patroni` section inside the default `OperatorConfiguration` as it's required field