### PR TITLE
spec.env can override clone and standby variables

### DIFF
--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -631,9 +631,9 @@ order (e.g. a variable defined in 4. overrides a variable with the same name
 in 5.):
 
 1. Assigned by the operator
-2. Clone section (with WAL settings from operator config when `s3_wal_path` is empty)
-3. Standby section
-4. `env` section in cluster manifest
+2. `env` section in cluster manifest
+3. Clone section (with WAL settings from operator config when `s3_wal_path` is empty)
+4. Standby section
 5. Pod environment secret via operator config
 6. Pod environment config map via operator config
 7. WAL and logical backup settings from operator config

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -962,17 +962,17 @@ func (c *Cluster) generateSpiloPodEnvVars(
 		envVars = append(envVars, v1.EnvVar{Name: "KUBERNETES_USE_CONFIGMAPS", Value: "true"})
 	}
 
+	// fetch cluster-specific variables that will override all subsequent global variables
+	if len(spec.Env) > 0 {
+		envVars = appendEnvVars(envVars, spec.Env...)
+	}
+
 	if spec.Clone != nil && spec.Clone.ClusterName != "" {
 		envVars = append(envVars, c.generateCloneEnvironment(spec.Clone)...)
 	}
 
 	if spec.StandbyCluster != nil {
 		envVars = append(envVars, c.generateStandbyEnvironment(spec.StandbyCluster)...)
-	}
-
-	// fetch cluster-specific variables that will override all subsequent global variables
-	if len(spec.Env) > 0 {
-		envVars = appendEnvVars(envVars, spec.Env...)
 	}
 
 	// fetch variables from custom environment Secret


### PR DESCRIPTION
Follow up to #1976 but only changes the order for spec.Env overriding variables that would be set when clone or standby section exist. The later still takes precedence over values from global pod_environment_secret/configmap.