### PR TITLE
Add support for PostgreSQL 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ pipelines with no access to Kubernetes API directly, promoting infrastructure as
 
 ### PostgreSQL features
 
-* Supports PostgreSQL 14, starting from 9.6+
+* Supports PostgreSQL 15, starting from 10+
 * Streaming replication cluster via Patroni
 * Point-In-Time-Recovery with
 [pg_basebackup](https://www.postgresql.org/docs/11/app-pgbasebackup.html) /
 [WAL-E](https://github.com/wal-e/wal-e) via [Spilo](https://github.com/zalando/spilo)
 * Preload libraries: [bg_mon](https://github.com/CyberDem0n/bg_mon),
-[pg_stat_statements](https://www.postgresql.org/docs/14/pgstatstatements.html),
+[pg_stat_statements](https://www.postgresql.org/docs/15/pgstatstatements.html),
 [pgextwlist](https://github.com/dimitri/pgextwlist),
 [pg_auth_mon](https://github.com/RafiaSabih/pg_auth_mon)
 * Incl. popular Postgres extensions such as

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ We introduce the major version into the backup path to smoothen the [major versi
 The new operator configuration can set a compatibility flag *enable_spilo_wal_path_compat* to make Spilo look for wal segments in the current path but also old format paths.
 This comes at potential performance costs and should be disabled after a few days.
 
-The newest Spilo image is: `registry.opensource.zalan.do/acid/spilo-14:2.1-p7`
+The newest Spilo image is: `registry.opensource.zalan.do/acid/spilo-cdp-15:2.1-p253`
 
 The last Spilo 12 image is: `registry.opensource.zalan.do/acid/spilo-12:1.6-p5`
 

--- a/charts/postgres-operator-ui/templates/deployment.yaml
+++ b/charts/postgres-operator-ui/templates/deployment.yaml
@@ -76,6 +76,7 @@ spec:
                   "cost_core": 0.0575,
                   "cost_memory": 0.014375,
                   "postgresql_versions": [
+                    "15",
                     "14",
                     "13",
                     "12",

--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -68,7 +68,7 @@ spec:
                   type: string
               docker_image:
                 type: string
-                default: "registry.opensource.zalan.do/acid/spilo-14:2.1-p7"
+                default: "registry.opensource.zalan.do/acid/spilo-cdp-15:2.1-p253"
               enable_crd_registration:
                 type: boolean
                 default: true

--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -170,7 +170,7 @@ spec:
                     default: "9.6"
                   target_major_version:
                     type: string
-                    default: "14"
+                    default: "15"
               kubernetes:
                 type: object
                 properties:

--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -367,13 +367,12 @@ spec:
                   version:
                     type: string
                     enum:
-                      - "9.5"
-                      - "9.6"
                       - "10"
                       - "11"
                       - "12"
                       - "13"
                       - "14"
+                      - "15"
                   parameters:
                     type: object
                     additionalProperties:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -89,9 +89,9 @@ configMajorVersionUpgrade:
   # - acid
 
   # minimal Postgres major version that will not automatically be upgraded
-  minimal_major_version: "9.6"
+  minimal_major_version: "10"
   # target Postgres major version when upgrading clusters automatically
-  target_major_version: "14"
+  target_major_version: "15"
 
 configKubernetes:
   # list of additional capabilities for postgres container

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -38,7 +38,7 @@ configGeneral:
   # etcd connection string for Patroni. Empty uses K8s-native DCS.
   etcd_host: ""
   # Spilo docker image
-  docker_image: registry.opensource.zalan.do/acid/spilo-14:2.1-p7
+  docker_image: registry.opensource.zalan.do/acid/spilo-cdp-15:2.1-p253
 
   # key name for annotation to ignore globally configured instance limits
   # ignore_instance_limits_annotation_key: ""

--- a/docker/logical-backup/Dockerfile
+++ b/docker/logical-backup/Dockerfile
@@ -23,13 +23,12 @@ RUN apt-get update     \
     && curl --silent https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
     && apt-get install --no-install-recommends -y  \
+        postgresql-client-15  \
         postgresql-client-14  \
         postgresql-client-13  \
         postgresql-client-12  \
         postgresql-client-11  \
         postgresql-client-10  \
-        postgresql-client-9.6 \
-        postgresql-client-9.5 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -558,7 +558,7 @@ Those parameters are grouped under the `tls` top-level key.
 ## Change data capture streams
 
 This sections enables change data capture (CDC) streams via Postgres' 
-[logical decoding](https://www.postgresql.org/docs/14/logicaldecoding.html)
+[logical decoding](https://www.postgresql.org/docs/15/logicaldecoding.html)
 feature and `pgoutput` plugin. While the Postgres operator takes responsibility
 for providing the setup to publish change events, it relies on external tools
 to consume them. At Zalando, we are using a workflow based on
@@ -590,7 +590,7 @@ can have the following properties:
   and `payloadColumn`). The CDC operator is following the [outbox pattern](https://debezium.io/blog/2019/02/19/reliable-microservices-data-exchange-with-the-outbox-pattern/).
   The application is responsible for putting events into a (JSON/B or VARCHAR)
   payload column of the outbox table in the structure of the specified target
-  event type. The operator will create a [PUBLICATION](https://www.postgresql.org/docs/14/logical-replication-publication.html)
+  event type. The operator will create a [PUBLICATION](https://www.postgresql.org/docs/15/logical-replication-publication.html)
   in Postgres for all tables specified for one `database` and `applicationId`.
   The CDC operator will consume from it shortly after transactions are
   committed to the outbox table. The `idColumn` will be used in telemetry for

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -251,7 +251,7 @@ CRD-configuration, they are grouped under the `major_version_upgrade` key.
 * **target_major_version**
   The target Postgres major version when upgrading clusters automatically
   which violate the configured allowed `minimal_major_version` when
-  `major_version_upgrade_mode` is set to `"full"`. The default is `"14"`.
+  `major_version_upgrade_mode` is set to `"full"`. The default is `"15"`.
 
 ## Kubernetes resources
 

--- a/docs/user.md
+++ b/docs/user.md
@@ -30,7 +30,7 @@ spec:
   databases:
     foo: zalando
   postgresql:
-    version: "14"
+    version: "15"
 ```
 
 Once you cloned the Postgres Operator [repository](https://github.com/zalando/postgres-operator)
@@ -109,7 +109,7 @@ metadata:
 spec:
   [...]
   postgresql:
-    version: "14"
+    version: "15"
     parameters:
       password_encryption: scram-sha-256
 ```

--- a/manifests/complete-postgres-manifest.yaml
+++ b/manifests/complete-postgres-manifest.yaml
@@ -10,7 +10,7 @@ metadata:
 #    "delete-date": "2020-08-31"  # can only be deleted on that day if "delete-date "key is configured
 #    "delete-clustername": "acid-test-cluster"  # can only be deleted when name matches if "delete-clustername" key is configured
 spec:
-  dockerImage: registry.opensource.zalan.do/acid/spilo-14:2.1-p7
+  dockerImage: registry.opensource.zalan.do/acid/spilo-cdp-15:2.1-p253
   teamId: "acid"
   numberOfInstances: 2
   users:  # Application/Robot users

--- a/manifests/complete-postgres-manifest.yaml
+++ b/manifests/complete-postgres-manifest.yaml
@@ -44,7 +44,7 @@ spec:
           defaultRoles: true
           defaultUsers: false
   postgresql:
-    version: "14"
+    version: "15"
     parameters:  # Expert section
       shared_buffers: "32MB"
       max_connections: "10"

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -34,7 +34,7 @@ data:
   # default_memory_request: 100Mi
   # delete_annotation_date_key: delete-date
   # delete_annotation_name_key: delete-clustername
-  docker_image: registry.opensource.zalan.do/acid/spilo-14:2.1-p7
+  docker_image: registry.opensource.zalan.do/acid/spilo-cdp-15:2.1-p253
   # downscaler_annotations: "deployment-time,downscaler/*"
   # enable_admin_role_for_users: "true"
   # enable_crd_registration: "true"

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -143,7 +143,7 @@ data:
   spilo_privileged: "false"
   storage_resize_mode: "pvc"
   super_username: postgres
-  # target_major_version: "14"
+  # target_major_version: "15"
   # team_admin_role: "admin"
   # team_api_role_configuration: "log_statement:all"
   # teams_api_url: http://fake-teams-api.default.svc.cluster.local

--- a/manifests/minimal-postgres-manifest.yaml
+++ b/manifests/minimal-postgres-manifest.yaml
@@ -17,4 +17,4 @@ spec:
   preparedDatabases:
     bar: {}
   postgresql:
-    version: "14"
+    version: "15"

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -165,10 +165,10 @@ spec:
                       type: string
                   minimal_major_version:
                     type: string
-                    default: "9.6"
+                    default: "10"
                   target_major_version:
                     type: string
-                    default: "14"
+                    default: "15"
               kubernetes:
                 type: object
                 properties:

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -66,7 +66,7 @@ spec:
                   type: string
               docker_image:
                 type: string
-                default: "registry.opensource.zalan.do/acid/spilo-14:2.1-p7"
+                default: "registry.opensource.zalan.do/acid/spilo-cdp-15:2.1-p253"
               enable_crd_registration:
                 type: boolean
                 default: true

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -39,8 +39,8 @@ configuration:
     major_version_upgrade_mode: "off"
     # major_version_upgrade_team_allow_list:
     # - acid
-    minimal_major_version: "9.6"
-    target_major_version: "14"
+    minimal_major_version: "10"
+    target_major_version: "15"
   kubernetes:
     # additional_pod_capabilities:
     # - "SYS_NICE"

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -3,7 +3,7 @@ kind: OperatorConfiguration
 metadata:
   name: postgresql-operator-default-configuration
 configuration:
-  docker_image: registry.opensource.zalan.do/acid/spilo-14:2.1-p7
+  docker_image: registry.opensource.zalan.do/acid/spilo-cdp-15:2.1-p253
   # enable_crd_registration: true
   # crd_categories:
   # - all

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -365,13 +365,12 @@ spec:
                   version:
                     type: string
                     enum:
-                      - "9.5"
-                      - "9.6"
                       - "10"
                       - "11"
                       - "12"
                       - "13"
                       - "14"
+                      - "15"
                   parameters:
                     type: object
                     additionalProperties:

--- a/manifests/standby-manifest.yaml
+++ b/manifests/standby-manifest.yaml
@@ -8,7 +8,7 @@ spec:
     size: 1Gi
   numberOfInstances: 1
   postgresql:
-    version: "14"
+    version: "15"
   # Make this a standby cluster and provide either the s3 bucket path of source cluster or the remote primary host for continuous streaming.
   standby:
     # s3_wal_path: "s3://mybucket/spilo/acid-minimal-cluster/abcd1234-2a4b-4b2a-8c9c-c1234defg567/wal/14/"

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -581,12 +581,6 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 								Type: "string",
 								Enum: []apiextv1.JSON{
 									{
-										Raw: []byte(`"9.5"`),
-									},
-									{
-										Raw: []byte(`"9.6"`),
-									},
-									{
 										Raw: []byte(`"10"`),
 									},
 									{
@@ -600,6 +594,9 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 									},
 									{
 										Raw: []byte(`"14"`),
+									},
+									{
+										Raw: []byte(`"15"`),
 									},
 								},
 							},

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -49,8 +49,8 @@ type PostgresUsersConfiguration struct {
 type MajorVersionUpgradeConfiguration struct {
 	MajorVersionUpgradeMode          string   `json:"major_version_upgrade_mode" default:"off"` // off - no actions, manual - manifest triggers action, full - manifest and minimal version violation trigger upgrade
 	MajorVersionUpgradeTeamAllowList []string `json:"major_version_upgrade_team_allow_list,omitempty"`
-	MinimalMajorVersion              string   `json:"minimal_major_version" default:"9.6"`
-	TargetMajorVersion               string   `json:"target_major_version" default:"14"`
+	MinimalMajorVersion              string   `json:"minimal_major_version" default:"10"`
+	TargetMajorVersion               string   `json:"target_major_version" default:"15"`
 }
 
 // KubernetesMetaConfiguration defines k8s conf required for all Postgres clusters and the operator itself

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -11,13 +11,12 @@ import (
 
 // VersionMap Map of version numbers
 var VersionMap = map[string]int{
-	"9.5": 90500,
-	"9.6": 90600,
 	"10":  100000,
 	"11":  110000,
 	"12":  120000,
 	"13":  130000,
 	"14":  140000,
+	"15":  150000,
 }
 
 // IsBiggerPostgresVersion Compare two Postgres version numbers
@@ -36,7 +35,7 @@ func (c *Cluster) GetDesiredMajorVersionAsInt() int {
 func (c *Cluster) GetDesiredMajorVersion() string {
 
 	if c.Config.OpConfig.MajorVersionUpgradeMode == "full" {
-		// e.g. current is 9.6, minimal is 11 allowing 11 to 14 clusters, everything below is upgraded
+		// e.g. current is 10, minimal is 11 allowing 11 to 15 clusters, everything below is upgraded
 		if IsBiggerPostgresVersion(c.Spec.PgVersion, c.Config.OpConfig.MinimalMajorVersion) {
 			c.logger.Infof("overwriting configured major version %s to %s", c.Spec.PgVersion, c.Config.OpConfig.TargetMajorVersion)
 			return c.Config.OpConfig.TargetMajorVersion

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -62,8 +62,8 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	// major version upgrade config
 	result.MajorVersionUpgradeMode = util.Coalesce(fromCRD.MajorVersionUpgrade.MajorVersionUpgradeMode, "off")
 	result.MajorVersionUpgradeTeamAllowList = fromCRD.MajorVersionUpgrade.MajorVersionUpgradeTeamAllowList
-	result.MinimalMajorVersion = util.Coalesce(fromCRD.MajorVersionUpgrade.MinimalMajorVersion, "9.6")
-	result.TargetMajorVersion = util.Coalesce(fromCRD.MajorVersionUpgrade.TargetMajorVersion, "14")
+	result.MinimalMajorVersion = util.Coalesce(fromCRD.MajorVersionUpgrade.MinimalMajorVersion, "10")
+	result.TargetMajorVersion = util.Coalesce(fromCRD.MajorVersionUpgrade.TargetMajorVersion, "15")
 
 	// kubernetes config
 	result.CustomPodAnnotations = fromCRD.Kubernetes.CustomPodAnnotations

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -39,7 +39,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.EnableTeamIdClusternamePrefix = fromCRD.EnableTeamIdClusternamePrefix
 	result.EtcdHost = fromCRD.EtcdHost
 	result.KubernetesUseConfigMaps = fromCRD.KubernetesUseConfigMaps
-	result.DockerImage = util.Coalesce(fromCRD.DockerImage, "registry.opensource.zalan.do/acid/spilo-14:2.1-p7")
+	result.DockerImage = util.Coalesce(fromCRD.DockerImage, "registry.opensource.zalan.do/acid/spilo-cdp-15:2.1-p253")
 	result.Workers = util.CoalesceUInt32(fromCRD.Workers, 8)
 	result.MinInstances = fromCRD.MinInstances
 	result.MaxInstances = fromCRD.MaxInstances

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -165,7 +165,7 @@ type Config struct {
 	WatchedNamespace        string            `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
 	KubernetesUseConfigMaps bool              `name:"kubernetes_use_configmaps" default:"false"`
 	EtcdHost                string            `name:"etcd_host" default:""` // special values: the empty string "" means Patroni will use K8s as a DCS
-	DockerImage             string            `name:"docker_image" default:"registry.opensource.zalan.do/acid/spilo-14:2.1-p7"`
+	DockerImage             string            `name:"docker_image" default:"registry.opensource.zalan.do/acid/spilo-cdp-15:2.1-p253"`
 	SidecarImages           map[string]string `name:"sidecar_docker_images"` // deprecated in favour of SidecarContainers
 	SidecarContainers       []v1.Container    `name:"sidecars"`
 	PodServiceAccountName   string            `name:"pod_service_account_name" default:"postgres-pod"`

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -230,8 +230,8 @@ type Config struct {
 	EnableTeamIdClusternamePrefix          bool              `name:"enable_team_id_clustername_prefix" default:"false"`
 	MajorVersionUpgradeMode                string            `name:"major_version_upgrade_mode" default:"off"`
 	MajorVersionUpgradeTeamAllowList       []string          `name:"major_version_upgrade_team_allow_list" default:""`
-	MinimalMajorVersion                    string            `name:"minimal_major_version" default:"9.6"`
-	TargetMajorVersion                     string            `name:"target_major_version" default:"14"`
+	MinimalMajorVersion                    string            `name:"minimal_major_version" default:"10"`
+	TargetMajorVersion                     string            `name:"target_major_version" default:"15"`
 	PatroniAPICheckInterval                time.Duration     `name:"patroni_api_check_interval" default:"1s"`
 	PatroniAPICheckTimeout                 time.Duration     `name:"patroni_api_check_timeout" default:"5s"`
 	EnablePatroniFailsafeMode              *bool             `name:"enable_patroni_failsafe_mode" default:"false"`

--- a/ui/manifests/deployment.yaml
+++ b/ui/manifests/deployment.yaml
@@ -72,6 +72,7 @@ spec:
                   "limit_iops": 16000,
                   "limit_throughput": 1000,
                   "postgresql_versions": [
+                    "15",
                     "14",
                     "13",
                     "12",

--- a/ui/operator_ui/main.py
+++ b/ui/operator_ui/main.py
@@ -321,7 +321,7 @@ DEFAULT_UI_CONFIG = {
     'users_visible': True,
     'databases_visible': True,
     'resources_visible': RESOURCES_VISIBLE,
-    'postgresql_versions': ['11','12','13','14'],
+    'postgresql_versions': ['11','12','13','14','15'],
     'dns_format_string': '{0}.{1}',
     'pgui_link': '',
     'static_network_whitelist': {},

--- a/ui/operator_ui/spiloutils.py
+++ b/ui/operator_ui/spiloutils.py
@@ -308,7 +308,7 @@ def read_versions(
         if uid == 'wal' or defaulting(lambda: UUID(uid))
     ]
 
-BACKUP_VERSION_PREFIXES = ['', '9.5/', '9.6/', '10/', '11/', '12/', '13/', '14/']
+BACKUP_VERSION_PREFIXES = ['', '10/', '11/', '12/', '13/', '14/', '15/']
 
 def read_basebackups(
     pg_cluster,

--- a/ui/run_local.sh
+++ b/ui/run_local.sh
@@ -25,6 +25,7 @@ default_operator_ui_config='{
   "cost_core": 0.0575,
   "cost_memory": 0.014375,
   "postgresql_versions": [
+    "15",
     "14",
     "13",
     "12",


### PR DESCRIPTION
Hi,

This PR adds support for PostgreSQL 15 and drops support for 9.5 and 9.6.
As for Spilo image, I've set `spilo-cdp-15:2.1-p253` for now, but I'm willing to change it to non-CDP one once it gets released.

Also, I chose not to touch under `./e2e` as there's currently no spilo image for it as far as I know.