### PR TITLE
Ineffectual assignment of the envVars for connection pooler

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -18,7 +18,8 @@ trap "cleanup" EXIT SIGINT
 bash "${CODEGEN_PKG}/generate-groups.sh" all \
   "${OPERATOR_PACKAGE_ROOT}/pkg/generated" "${OPERATOR_PACKAGE_ROOT}/pkg/apis" \
   "acid.zalan.do:v1 zalando.org:v1" \
-  --go-header-file "${SCRIPT_ROOT}"/hack/custom-boilerplate.go.txt
+  --go-header-file "${SCRIPT_ROOT}"/hack/custom-boilerplate.go.txt \
+  -o ./
 
 cp -r "${OPERATOR_PACKAGE_ROOT}"/pkg/* "${TARGET_CODE_DIR}"
 

--- a/pkg/cluster/connection_pooler.go
+++ b/pkg/cluster/connection_pooler.go
@@ -324,7 +324,6 @@ func (c *Cluster) generateConnectionPoolerPodTemplate(role PostgresRole) (
 				Protocol:      v1.ProtocolTCP,
 			},
 		},
-		Env: envVars,
 		ReadinessProbe: &v1.Probe{
 			ProbeHandler: v1.ProbeHandler{
 				TCPSocket: &v1.TCPSocketAction{
@@ -341,7 +340,7 @@ func (c *Cluster) generateConnectionPoolerPodTemplate(role PostgresRole) (
 	//  1. Add environment variables to tell pgBouncer where to find the TLS certificates
 	//  2. Reference the secret in a volume
 	//  3. Mount the volume to the container at /tls
-	poolerVolumes := []v1.Volume{}
+	var poolerVolumes []v1.Volume
 	if spec.TLS != nil && spec.TLS.SecretName != "" {
 		// Env vars
 		crtFile := spec.TLS.CertificateFile
@@ -383,6 +382,7 @@ func (c *Cluster) generateConnectionPoolerPodTemplate(role PostgresRole) (
 		}}
 	}
 
+	poolerContainer.Env = envVars
 	tolerationsSpec := tolerations(&spec.Tolerations, c.OpConfig.PodToleration)
 
 	podTemplate := &v1.PodTemplateSpec{


### PR DESCRIPTION
Ineffectual assignment of the envVars for connection pooler if `spec.TLS` is specified.
@FxKu please have a look at this bug and try to fit it into the 1.9 if possible
Test case can be added, but this case should be covered by the linter