### PR TITLE
better backwards compatibility with old DNS name format for LBs

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -433,8 +433,16 @@ spec:
                     default: "Cluster"
                   master_dns_name_format:
                     type: string
+                    description: deprecated
+                    default: "{cluster}.{team}.{hostedzone}"
+                  master_lb_dns_name_format:
+                    type: string
                     default: "{cluster}.{namespace}.{hostedzone}"
                   replica_dns_name_format:
+                    type: string
+                    description: deprecated
+                    default: "{cluster}-repl.{team}.{hostedzone}"
+                  replica_lb_dns_name_format:
                     type: string
                     default: "{cluster}-repl.{namespace}.{hostedzone}"
               aws_or_gcp:

--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -433,18 +433,16 @@ spec:
                     default: "Cluster"
                   master_dns_name_format:
                     type: string
-                    description: deprecated
-                    default: "{cluster}.{team}.{hostedzone}"
-                  master_lb_dns_name_format:
-                    type: string
                     default: "{cluster}.{namespace}.{hostedzone}"
+                  master_old_dns_name_format:
+                    type: string
+                    default: "{cluster}.{team}.{hostedzone}"
                   replica_dns_name_format:
                     type: string
-                    description: deprecated
-                    default: "{cluster}-repl.{team}.{hostedzone}"
-                  replica_lb_dns_name_format:
-                    type: string
                     default: "{cluster}-repl.{namespace}.{hostedzone}"
+                  replica_old_dns_name_format:
+                    type: string
+                    default: "{cluster}-repl.{team}.{hostedzone}"
               aws_or_gcp:
                 type: object
                 properties:

--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -434,13 +434,13 @@ spec:
                   master_dns_name_format:
                     type: string
                     default: "{cluster}.{namespace}.{hostedzone}"
-                  master_old_dns_name_format:
+                  master_legacy_dns_name_format:
                     type: string
                     default: "{cluster}.{team}.{hostedzone}"
                   replica_dns_name_format:
                     type: string
                     default: "{cluster}-repl.{namespace}.{hostedzone}"
-                  replica_old_dns_name_format:
+                  replica_legacy_dns_name_format:
                     type: string
                     default: "{cluster}-repl.{team}.{hostedzone}"
               aws_or_gcp:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -275,10 +275,14 @@ configLoadBalancer:
   enable_replica_pooler_load_balancer: false
   # define external traffic policy for the load balancer
   external_traffic_policy: "Cluster"
+  # deprecated DNS template for master load balancer using team name
+  master_dns_name_format: "{cluster}.{team}.{hostedzone}"
   # defines the DNS name string template for the master load balancer cluster
-  master_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
+  master_lb_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
+  # deprecated DNS template for master load balancer using team name
+  replica_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
   # defines the DNS name string template for the replica load balancer cluster
-  replica_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
+  replica_lb_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
 
 # options to aid debugging of the operator itself
 configDebug:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -278,11 +278,11 @@ configLoadBalancer:
   # defines the DNS name string template for the master load balancer cluster
   master_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
   # deprecated DNS template for master load balancer using team name
-  master_old_dns_name_format: "{cluster}.{team}.{hostedzone}"
+  master_legacy_dns_name_format: "{cluster}.{team}.{hostedzone}"
   # defines the DNS name string template for the replica load balancer cluster
   replica_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
-    # deprecated DNS template for replica load balancer using team name
-  replica_old_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
+  # deprecated DNS template for replica load balancer using team name
+  replica_legacy_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
 
 # options to aid debugging of the operator itself
 configDebug:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -275,14 +275,14 @@ configLoadBalancer:
   enable_replica_pooler_load_balancer: false
   # define external traffic policy for the load balancer
   external_traffic_policy: "Cluster"
-  # deprecated DNS template for master load balancer using team name
-  master_dns_name_format: "{cluster}.{team}.{hostedzone}"
   # defines the DNS name string template for the master load balancer cluster
-  master_lb_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
+  master_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
   # deprecated DNS template for master load balancer using team name
-  replica_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
+  master_old_dns_name_format: "{cluster}.{team}.{hostedzone}"
   # defines the DNS name string template for the replica load balancer cluster
-  replica_lb_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
+  replica_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
+    # deprecated DNS template for replica load balancer using team name
+  replica_old_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
 
 # options to aid debugging of the operator itself
 configDebug:

--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -780,7 +780,7 @@ If load balancing is enabled two default annotations will be applied to its
 services:
 
 - `external-dns.alpha.kubernetes.io/hostname` with the value defined by the
-  operator configs `master_lb_dns_name_format` and `replica_lb_dns_name_format`.
+  operator configs `master_dns_name_format` and `replica_dns_name_format`.
   This value can't be overwritten. If any changing in its value is needed, it
   MUST be done changing the DNS format operator config parameters; and
 - `service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout` with

--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -780,7 +780,7 @@ If load balancing is enabled two default annotations will be applied to its
 services:
 
 - `external-dns.alpha.kubernetes.io/hostname` with the value defined by the
-  operator configs `master_dns_name_format` and `replica_dns_name_format`.
+  operator configs `master_lb_dns_name_format` and `replica_lb_dns_name_format`.
   This value can't be overwritten. If any changing in its value is needed, it
   MUST be done changing the DNS format operator config parameters; and
 - `service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout` with

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -627,22 +627,33 @@ In the CRD-based configuration they are grouped under the `load_balancer` key.
   the cluster. Can be overridden by individual cluster settings. The default
   is `false`.
 
-* **external_traffic_policy** defines external traffic policy for load
+* **external_traffic_policy**
+  defines external traffic policy for load
   balancers. Allowed values are `Cluster` (default) and `Local`.
 
-* **master_dns_name_format** defines the DNS name string template for the
-  master load balancer cluster.  The default is
-  `{cluster}.{namespace}.{hostedzone}`, where `{cluster}` is replaced by the cluster
-  name, `{namespace}` is replaced with the namespace and `{hostedzone}` is replaced
-  with the hosted zone (the value of the `db_hosted_zone` parameter). No other
-  placeholders are allowed.
+* **master_lb_dns_name_format**
+  defines the DNS name string template for the master load balancer cluster. 
+  The default is `{cluster}.{namespace}.{hostedzone}`, where `{cluster}` is
+  replaced by the cluster name, `{namespace}` is replaced with the namespace
+  and `{hostedzone}` is replaced with the hosted zone (the value of the
+  `db_hosted_zone` parameter). No other placeholders are allowed!
 
-* **replica_dns_name_format** defines the DNS name string template for the
-  replica load balancer cluster.  The default is
-  `{cluster}-repl.{namespace}.{hostedzone}`, where `{cluster}` is replaced by the
-  cluster name, `{namespace}` is replaced with the namespace and `{hostedzone}` is
-  replaced with the hosted zone (the value of the `db_hosted_zone` parameter).
-  No other placeholders are allowed.
+* **master_dns_name_format**
+  *deprecated* option that uses the old default `{cluster}.{team}.{hostedzone}`.
+  If cluster name starts with `teamId` then a second DNS entry will be created
+  using the template defined here to provide backwards compatibility.
+
+* **replica_lb_dns_name_format**
+  defines the DNS name string template for the replica load balancer cluster.
+  The default is `{cluster}-repl.{namespace}.{hostedzone}`, where `{cluster}`
+  is replaced by the cluster name, `{namespace}` is replaced with the
+  namespace and `{hostedzone}` is replaced with the hosted zone (the value of
+  the `db_hosted_zone` parameter). No other placeholders are allowed!
+
+* **replica_dns_name_format**
+  *deprecated* option that uses the old default `{cluster}-repl.{team}.{hostedzone}`.
+  If cluster name starts with `teamId` then a second DNS entry will be created
+  using the template defined here to provide backwards compatibility.
 
 ## AWS or GCP interaction
 

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -641,12 +641,14 @@ In the CRD-based configuration they are grouped under the `load_balancer` key.
   If the cluster name starts with the `teamId` it will also be part of the
   DNS, aynway. No other placeholders are allowed!
 
-* **master_old_dns_name_format**
-  option that uses the old *deprecated* default `{cluster}.{team}.{hostedzone}`.
-  If cluster name starts with `teamId` then a second DNS entry will be created
-  using the template defined here to provide backwards compatibility. The
-  `teamId` prefix will be extracted from the clustername, because it follows
-  later in the DNS string.
+* **master_legacy_dns_name_format**
+  *deprecated* default master DNS template `{cluster}.{team}.{hostedzone}` as
+  of pre `v1.9.0`. If cluster name starts with `teamId` then a second DNS
+  entry will be created using the template defined here to provide backwards
+  compatibility. The `teamId` prefix will be extracted from the clustername
+  because it follows later in the DNS string. When using a customized
+  `master_dns_name_format` make sure to define the legacy DNS format when
+  switching to v1.9.0.
 
 * **replica_dns_name_format**
   defines the DNS name string template for the replica load balancer cluster.
@@ -658,12 +660,14 @@ In the CRD-based configuration they are grouped under the `load_balancer` key.
   If the cluster name starts with the `teamId` it will also be part of the
   DNS, aynway. No other placeholders are allowed!
 
-* **replica_old_dns_name_format**
-  option that uses the old *deprecated* default `{cluster}-repl.{team}.{hostedzone}`.
-  If cluster name starts with `teamId` then a second DNS entry will be created
-  using the template defined here to provide backwards compatibility. The
-  `teamId` prefix will be extracted from the clustername, because it follows
-  later in the DNS string.
+* **replica_legacy_dns_name_format**
+  *deprecated* default master DNS template `{cluster}-repl.{team}.{hostedzone}`
+  as of pre `v1.9.0`. If cluster name starts with `teamId` then a second DNS
+  entry will be created using the template defined here to provide backwards
+  compatibility. The `teamId` prefix will be extracted from the clustername
+  because it follows later in the DNS string. When using a customized
+  `master_dns_name_format` make sure to define the legacy DNS format when
+  switching to v1.9.0.
 
 ## AWS or GCP interaction
 

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -636,24 +636,34 @@ In the CRD-based configuration they are grouped under the `load_balancer` key.
   The default is `{cluster}.{namespace}.{hostedzone}`, where `{cluster}` is
   replaced by the cluster name, `{namespace}` is replaced with the namespace
   and `{hostedzone}` is replaced with the hosted zone (the value of the
-  `db_hosted_zone` parameter). No other placeholders are allowed!
+  `db_hosted_zone` parameter). The `{team}` placeholder can still be used,
+  although it is not recommened because the team of a cluster can change.
+  If the cluster name starts with the `teamId` it will also be part of the
+  DNS, aynway. No other placeholders are allowed!
 
 * **master_old_dns_name_format**
   option that uses the old *deprecated* default `{cluster}.{team}.{hostedzone}`.
   If cluster name starts with `teamId` then a second DNS entry will be created
-  using the template defined here to provide backwards compatibility.
+  using the template defined here to provide backwards compatibility. The
+  `teamId` prefix will be extracted from the clustername, because it follows
+  later in the DNS string.
 
 * **replica_dns_name_format**
   defines the DNS name string template for the replica load balancer cluster.
   The default is `{cluster}-repl.{namespace}.{hostedzone}`, where `{cluster}`
   is replaced by the cluster name, `{namespace}` is replaced with the
   namespace and `{hostedzone}` is replaced with the hosted zone (the value of
-  the `db_hosted_zone` parameter). No other placeholders are allowed!
+  the `db_hosted_zone` parameter). The `{team}` placeholder can still be used,
+  although it is not recommened because the team of a cluster can change.
+  If the cluster name starts with the `teamId` it will also be part of the
+  DNS, aynway. No other placeholders are allowed!
 
 * **replica_old_dns_name_format**
   option that uses the old *deprecated* default `{cluster}-repl.{team}.{hostedzone}`.
   If cluster name starts with `teamId` then a second DNS entry will be created
-  using the template defined here to provide backwards compatibility.
+  using the template defined here to provide backwards compatibility. The
+  `teamId` prefix will be extracted from the clustername, because it follows
+  later in the DNS string.
 
 ## AWS or GCP interaction
 

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -631,27 +631,27 @@ In the CRD-based configuration they are grouped under the `load_balancer` key.
   defines external traffic policy for load
   balancers. Allowed values are `Cluster` (default) and `Local`.
 
-* **master_lb_dns_name_format**
+* **master_dns_name_format**
   defines the DNS name string template for the master load balancer cluster. 
   The default is `{cluster}.{namespace}.{hostedzone}`, where `{cluster}` is
   replaced by the cluster name, `{namespace}` is replaced with the namespace
   and `{hostedzone}` is replaced with the hosted zone (the value of the
   `db_hosted_zone` parameter). No other placeholders are allowed!
 
-* **master_dns_name_format**
-  *deprecated* option that uses the old default `{cluster}.{team}.{hostedzone}`.
+* **master_old_dns_name_format**
+  option that uses the old *deprecated* default `{cluster}.{team}.{hostedzone}`.
   If cluster name starts with `teamId` then a second DNS entry will be created
   using the template defined here to provide backwards compatibility.
 
-* **replica_lb_dns_name_format**
+* **replica_dns_name_format**
   defines the DNS name string template for the replica load balancer cluster.
   The default is `{cluster}-repl.{namespace}.{hostedzone}`, where `{cluster}`
   is replaced by the cluster name, `{namespace}` is replaced with the
   namespace and `{hostedzone}` is replaced with the hosted zone (the value of
   the `db_hosted_zone` parameter). No other placeholders are allowed!
 
-* **replica_dns_name_format**
-  *deprecated* option that uses the old default `{cluster}-repl.{team}.{hostedzone}`.
+* **replica_old_dns_name_format**
+  option that uses the old *deprecated* default `{cluster}-repl.{team}.{hostedzone}`.
   If cluster name starts with `teamId` then a second DNS entry will be created
   using the template defined here to provide backwards compatibility.
 

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -97,7 +97,7 @@ data:
   major_version_upgrade_mode: "manual"
   # major_version_upgrade_team_allow_list: ""
   master_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
-  # master_old_dns_name_format: "{cluster}.{team}.{hostedzone}"
+  # master_legacy_dns_name_format: "{cluster}.{team}.{hostedzone}"
   # master_pod_move_timeout: 20m
   # max_instances: "-1"
   # min_instances: "-1"
@@ -136,7 +136,7 @@ data:
   ready_wait_timeout: 30s
   repair_period: 5m
   replica_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
-  # replica_old_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
+  # replica_legacy_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
   replication_username: standby
   resource_check_interval: 3s
   resource_check_timeout: 10m

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -96,7 +96,8 @@ data:
   logical_backup_schedule: "30 00 * * *"
   major_version_upgrade_mode: "manual"
   # major_version_upgrade_team_allow_list: ""
-  master_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
+  # master_dns_name_format: "{cluster}.{team}.{hostedzone}"
+  master_lb_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
   # master_pod_move_timeout: 20m
   # max_instances: "-1"
   # min_instances: "-1"
@@ -134,7 +135,8 @@ data:
   ready_wait_interval: 3s
   ready_wait_timeout: 30s
   repair_period: 5m
-  replica_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
+  # replica_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
+  replica_lb_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
   replication_username: standby
   resource_check_interval: 3s
   resource_check_timeout: 10m

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -96,8 +96,8 @@ data:
   logical_backup_schedule: "30 00 * * *"
   major_version_upgrade_mode: "manual"
   # major_version_upgrade_team_allow_list: ""
-  # master_dns_name_format: "{cluster}.{team}.{hostedzone}"
-  master_lb_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
+  master_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
+  # master_old_dns_name_format: "{cluster}.{team}.{hostedzone}"
   # master_pod_move_timeout: 20m
   # max_instances: "-1"
   # min_instances: "-1"
@@ -135,8 +135,8 @@ data:
   ready_wait_interval: 3s
   ready_wait_timeout: 30s
   repair_period: 5m
-  # replica_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
-  replica_lb_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
+  replica_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
+  # replica_old_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
   replication_username: standby
   resource_check_interval: 3s
   resource_check_timeout: 10m

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -431,8 +431,16 @@ spec:
                     default: "Cluster"
                   master_dns_name_format:
                     type: string
+                    description: deprecated
+                    default: "{cluster}.{team}.{hostedzone}"
+                  master_lb_dns_name_format:
+                    type: string
                     default: "{cluster}.{namespace}.{hostedzone}"
                   replica_dns_name_format:
+                    type: string
+                    description: deprecated
+                    default: "{cluster}-repl.{team}.{hostedzone}"
+                  replica_lb_dns_name_format:
                     type: string
                     default: "{cluster}-repl.{namespace}.{hostedzone}"
               aws_or_gcp:

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -432,13 +432,13 @@ spec:
                   master_dns_name_format:
                     type: string
                     default: "{cluster}.{namespace}.{hostedzone}"
-                  master_old_dns_name_format:
+                  master_legacy_dns_name_format:
                     type: string
                     default: "{cluster}.{team}.{hostedzone}"
                   replica_dns_name_format:
                     type: string
                     default: "{cluster}-repl.{namespace}.{hostedzone}"
-                  replica_old_dns_name_format:
+                  replica_legacy_dns_name_format:
                     type: string
                     default: "{cluster}-repl.{team}.{hostedzone}"
               aws_or_gcp:

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -431,18 +431,16 @@ spec:
                     default: "Cluster"
                   master_dns_name_format:
                     type: string
-                    description: deprecated
-                    default: "{cluster}.{team}.{hostedzone}"
-                  master_lb_dns_name_format:
-                    type: string
                     default: "{cluster}.{namespace}.{hostedzone}"
+                  master_old_dns_name_format:
+                    type: string
+                    default: "{cluster}.{team}.{hostedzone}"
                   replica_dns_name_format:
                     type: string
-                    description: deprecated
-                    default: "{cluster}-repl.{team}.{hostedzone}"
-                  replica_lb_dns_name_format:
-                    type: string
                     default: "{cluster}-repl.{namespace}.{hostedzone}"
+                  replica_old_dns_name_format:
+                    type: string
+                    default: "{cluster}-repl.{team}.{hostedzone}"
               aws_or_gcp:
                 type: object
                 properties:

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -136,8 +136,10 @@ configuration:
     enable_replica_load_balancer: false
     enable_replica_pooler_load_balancer: false
     external_traffic_policy: "Cluster"
-    master_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
-    replica_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
+    # master_dns_name_format: "{cluster}.{team}.{hostedzone}"
+    master_lb_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
+    # replica_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
+    replica_lb_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
   aws_or_gcp:
     # additional_secret_mount: "some-secret-name"
     # additional_secret_mount_path: "/some/dir"

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -136,10 +136,10 @@ configuration:
     enable_replica_load_balancer: false
     enable_replica_pooler_load_balancer: false
     external_traffic_policy: "Cluster"
-    # master_dns_name_format: "{cluster}.{team}.{hostedzone}"
-    master_lb_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
-    # replica_dns_name_format: "{cluster}-repl.{team}.{hostedzone}"
-    replica_lb_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
+    master_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
+    # master_old_dns_name_format: "{cluster}.{team}.{hostedzone}"
+    replica_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
+    # replica_dns_old_name_format: "{cluster}-repl.{team}.{hostedzone}"
   aws_or_gcp:
     # additional_secret_mount: "some-secret-name"
     # additional_secret_mount_path: "/some/dir"

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -137,7 +137,7 @@ configuration:
     enable_replica_pooler_load_balancer: false
     external_traffic_policy: "Cluster"
     master_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
-    # master_old_dns_name_format: "{cluster}.{team}.{hostedzone}"
+    # master_legacy_dns_name_format: "{cluster}.{team}.{hostedzone}"
     replica_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"
     # replica_dns_old_name_format: "{cluster}-repl.{team}.{hostedzone}"
   aws_or_gcp:

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1594,13 +1594,13 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 							"master_dns_name_format": {
 								Type: "string",
 							},
-							"master_old_dns_name_format": {
+							"master_legacy_dns_name_format": {
 								Type: "string",
 							},
 							"replica_dns_name_format": {
 								Type: "string",
 							},
-							"replica_old_dns_name_format": {
+							"replica_legacy_dns_name_format": {
 								Type: "string",
 							},
 						},

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1592,9 +1592,17 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 								},
 							},
 							"master_dns_name_format": {
+								Type:        "string",
+								Description: "deprecated",
+							},
+							"master_lb_dns_name_format": {
 								Type: "string",
 							},
 							"replica_dns_name_format": {
+								Type:        "string",
+								Description: "deprecated",
+							},
+							"replica_lb_dns_name_format": {
 								Type: "string",
 							},
 						},

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1592,17 +1592,15 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 								},
 							},
 							"master_dns_name_format": {
-								Type:        "string",
-								Description: "deprecated",
+								Type: "string",
 							},
-							"master_lb_dns_name_format": {
+							"master_old_dns_name_format": {
 								Type: "string",
 							},
 							"replica_dns_name_format": {
-								Type:        "string",
-								Description: "deprecated",
+								Type: "string",
 							},
-							"replica_lb_dns_name_format": {
+							"replica_old_dns_name_format": {
 								Type: "string",
 							},
 						},

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -137,7 +137,9 @@ type LoadBalancerConfiguration struct {
 	EnableReplicaPoolerLoadBalancer bool                  `json:"enable_replica_pooler_load_balancer,omitempty"`
 	CustomServiceAnnotations        map[string]string     `json:"custom_service_annotations,omitempty"`
 	MasterDNSNameFormat             config.StringTemplate `json:"master_dns_name_format,omitempty"`
+	MasterLBDNSNameFormat           config.StringTemplate `json:"master_lb_dns_name_format,omitempty"`
 	ReplicaDNSNameFormat            config.StringTemplate `json:"replica_dns_name_format,omitempty"`
+	ReplicaLBDNSNameFormat          config.StringTemplate `json:"replica_lb_dns_name_format,omitempty"`
 	ExternalTrafficPolicy           string                `json:"external_traffic_policy" default:"Cluster"`
 }
 

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -137,9 +137,9 @@ type LoadBalancerConfiguration struct {
 	EnableReplicaPoolerLoadBalancer bool                  `json:"enable_replica_pooler_load_balancer,omitempty"`
 	CustomServiceAnnotations        map[string]string     `json:"custom_service_annotations,omitempty"`
 	MasterDNSNameFormat             config.StringTemplate `json:"master_dns_name_format,omitempty"`
-	MasterOldDNSNameFormat          config.StringTemplate `json:"master_old_dns_name_format,omitempty"`
+	MasterLegacyDNSNameFormat       config.StringTemplate `json:"master_legacy_dns_name_format,omitempty"`
 	ReplicaDNSNameFormat            config.StringTemplate `json:"replica_dns_name_format,omitempty"`
-	ReplicaOldDNSNameFormat         config.StringTemplate `json:"replica_old_dns_name_format,omitempty"`
+	ReplicaLegacyDNSNameFormat      config.StringTemplate `json:"replica_legacy_dns_name_format,omitempty"`
 	ExternalTrafficPolicy           string                `json:"external_traffic_policy" default:"Cluster"`
 }
 

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -137,9 +137,9 @@ type LoadBalancerConfiguration struct {
 	EnableReplicaPoolerLoadBalancer bool                  `json:"enable_replica_pooler_load_balancer,omitempty"`
 	CustomServiceAnnotations        map[string]string     `json:"custom_service_annotations,omitempty"`
 	MasterDNSNameFormat             config.StringTemplate `json:"master_dns_name_format,omitempty"`
-	MasterLBDNSNameFormat           config.StringTemplate `json:"master_lb_dns_name_format,omitempty"`
+	MasterOldDNSNameFormat          config.StringTemplate `json:"master_old_dns_name_format,omitempty"`
 	ReplicaDNSNameFormat            config.StringTemplate `json:"replica_dns_name_format,omitempty"`
-	ReplicaLBDNSNameFormat          config.StringTemplate `json:"replica_lb_dns_name_format,omitempty"`
+	ReplicaOldDNSNameFormat         config.StringTemplate `json:"replica_old_dns_name_format,omitempty"`
 	ExternalTrafficPolicy           string                `json:"external_traffic_policy" default:"Cluster"`
 }
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -549,7 +549,7 @@ func TestServiceAnnotations(t *testing.T) {
 			operatorAnnotations:          make(map[string]string),
 			serviceAnnotations:           make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.test.db.example.com,test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg.test.db.example.com,test-stg.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -571,7 +571,7 @@ func TestServiceAnnotations(t *testing.T) {
 			operatorAnnotations:        make(map[string]string),
 			serviceAnnotations:         make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.test.db.example.com,test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg.test.db.example.com,test-stg.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -583,7 +583,7 @@ func TestServiceAnnotations(t *testing.T) {
 			operatorAnnotations:        make(map[string]string),
 			serviceAnnotations:         map[string]string{"foo": "bar"},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.test.db.example.com,test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg.test.db.example.com,test-stg.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 				"foo": "bar",
 			},
@@ -606,7 +606,7 @@ func TestServiceAnnotations(t *testing.T) {
 			operatorAnnotations:        map[string]string{"foo": "bar"},
 			serviceAnnotations:         make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.test.db.example.com,test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg.test.db.example.com,test-stg.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 				"foo": "bar",
 			},
@@ -621,7 +621,7 @@ func TestServiceAnnotations(t *testing.T) {
 			},
 			serviceAnnotations: make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.test.db.example.com,test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg.test.db.example.com,test-stg.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 		},
@@ -635,7 +635,7 @@ func TestServiceAnnotations(t *testing.T) {
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.test.db.example.com,test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg.test.db.example.com,test-stg.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 		},
@@ -649,7 +649,7 @@ func TestServiceAnnotations(t *testing.T) {
 				"external-dns.alpha.kubernetes.io/hostname": "wrong.external-dns-name.example.com",
 			},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.test.db.example.com,test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg.test.db.example.com,test-stg.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -661,7 +661,7 @@ func TestServiceAnnotations(t *testing.T) {
 			serviceAnnotations:         make(map[string]string),
 			operatorAnnotations:        make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.test.db.example.com,test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg.test.db.example.com,test-stg.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -679,7 +679,7 @@ func TestServiceAnnotations(t *testing.T) {
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "2000",
 			},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test.test.db.example.com,test.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg.test.db.example.com,test-stg.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type":         "ip",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "2000",
 			},
@@ -704,7 +704,7 @@ func TestServiceAnnotations(t *testing.T) {
 			operatorAnnotations:           make(map[string]string),
 			serviceAnnotations:            make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.test.db.example.com,test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg-repl.test.db.example.com,test-stg-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -726,7 +726,7 @@ func TestServiceAnnotations(t *testing.T) {
 			operatorAnnotations:         make(map[string]string),
 			serviceAnnotations:          make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.test.db.example.com,test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg-repl.test.db.example.com,test-stg-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -738,7 +738,7 @@ func TestServiceAnnotations(t *testing.T) {
 			operatorAnnotations:         make(map[string]string),
 			serviceAnnotations:          map[string]string{"foo": "bar"},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.test.db.example.com,test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg-repl.test.db.example.com,test-stg-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 				"foo": "bar",
 			},
@@ -761,7 +761,7 @@ func TestServiceAnnotations(t *testing.T) {
 			operatorAnnotations:         map[string]string{"foo": "bar"},
 			serviceAnnotations:          make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.test.db.example.com,test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg-repl.test.db.example.com,test-stg-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 				"foo": "bar",
 			},
@@ -776,7 +776,7 @@ func TestServiceAnnotations(t *testing.T) {
 			},
 			serviceAnnotations: make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.test.db.example.com,test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg-repl.test.db.example.com,test-stg-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 		},
@@ -790,7 +790,7 @@ func TestServiceAnnotations(t *testing.T) {
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.test.db.example.com,test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg-repl.test.db.example.com,test-stg-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "1800",
 			},
 		},
@@ -804,7 +804,7 @@ func TestServiceAnnotations(t *testing.T) {
 				"external-dns.alpha.kubernetes.io/hostname": "wrong.external-dns-name.example.com",
 			},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.test.db.example.com,test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg-repl.test.db.example.com,test-stg-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -816,7 +816,7 @@ func TestServiceAnnotations(t *testing.T) {
 			serviceAnnotations:          make(map[string]string),
 			operatorAnnotations:         make(map[string]string),
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.test.db.example.com,test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg-repl.test.db.example.com,test-stg-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
 			},
 		},
@@ -834,7 +834,7 @@ func TestServiceAnnotations(t *testing.T) {
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "2000",
 			},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-repl.test.db.example.com,test-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname":                            "acid-test-stg-repl.test.db.example.com,test-stg-repl.acid.db.example.com",
 				"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type":         "ip",
 				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "2000",
 			},
@@ -867,8 +867,10 @@ func TestServiceAnnotations(t *testing.T) {
 			cl.OpConfig.CustomServiceAnnotations = tt.operatorAnnotations
 			cl.OpConfig.EnableMasterLoadBalancer = tt.enableMasterLoadBalancerOC
 			cl.OpConfig.EnableReplicaLoadBalancer = tt.enableReplicaLoadBalancerOC
-			cl.OpConfig.MasterDNSNameFormat = "{cluster}.{namespace}.{hostedzone}"
-			cl.OpConfig.ReplicaDNSNameFormat = "{cluster}-repl.{namespace}.{hostedzone}"
+			cl.OpConfig.MasterDNSNameFormat = "{cluster}-stg.{team}.{hostedzone}"
+			cl.OpConfig.MasterLBDNSNameFormat = "{cluster}-stg.{namespace}.{hostedzone}"
+			cl.OpConfig.ReplicaDNSNameFormat = "{cluster}-stg-repl.{team}.{hostedzone}"
+			cl.OpConfig.ReplicaLBDNSNameFormat = "{cluster}-stg-repl.{namespace}.{hostedzone}"
 			cl.OpConfig.DbHostedZone = "db.example.com"
 
 			cl.Postgresql.Spec.ClusterName = ""

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -867,10 +867,10 @@ func TestServiceAnnotations(t *testing.T) {
 			cl.OpConfig.CustomServiceAnnotations = tt.operatorAnnotations
 			cl.OpConfig.EnableMasterLoadBalancer = tt.enableMasterLoadBalancerOC
 			cl.OpConfig.EnableReplicaLoadBalancer = tt.enableReplicaLoadBalancerOC
-			cl.OpConfig.MasterDNSNameFormat = "{cluster}-stg.{team}.{hostedzone}"
-			cl.OpConfig.MasterLBDNSNameFormat = "{cluster}-stg.{namespace}.{hostedzone}"
-			cl.OpConfig.ReplicaDNSNameFormat = "{cluster}-stg-repl.{team}.{hostedzone}"
-			cl.OpConfig.ReplicaLBDNSNameFormat = "{cluster}-stg-repl.{namespace}.{hostedzone}"
+			cl.OpConfig.MasterDNSNameFormat = "{cluster}-stg.{namespace}.{hostedzone}"
+			cl.OpConfig.MasterOldDNSNameFormat = "{cluster}-stg.{team}.{hostedzone}"
+			cl.OpConfig.ReplicaDNSNameFormat = "{cluster}-stg-repl.{namespace}.{hostedzone}"
+			cl.OpConfig.ReplicaOldDNSNameFormat = "{cluster}-stg-repl.{team}.{hostedzone}"
 			cl.OpConfig.DbHostedZone = "db.example.com"
 
 			cl.Postgresql.Spec.ClusterName = ""

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -868,9 +868,9 @@ func TestServiceAnnotations(t *testing.T) {
 			cl.OpConfig.EnableMasterLoadBalancer = tt.enableMasterLoadBalancerOC
 			cl.OpConfig.EnableReplicaLoadBalancer = tt.enableReplicaLoadBalancerOC
 			cl.OpConfig.MasterDNSNameFormat = "{cluster}-stg.{namespace}.{hostedzone}"
-			cl.OpConfig.MasterOldDNSNameFormat = "{cluster}-stg.{team}.{hostedzone}"
+			cl.OpConfig.MasterLegacyDNSNameFormat = "{cluster}-stg.{team}.{hostedzone}"
 			cl.OpConfig.ReplicaDNSNameFormat = "{cluster}-stg-repl.{namespace}.{hostedzone}"
-			cl.OpConfig.ReplicaOldDNSNameFormat = "{cluster}-stg-repl.{team}.{hostedzone}"
+			cl.OpConfig.ReplicaLegacyDNSNameFormat = "{cluster}-stg-repl.{team}.{hostedzone}"
 			cl.OpConfig.DbHostedZone = "db.example.com"
 
 			cl.Postgresql.Spec.ClusterName = ""

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -545,14 +545,14 @@ func (c *Cluster) replicaDNSName() string {
 }
 
 func (c *Cluster) oldMasterDNSName(clusterName string) string {
-	return strings.ToLower(c.OpConfig.MasterOldDNSNameFormat.Format(
+	return strings.ToLower(c.OpConfig.MasterLegacyDNSNameFormat.Format(
 		"cluster", clusterName,
 		"team", c.teamName(),
 		"hostedzone", c.OpConfig.DbHostedZone))
 }
 
 func (c *Cluster) oldReplicaDNSName(clusterName string) string {
-	return strings.ToLower(c.OpConfig.ReplicaOldDNSNameFormat.Format(
+	return strings.ToLower(c.OpConfig.ReplicaLegacyDNSNameFormat.Format(
 		"cluster", clusterName,
 		"team", c.teamName(),
 		"hostedzone", c.OpConfig.DbHostedZone))

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -529,28 +529,30 @@ func (c *Cluster) dnsName(role PostgresRole) string {
 }
 
 func (c *Cluster) masterDNSName() string {
-	return strings.ToLower(c.OpConfig.MasterLBDNSNameFormat.Format(
+	return strings.ToLower(c.OpConfig.MasterDNSNameFormat.Format(
 		"cluster", c.Name,
 		"namespace", c.Namespace,
+		"team", c.teamName(),
 		"hostedzone", c.OpConfig.DbHostedZone))
 }
 
 func (c *Cluster) replicaDNSName() string {
-	return strings.ToLower(c.OpConfig.ReplicaLBDNSNameFormat.Format(
+	return strings.ToLower(c.OpConfig.ReplicaDNSNameFormat.Format(
 		"cluster", c.Name,
 		"namespace", c.Namespace,
+		"team", c.teamName(),
 		"hostedzone", c.OpConfig.DbHostedZone))
 }
 
 func (c *Cluster) oldMasterDNSName(clusterName string) string {
-	return strings.ToLower(c.OpConfig.MasterDNSNameFormat.Format(
+	return strings.ToLower(c.OpConfig.MasterOldDNSNameFormat.Format(
 		"cluster", clusterName,
 		"team", c.teamName(),
 		"hostedzone", c.OpConfig.DbHostedZone))
 }
 
 func (c *Cluster) oldReplicaDNSName(clusterName string) string {
-	return strings.ToLower(c.OpConfig.ReplicaDNSNameFormat.Format(
+	return strings.ToLower(c.OpConfig.ReplicaOldDNSNameFormat.Format(
 		"cluster", clusterName,
 		"team", c.teamName(),
 		"hostedzone", c.OpConfig.DbHostedZone))

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -154,7 +154,9 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.EnableReplicaPoolerLoadBalancer = fromCRD.LoadBalancer.EnableReplicaPoolerLoadBalancer
 	result.CustomServiceAnnotations = fromCRD.LoadBalancer.CustomServiceAnnotations
 	result.MasterDNSNameFormat = fromCRD.LoadBalancer.MasterDNSNameFormat
+	result.MasterLBDNSNameFormat = fromCRD.LoadBalancer.MasterLBDNSNameFormat
 	result.ReplicaDNSNameFormat = fromCRD.LoadBalancer.ReplicaDNSNameFormat
+	result.ReplicaLBDNSNameFormat = fromCRD.LoadBalancer.ReplicaLBDNSNameFormat
 	result.ExternalTrafficPolicy = util.Coalesce(fromCRD.LoadBalancer.ExternalTrafficPolicy, "Cluster")
 
 	// AWS or GCP config

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -154,9 +154,9 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.EnableReplicaPoolerLoadBalancer = fromCRD.LoadBalancer.EnableReplicaPoolerLoadBalancer
 	result.CustomServiceAnnotations = fromCRD.LoadBalancer.CustomServiceAnnotations
 	result.MasterDNSNameFormat = fromCRD.LoadBalancer.MasterDNSNameFormat
-	result.MasterLBDNSNameFormat = fromCRD.LoadBalancer.MasterLBDNSNameFormat
+	result.MasterOldDNSNameFormat = fromCRD.LoadBalancer.MasterOldDNSNameFormat
 	result.ReplicaDNSNameFormat = fromCRD.LoadBalancer.ReplicaDNSNameFormat
-	result.ReplicaLBDNSNameFormat = fromCRD.LoadBalancer.ReplicaLBDNSNameFormat
+	result.ReplicaOldDNSNameFormat = fromCRD.LoadBalancer.ReplicaOldDNSNameFormat
 	result.ExternalTrafficPolicy = util.Coalesce(fromCRD.LoadBalancer.ExternalTrafficPolicy, "Cluster")
 
 	// AWS or GCP config

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -154,9 +154,9 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.EnableReplicaPoolerLoadBalancer = fromCRD.LoadBalancer.EnableReplicaPoolerLoadBalancer
 	result.CustomServiceAnnotations = fromCRD.LoadBalancer.CustomServiceAnnotations
 	result.MasterDNSNameFormat = fromCRD.LoadBalancer.MasterDNSNameFormat
-	result.MasterOldDNSNameFormat = fromCRD.LoadBalancer.MasterOldDNSNameFormat
+	result.MasterLegacyDNSNameFormat = fromCRD.LoadBalancer.MasterLegacyDNSNameFormat
 	result.ReplicaDNSNameFormat = fromCRD.LoadBalancer.ReplicaDNSNameFormat
-	result.ReplicaOldDNSNameFormat = fromCRD.LoadBalancer.ReplicaOldDNSNameFormat
+	result.ReplicaLegacyDNSNameFormat = fromCRD.LoadBalancer.ReplicaLegacyDNSNameFormat
 	result.ExternalTrafficPolicy = util.Coalesce(fromCRD.LoadBalancer.ExternalTrafficPolicy, "Cluster")
 
 	// AWS or GCP config

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -214,8 +214,10 @@ type Config struct {
 	StorageResizeMode                        string            `name:"storage_resize_mode" default:"pvc"`
 	EnableLoadBalancer                       *bool             `name:"enable_load_balancer"` // deprecated and kept for backward compatibility
 	ExternalTrafficPolicy                    string            `name:"external_traffic_policy" default:"Cluster"`
-	MasterDNSNameFormat                      StringTemplate    `name:"master_dns_name_format" default:"{cluster}.{namespace}.{hostedzone}"`
-	ReplicaDNSNameFormat                     StringTemplate    `name:"replica_dns_name_format" default:"{cluster}-repl.{namespace}.{hostedzone}"`
+	MasterDNSNameFormat                      StringTemplate    `name:"master_dns_name_format" default:"{cluster}.{team}.{hostedzone}"`
+	MasterLBDNSNameFormat                    StringTemplate    `name:"master_lb_dns_name_format" default:"{cluster}.{namespace}.{hostedzone}"`
+	ReplicaDNSNameFormat                     StringTemplate    `name:"replica_dns_name_format" default:"{cluster}-repl.{team}.{hostedzone}"`
+	ReplicaLBDNSNameFormat                   StringTemplate    `name:"replica_lb_dns_name_format" default:"{cluster}-repl.{namespace}.{hostedzone}"`
 	PDBNameFormat                            StringTemplate    `name:"pdb_name_format" default:"postgres-{cluster}-pdb"`
 	EnablePodDisruptionBudget                *bool             `name:"enable_pod_disruption_budget" default:"true"`
 	EnableInitContainers                     *bool             `name:"enable_init_containers" default:"true"`

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -214,10 +214,10 @@ type Config struct {
 	StorageResizeMode                        string            `name:"storage_resize_mode" default:"pvc"`
 	EnableLoadBalancer                       *bool             `name:"enable_load_balancer"` // deprecated and kept for backward compatibility
 	ExternalTrafficPolicy                    string            `name:"external_traffic_policy" default:"Cluster"`
-	MasterDNSNameFormat                      StringTemplate    `name:"master_dns_name_format" default:"{cluster}.{team}.{hostedzone}"`
-	MasterLBDNSNameFormat                    StringTemplate    `name:"master_lb_dns_name_format" default:"{cluster}.{namespace}.{hostedzone}"`
-	ReplicaDNSNameFormat                     StringTemplate    `name:"replica_dns_name_format" default:"{cluster}-repl.{team}.{hostedzone}"`
-	ReplicaLBDNSNameFormat                   StringTemplate    `name:"replica_lb_dns_name_format" default:"{cluster}-repl.{namespace}.{hostedzone}"`
+	MasterDNSNameFormat                      StringTemplate    `name:"master_dns_name_format" default:"{cluster}.{namespace}.{hostedzone}"`
+	MasterOldDNSNameFormat                   StringTemplate    `name:"master_old_dns_name_format" default:"{cluster}.{team}.{hostedzone}"`
+	ReplicaDNSNameFormat                     StringTemplate    `name:"replica_dns_name_format" default:"{cluster}-repl.{namespace}.{hostedzone}"`
+	ReplicaOldDNSNameFormat                  StringTemplate    `name:"replica_old_dns_name_format" default:"{cluster}-repl.{team}.{hostedzone}"`
 	PDBNameFormat                            StringTemplate    `name:"pdb_name_format" default:"postgres-{cluster}-pdb"`
 	EnablePodDisruptionBudget                *bool             `name:"enable_pod_disruption_budget" default:"true"`
 	EnableInitContainers                     *bool             `name:"enable_init_containers" default:"true"`

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -215,9 +215,9 @@ type Config struct {
 	EnableLoadBalancer                       *bool             `name:"enable_load_balancer"` // deprecated and kept for backward compatibility
 	ExternalTrafficPolicy                    string            `name:"external_traffic_policy" default:"Cluster"`
 	MasterDNSNameFormat                      StringTemplate    `name:"master_dns_name_format" default:"{cluster}.{namespace}.{hostedzone}"`
-	MasterOldDNSNameFormat                   StringTemplate    `name:"master_old_dns_name_format" default:"{cluster}.{team}.{hostedzone}"`
+	MasterLegacyDNSNameFormat                StringTemplate    `name:"master_legacy_dns_name_format" default:"{cluster}.{team}.{hostedzone}"`
 	ReplicaDNSNameFormat                     StringTemplate    `name:"replica_dns_name_format" default:"{cluster}-repl.{namespace}.{hostedzone}"`
-	ReplicaOldDNSNameFormat                  StringTemplate    `name:"replica_old_dns_name_format" default:"{cluster}-repl.{team}.{hostedzone}"`
+	ReplicaLegacyDNSNameFormat               StringTemplate    `name:"replica_legacy_dns_name_format" default:"{cluster}-repl.{team}.{hostedzone}"`
 	PDBNameFormat                            StringTemplate    `name:"pdb_name_format" default:"postgres-{cluster}-pdb"`
 	EnablePodDisruptionBudget                *bool             `name:"enable_pod_disruption_budget" default:"true"`
 	EnableInitContainers                     *bool             `name:"enable_init_containers" default:"true"`


### PR DESCRIPTION
With #2011 we changed the default DNS name format template used when LoadBalancers are enabled. For backwards compatibility we are already appending a second DNS entry when the cluster name still starts with the team Id (mandatory before #2001), because we do not want to break existing connections.

For the old format we only assumed the default template value `"{cluster}.{team}.{hostedzone}"`. There's no option to specify what you have used before. If you have customized the template, all apps would need to be redeployed using the new DNS format. To avoid such a hassle this PR suggest to make the old format configurable with `master|replica_old_dns_name_format` options.

The unit test in cluster_test_go has be updated to also use a template different from the default value.