### PR TITLE
stream resource name must be lower case

### DIFF
--- a/pkg/cluster/streams.go
+++ b/pkg/cluster/streams.go
@@ -192,7 +192,7 @@ func (c *Cluster) generateFabricEventStream(appId string) *zalandov1.FabricEvent
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			// max length for cluster name is 58 so we can only add 5 more characters / numbers
-			Name:        fmt.Sprintf("%s-%s", c.Name, util.RandomPassword(5)),
+			Name:        fmt.Sprintf("%s-%s", c.Name, strings.ToLower(util.RandomPassword(5))),
 			Namespace:   c.Namespace,
 			Labels:      c.labelsSet(true),
 			Annotations: c.AnnotationsToPropagate(c.annotationsSet(nil)),


### PR DESCRIPTION
Bugfix for feature merged with #2137. To avoid the following error:

```
level=error msg="could not sync cluster: could not sync streams: failed creating event streams with applicationId test-app: FabricEventStream.zalando.org \"acid-minimal-cluster-oKwZV\" is invalid: metadata.name: Invalid value: \"acid-minimal-cluster-oKwZV\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')" cluster-name=default/acid-minimal-cluster pkg=controller worker=0
```