### PR TITLE
use random short name for stream CRDs

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -32,7 +32,7 @@ clean:
 
 copy: clean
 	mkdir manifests
-	cp ../manifests -r .
+	cp -r ../manifests .
 
 docker: scm-source.json
 	docker build -t "$(IMAGE):$(TAG)" .

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -91,7 +91,6 @@ type Cluster struct {
 	currentProcess      Process
 	processMu           sync.RWMutex // protects the current operation for reporting, no need to hold the master mutex
 	specMu              sync.RWMutex // protects the spec for reporting, no need to hold the master mutex
-	streamApplications  []string
 	ConnectionPooler    map[PostgresRole]*ConnectionPoolerObjects
 	EBSVolumes          map[string]volumes.VolumeProperties
 	VolumeResizer       volumes.VolumeResizer

--- a/pkg/cluster/streams.go
+++ b/pkg/cluster/streams.go
@@ -15,15 +15,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (c *Cluster) createStreams(appId string) error {
+func (c *Cluster) createStreams(appId string) (*zalandov1.FabricEventStream, error) {
 	c.setProcessName("creating streams")
 
 	fes := c.generateFabricEventStream(appId)
-	if _, err := c.KubeClient.FabricEventStreams(c.Namespace).Create(context.TODO(), fes, metav1.CreateOptions{}); err != nil {
-		return err
+	streamCRD, err := c.KubeClient.FabricEventStreams(c.Namespace).Create(context.TODO(), fes, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
 	}
 
-	return nil
+	return streamCRD, nil
 }
 
 func (c *Cluster) updateStreams(newEventStreams *zalandov1.FabricEventStream) error {
@@ -46,11 +47,17 @@ func (c *Cluster) deleteStreams() error {
 	}
 
 	errors := make([]string, 0)
-	for _, appId := range c.streamApplications {
-		fesName := fmt.Sprintf("%s-%s", c.Name, appId)
-		err = c.KubeClient.FabricEventStreams(c.Namespace).Delete(context.TODO(), fesName, metav1.DeleteOptions{})
+	listOptions := metav1.ListOptions{
+		LabelSelector: c.labelsSet(true).String(),
+	}
+	streams, err := c.KubeClient.FabricEventStreams(c.Namespace).List(context.TODO(), listOptions)
+	if err != nil {
+		return fmt.Errorf("could not list of FabricEventStreams: %v", err)
+	}
+	for _, stream := range streams.Items {
+		err = c.KubeClient.FabricEventStreams(stream.Namespace).Delete(context.TODO(), stream.Name, metav1.DeleteOptions{})
 		if err != nil {
-			errors = append(errors, fmt.Sprintf("could not delete event stream %q: %v", fesName, err))
+			errors = append(errors, fmt.Sprintf("could not delete event stream %q: %v", stream.Name, err))
 		}
 	}
 
@@ -184,8 +191,10 @@ func (c *Cluster) generateFabricEventStream(appId string) *zalandov1.FabricEvent
 			Kind:       constants.EventStreamCRDKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        fmt.Sprintf("%s-%s", c.Name, appId),
+			// max length for cluster name is 53 so we can only add 10 more characters / numbers
+			Name:        fmt.Sprintf("%s-%s-%s", c.Name, constants.EventStreamSourceSlotPrefix, util.RandomPassword(5)),
 			Namespace:   c.Namespace,
+			Labels:      c.labelsSet(true),
 			Annotations: c.AnnotationsToPropagate(c.annotationsSet(nil)),
 			// make cluster StatefulSet the owner (like with connection pooler objects)
 			OwnerReferences: c.ownerReferences(),
@@ -284,11 +293,6 @@ func (c *Cluster) syncStreams() error {
 		return nil
 	}
 
-	// fetch different application IDs from streams section
-	// there will be a separate event stream resource for each ID
-	appIds := gatherApplicationIds(c.Spec.Streams)
-	c.streamApplications = appIds
-
 	slots := make(map[string]map[string]string)
 	slotsToSync := make(map[string]map[string]string)
 	publications := make(map[string]map[string]acidv1.StreamTable)
@@ -355,32 +359,43 @@ func (c *Cluster) syncStreams() error {
 }
 
 func (c *Cluster) createOrUpdateStreams() error {
-	for _, appId := range c.streamApplications {
-		fesName := fmt.Sprintf("%s-%s", c.Name, appId)
-		effectiveStreams, err := c.KubeClient.FabricEventStreams(c.Namespace).Get(context.TODO(), fesName, metav1.GetOptions{})
-		if err != nil {
-			if !k8sutil.ResourceNotFound(err) {
-				return fmt.Errorf("failed reading event stream %s: %v", fesName, err)
-			}
 
-			c.logger.Infof("event streams do not exist, create it")
-			err = c.createStreams(appId)
-			if err != nil {
-				return fmt.Errorf("failed creating event stream %s: %v", fesName, err)
-			}
-			c.logger.Infof("event stream %q has been successfully created", fesName)
-		} else {
-			desiredStreams := c.generateFabricEventStream(appId)
-			if match, reason := sameStreams(effectiveStreams.Spec.EventStreams, desiredStreams.Spec.EventStreams); !match {
-				c.logger.Debugf("updating event streams: %s", reason)
-				desiredStreams.ObjectMeta.ResourceVersion = effectiveStreams.ObjectMeta.ResourceVersion
-				err = c.updateStreams(desiredStreams)
-				if err != nil {
-					return fmt.Errorf("failed updating event stream %s: %v", fesName, err)
+	// fetch different application IDs from streams section
+	// there will be a separate event stream resource for each ID
+	appIds := gatherApplicationIds(c.Spec.Streams)
+
+	// list all existing stream CRDs
+	listOptions := metav1.ListOptions{
+		LabelSelector: c.labelsSet(true).String(),
+	}
+	streams, err := c.KubeClient.FabricEventStreams(c.Namespace).List(context.TODO(), listOptions)
+	if err != nil {
+		return fmt.Errorf("could not list of FabricEventStreams: %v", err)
+	}
+
+	for _, appId := range appIds {
+		// update stream when it exists and EventStreams array differs
+		for _, stream := range streams.Items {
+			if appId == stream.Spec.ApplicationId {
+				desiredStreams := c.generateFabricEventStream(appId)
+				if match, reason := sameStreams(stream.Spec.EventStreams, desiredStreams.Spec.EventStreams); !match {
+					c.logger.Debugf("updating event streams: %s", reason)
+					desiredStreams.ObjectMeta.ResourceVersion = stream.ObjectMeta.ResourceVersion
+					err = c.updateStreams(desiredStreams)
+					if err != nil {
+						return fmt.Errorf("failed updating event stream %s: %v", stream.Name, err)
+					}
+					c.logger.Infof("event stream %q has been successfully updated", stream.Name)
 				}
-				c.logger.Infof("event stream %q has been successfully updated", fesName)
+				continue
 			}
 		}
+		c.logger.Infof("event streams do not exist, create it")
+		streamCRD, err := c.createStreams(appId)
+		if err != nil {
+			return fmt.Errorf("failed creating event stream for cluster %s with applicationId %s: %v", c.Name, appId, err)
+		}
+		c.logger.Infof("event stream %q has been successfully created", streamCRD.Name)
 	}
 
 	return nil


### PR DESCRIPTION
So far, the name of stream CRDs is concatenated from Postgres cluster name + applicationID if the stream. However, this can produce quite long resource names which leads to errors when creating deployments by the stream operator. It sets a label with the CRD name and that is only allowed to be 63 characters long in K8s.

Postgres cluster names can only be 53 characters long. I think, it still makes sense to re-use the cluster name in the stream CRD, but instead of the applicationID we can append a random string (+ EventStreamSourceSlotPrefix) to stay below 64 characters.

The random string makes the search for a particular stream CRD non-deterministic. A list request is required, followed by comparing the applicationID. Labels must be set to filter for the stream CRDs belonging to the Postgres cluster. By doing so, the cached streamApplicationIds of the cluster are not necessary anymore.