### PR TITLE
do not rotate secrets for standby clusters

### DIFF
--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -759,7 +759,7 @@ func (c *Cluster) updateSecret(
 
 	// globally enabled rotation is only allowed for manifest and bootstrapped roles
 	allowedRoleTypes := []spec.RoleOrigin{spec.RoleOriginManifest, spec.RoleOriginBootstrap}
-	rotationAllowed := !pwdUser.IsDbOwner && util.SliceContains(allowedRoleTypes, pwdUser.Origin)
+	rotationAllowed := !pwdUser.IsDbOwner && util.SliceContains(allowedRoleTypes, pwdUser.Origin) && c.Spec.StandbyCluster == nil
 
 	if (c.OpConfig.EnablePasswordRotation && rotationAllowed) || rotationEnabledInManifest {
 		updateSecretMsg, err = c.rotatePasswordInSecret(secret, secretUsername, pwdUser.Origin, currentTime, retentionUsers)


### PR DESCRIPTION
Password rotation should not be allowed for standby clusters because rotation users cannot be added anyway.
This is particularly helpful if the source clusters has no rotation enabled (e.g. is not maintained by Postgres Operator).
However, if the secrets are updated for the source cluster, then credentials must be synced manually - like during the initial setup of a standby.