### PR TITLE
refactor podAffinity generation

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -278,12 +278,12 @@ spec:
                   pdb_name_format:
                     type: string
                     default: "postgres-{cluster}-pdb"
-                  pod_antiaffinity_topology_key:
-                    type: string
-                    default: "kubernetes.io/hostname"
                   pod_antiaffinity_preferred_during_scheduling:
                     type: boolean
                     default: false
+                  pod_antiaffinity_topology_key:
+                    type: string
+                    default: "kubernetes.io/hostname"
                   pod_environment_configmap:
                     type: string
                   pod_environment_secret:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -165,10 +165,10 @@ configKubernetes:
 
   # defines the template for PDB (Pod Disruption Budget) names
   pdb_name_format: "postgres-{cluster}-pdb"
+  # switches pod anti affinity type to `preferredDuringSchedulingIgnoredDuringExecution`
+  pod_antiaffinity_preferred_during_scheduling: false
   # override topology key for pod anti affinity
   pod_antiaffinity_topology_key: "kubernetes.io/hostname"
-  # switches pod anti affinity type to `preferredDuringSchedulingIgnoredDuringExecution`
-  # pod_antiaffinity_preferred_during_scheduling: true
   # namespaced name of the ConfigMap with environment variables to populate on every pod
   # pod_environment_configmap: "default/my-custom-config"
   # name of the Secret (in cluster namespace) with environment variables to populate on every pod

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -109,6 +109,7 @@ data:
   # password_rotation_interval: "90"
   # password_rotation_user_retention: "180"
   pdb_name_format: "postgres-{cluster}-pdb"
+  # pod_antiaffinity_preferred_during_scheduling: "false"
   # pod_antiaffinity_topology_key: "kubernetes.io/hostname"
   pod_deletion_wait_timeout: 10m
   # pod_environment_configmap: "default/my-custom-config"

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -276,6 +276,9 @@ spec:
                   pdb_name_format:
                     type: string
                     default: "postgres-{cluster}-pdb"
+                  pod_antiaffinity_preferred_during_scheduling:
+                    type: boolean
+                    default: false
                   pod_antiaffinity_topology_key:
                     type: string
                     default: "kubernetes.io/hostname"

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -84,6 +84,7 @@ configuration:
     # node_readiness_label_merge: "OR"
     oauth_token_secret_name: postgresql-operator
     pdb_name_format: "postgres-{cluster}-pdb"
+    pod_antiaffinity_preferred_during_scheduling: false
     pod_antiaffinity_topology_key: "kubernetes.io/hostname"
     # pod_environment_configmap: "default/my-custom-config"
     # pod_environment_secret: "my-custom-secret"
@@ -95,6 +96,7 @@ configuration:
     # pod_service_account_role_binding_definition: ""
     pod_terminate_grace_period: 5m
     secret_name_template: "{username}.{cluster}.credentials.{tprkind}.{tprgroup}"
+    share_pgsocket_with_sidecars: false
     spilo_allow_privilege_escalation: true
     # spilo_runasuser: 101
     # spilo_runasgroup: 103

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1372,11 +1372,11 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 							"pdb_name_format": {
 								Type: "string",
 							},
-							"pod_antiaffinity_topology_key": {
-								Type: "string",
-							},
 							"pod_antiaffinity_preferred_during_scheduling": {
 								Type: "boolean",
+							},
+							"pod_antiaffinity_topology_key": {
+								Type: "string",
 							},
 							"pod_environment_configmap": {
 								Type: "string",

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -97,10 +97,10 @@ type KubernetesMetaConfiguration struct {
 	PodPriorityClassName                     string              `json:"pod_priority_class_name,omitempty"`
 	MasterPodMoveTimeout                     Duration            `json:"master_pod_move_timeout,omitempty"`
 	EnablePodAntiAffinity                    bool                `json:"enable_pod_antiaffinity,omitempty"`
-	PodAntiAffinityTopologyKey               string              `json:"pod_antiaffinity_topology_key,omitempty"`
 	PodAntiAffinityPreferredDuringScheduling bool                `json:"pod_antiaffinity_preferred_during_scheduling,omitempty"`
+	PodAntiAffinityTopologyKey               string              `json:"pod_antiaffinity_topology_key,omitempty"`
 	PodManagementPolicy                      string              `json:"pod_management_policy,omitempty"`
-  EnableReadinessProbe                     bool                `json:"enable_readiness_probe,omitempty"`
+	EnableReadinessProbe                     bool                `json:"enable_readiness_probe,omitempty"`
 	EnableCrossNamespaceSecret               bool                `json:"enable_cross_namespace_secret,omitempty"`
 }
 

--- a/pkg/cluster/connection_pooler.go
+++ b/pkg/cluster/connection_pooler.go
@@ -354,11 +354,12 @@ func (c *Cluster) generateConnectionPoolerPodTemplate(role PostgresRole) (
 	nodeAffinity := c.nodeAffinity(c.OpConfig.NodeReadinessLabel, spec.NodeAffinity)
 	if c.OpConfig.EnablePodAntiAffinity {
 		labelsSet := labels.Set(c.connectionPoolerLabels(role, false).MatchLabels)
-		podTemplate.Spec.Affinity = generatePodAffinity(
+		podTemplate.Spec.Affinity = podAffinity(
 			labelsSet,
 			c.OpConfig.PodAntiAffinityTopologyKey,
 			nodeAffinity,
 			c.OpConfig.PodAntiAffinityPreferredDuringScheduling,
+			true,
 		)
 	} else if nodeAffinity != nil {
 		podTemplate.Spec.Affinity = nodeAffinity

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -202,8 +202,8 @@ type Config struct {
 	CustomServiceAnnotations                 map[string]string `name:"custom_service_annotations"`
 	CustomPodAnnotations                     map[string]string `name:"custom_pod_annotations"`
 	EnablePodAntiAffinity                    bool              `name:"enable_pod_antiaffinity" default:"false"`
-	PodAntiAffinityTopologyKey               string            `name:"pod_antiaffinity_topology_key" default:"kubernetes.io/hostname"`
 	PodAntiAffinityPreferredDuringScheduling bool              `name:"pod_antiaffinity_preferred_during_scheduling" default:"false"`
+	PodAntiAffinityTopologyKey               string            `name:"pod_antiaffinity_topology_key" default:"kubernetes.io/hostname"`
 	StorageResizeMode                        string            `name:"storage_resize_mode" default:"pvc"`
 	EnableLoadBalancer                       *bool             `name:"enable_load_balancer"` // deprecated and kept for backward compatibility
 	ExternalTrafficPolicy                    string            `name:"external_traffic_policy" default:"Cluster"`


### PR DESCRIPTION
Follow up to #2048

- List new option `pod_antiaffinity_preferred_during_scheduling` in all example manifests
- Swap with `pod_antiaffinity_topology_key` for alphabetical sorting
- Have one function to generate PodAffinity and PodAntiAffinity
- Unify unit tests about different pod anti affinity settings