### PR TITLE
fix: add missing json tags to the MaintenanceWindow type struct.

### DIFF
--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -115,10 +115,10 @@ type PreparedSchema struct {
 
 // MaintenanceWindow describes the time window when the operator is allowed to do maintenance on a cluster.
 type MaintenanceWindow struct {
-	Everyday  bool
-	Weekday   time.Weekday
-	StartTime metav1.Time // Start time
-	EndTime   metav1.Time // End time
+	Everyday  bool         `json:"everyday,omitempty"`
+	Weekday   time.Weekday `json:"weekday,omitempty"`
+	StartTime metav1.Time  `json:"startTime,omitempty"`
+	EndTime   metav1.Time  `json:"endTime,omitempty"`
 }
 
 // Volume describes a single volume in the manifest.


### PR DESCRIPTION
If you import the zalando postgresql v1 api with kubebuilder, it complains about the missing tags.

```
❯ make manifests
test -s /.../bin/controller-gen && /.../bin/controller-gen --version | grep -q v0.10.0 || \
        GOBIN=/.../bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.10.0
/.../bin/controller-gen rbac:roleName=manager-role crd:allowDangerousTypes=true webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/.../go/pkg/mod/github.com/zalando/postgres-operator@v1.8.2/pkg/apis/acid.zalan.do/v1/postgresql_type.go:116:2: encountered struct field "Everyday" without JSON tag in type "MaintenanceWindow"
/.../go/pkg/mod/github.com/zalando/postgres-operator@v1.8.2/pkg/apis/acid.zalan.do/v1/postgresql_type.go:117:2: encountered struct field "Weekday" without JSON tag in type "MaintenanceWindow"
/.../go/pkg/mod/github.com/zalando/postgres-operator@v1.8.2/pkg/apis/acid.zalan.do/v1/postgresql_type.go:118:2: encountered struct field "StartTime" without JSON tag in type "MaintenanceWindow"
/.../go/pkg/mod/github.com/zalando/postgres-operator@v1.8.2/pkg/apis/acid.zalan.do/v1/postgresql_type.go:119:2: encountered struct field "EndTime" without JSON tag in type "MaintenanceWindow"
Error: not all generators ran successfully
run `controller-gen rbac:roleName=manager-role crd:allowDangerousTypes=true webhook paths=./... output:crd:artifacts:config=config/crd/bases -w` to see all available markers, or `controller-gen rbac:roleName=manager-role crd:allowDangerousTypes=true webhook paths=./... output:crd:artifacts:config=config/crd/bases -h` for usage
make: *** [manifests] Error 1
```