### PR TITLE
Add Support for Custom TLS Certificates in Connection Pooler

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -603,7 +603,7 @@ spec:
                     default: "pooler"
                   connection_pooler_image:
                     type: string
-                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-24"
+                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-26"
                   connection_pooler_max_db_connections:
                     type: integer
                     default: 60

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -396,7 +396,7 @@ configConnectionPooler:
   # db user for pooler to use
   connection_pooler_user: "pooler"
   # docker image
-  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-24"
+  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-26"
   # max db connections the pooler should hold
   connection_pooler_max_db_connections: 60
   # default pooling mode

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -17,7 +17,7 @@ data:
   # connection_pooler_default_cpu_request: "500m"
   # connection_pooler_default_memory_limit: 100Mi
   # connection_pooler_default_memory_request: 100Mi
-  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-24"
+  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-26"
   # connection_pooler_max_db_connections: 60
   # connection_pooler_mode: "transaction"
   # connection_pooler_number_of_instances: 2

--- a/manifests/minimal-fake-pooler-deployment.yaml
+++ b/manifests/minimal-fake-pooler-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: postgres-operator
       containers:
       - name: postgres-operator
-        image: registry.opensource.zalan.do/acid/pgbouncer:master-24
+        image: registry.opensource.zalan.do/acid/pgbouncer:master-26
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -601,7 +601,7 @@ spec:
                     default: "pooler"
                   connection_pooler_image:
                     type: string
-                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-24"
+                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-26"
                   connection_pooler_max_db_connections:
                     type: integer
                     default: 60

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -192,7 +192,7 @@ configuration:
     connection_pooler_default_cpu_request: "500m"
     connection_pooler_default_memory_limit: 100Mi
     connection_pooler_default_memory_request: 100Mi
-    connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-24"
+    connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-26"
     # connection_pooler_max_db_connections: 60
     connection_pooler_mode: "transaction"
     connection_pooler_number_of_instances: 2


### PR DESCRIPTION
This pull request is heavily inspired by [this PR](https://github.com/zalando/postgres-operator/pull/1232) by @borchero and try to solve [#1230](https://github.com/zalando/postgres-operator/issues/1230)  But do not include the additional annotations on the pgBouncer deployment.

The entrypoint.sh in pgbouncer docker image also need to be updated to use the certificates when present like so:
``` bash
if [ -z "${CONNECTION_POOLER_CLIENT_TLS_CRT}" ]; then
    openssl req -nodes -new -x509 -subj /CN=spilo.dummy.org \
        -keyout /etc/ssl/certs/pgbouncer.key \
        -out /etc/ssl/certs/pgbouncer.crt
else
    ln ${CONNECTION_POOLER_CLIENT_TLS_CRT} /etc/ssl/certs/pgbouncer.crt
    ln ${CONNECTION_POOLER_CLIENT_TLS_KEY} /etc/ssl/certs/pgbouncer.key
fi
```

however the dockerfile of pgbouncer included in the operator does not seems to be public, is it accessible somewhere ? 

If this solution is accepted, certificate renewal will need to be handled either on the operator side with a restart of the pooler deployment or directly on pgbouncer if the reload command is sufficient.  