### PR TITLE
fix syncing of stream CRDs

### DIFF
--- a/pkg/cluster/streams.go
+++ b/pkg/cluster/streams.go
@@ -383,7 +383,7 @@ func (c *Cluster) createOrUpdateStreams() error {
 				desiredStreams := c.generateFabricEventStream(appId)
 				if match, reason := sameStreams(stream.Spec.EventStreams, desiredStreams.Spec.EventStreams); !match {
 					c.logger.Debugf("updating event streams: %s", reason)
-					desiredStreams.ObjectMeta.ResourceVersion = stream.ObjectMeta.ResourceVersion
+					desiredStreams.ObjectMeta = stream.ObjectMeta
 					err = c.updateStreams(desiredStreams)
 					if err != nil {
 						return fmt.Errorf("failed updating event stream %s: %v", stream.Name, err)

--- a/pkg/cluster/streams_test.go
+++ b/pkg/cluster/streams_test.go
@@ -360,19 +360,14 @@ func TestUpdateFabricEventStream(t *testing.T) {
 	assert.NoError(t, err)
 
 	// change specs of streams and patch CRD
-	pg.Spec.Streams = []acidv1.Stream{
-		{
-			ApplicationId: appId,
-			Database:      dbName,
-			Tables: map[string]acidv1.StreamTable{
-				"data.bar": acidv1.StreamTable{
-					EventType:     "stream-type-c",
-					IdColumn:      k8sutil.StringToPointer("b_id"),
-					PayloadColumn: k8sutil.StringToPointer("b_payload"),
-				},
-			},
-			BatchSize: k8sutil.UInt32ToPointer(uint32(250)),
-		},
+	for i, stream := range pg.Spec.Streams {
+		if stream.ApplicationId == appId {
+			streamTable := stream.Tables["data.bar"]
+			streamTable.EventType = "stream-type-c"
+			stream.Tables["data.bar"] = streamTable
+			stream.BatchSize = k8sutil.UInt32ToPointer(uint32(250))
+			pg.Spec.Streams[i] = stream
+		}
 	}
 
 	patchData, err := specPatch(pg.Spec)


### PR DESCRIPTION
With #2137 merged, stream CRD names are no longer known beforehand and, therefore, can only be listed using a label selector. The check if a stream CRD does exist and can be updated now happens within a loop over all fetched CRDs. If found that loop is exited - however NOT the loop over application Ids which handles creation of stream CRDs.

This means, stream CRDs are now created on each sync which succeeds because the name now has a random suffix. An extra bool flag is needed per application Id iteration to avoid that.

Unit tests were extended to cover this case.