### PR TITLE
add pooler suffix to DNS annotation of pooler LoadBalancer service

### DIFF
--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -810,6 +810,9 @@ Load balancer services can also be enabled for the [connection pooler](user.md#c
 pods with manifest flags `enableMasterPoolerLoadBalancer` and/or
 `enableReplicaPoolerLoadBalancer` or in the operator configuration with
 `enable_master_pooler_load_balancer` and/or `enable_replica_pooler_load_balancer`.
+For the `external-dns.alpha.kubernetes.io/hostname` annotation the `-pooler`
+suffix will be appended to the cluster name used in the template which is
+defined in `master|replica_dns_name_format`.
 
 ## Running periodic 'autorepair' scans of K8s objects
 

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -670,6 +670,20 @@ class EndToEndTestCase(unittest.TestCase):
                              'LoadBalancer',
                              "Expected LoadBalancer service type for replica pooler pod, found {}")
 
+        master_annotations = {
+            "external-dns.alpha.kubernetes.io/hostname": "acid-minimal-cluster-pooler.default.db.example.com",
+            "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
+        }
+        self.eventuallyTrue(lambda: k8s.check_service_annotations(
+            master_pooler_label+","+pooler_label, master_annotations), "Wrong annotations")
+
+        replica_annotations = {
+            "external-dns.alpha.kubernetes.io/hostname": "acid-minimal-cluster-pooler-repl.default.db.example.com",
+            "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",
+        }
+        self.eventuallyTrue(lambda: k8s.check_service_annotations(
+            replica_pooler_label+","+pooler_label, replica_annotations), "Wrong annotations")
+
         # Turn off only master connection pooler
         k8s.api.custom_objects_api.patch_namespaced_custom_object(
             'acid.zalan.do', 'v1', 'default',

--- a/manifests/complete-postgres-manifest.yaml
+++ b/manifests/complete-postgres-manifest.yaml
@@ -28,6 +28,8 @@ spec:
   enableReplicaLoadBalancer: false
   enableConnectionPooler: false # enable/disable connection pooler deployment
   enableReplicaConnectionPooler: false # set to enable connectionPooler for replica service
+  enableMasterPoolerLoadBalancer: false
+  enableReplicaPoolerLoadBalancer: false
   allowedSourceRanges:  # load balancers' source ranges for both master and replica services
   - 127.0.0.1/32
   databases:

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -509,9 +509,9 @@ func (c *Cluster) dnsName(role PostgresRole) string {
 	var dnsString, oldDnsString string
 
 	if role == Master {
-		dnsString = c.masterDNSName()
+		dnsString = c.masterDNSName(c.Name)
 	} else {
-		dnsString = c.replicaDNSName()
+		dnsString = c.replicaDNSName(c.Name)
 	}
 
 	// if cluster name starts with teamID we might need to provide backwards compatibility
@@ -528,17 +528,17 @@ func (c *Cluster) dnsName(role PostgresRole) string {
 	return dnsString
 }
 
-func (c *Cluster) masterDNSName() string {
+func (c *Cluster) masterDNSName(clusterName string) string {
 	return strings.ToLower(c.OpConfig.MasterDNSNameFormat.Format(
-		"cluster", c.Name,
+		"cluster", clusterName,
 		"namespace", c.Namespace,
 		"team", c.teamName(),
 		"hostedzone", c.OpConfig.DbHostedZone))
 }
 
-func (c *Cluster) replicaDNSName() string {
+func (c *Cluster) replicaDNSName(clusterName string) string {
 	return strings.ToLower(c.OpConfig.ReplicaDNSNameFormat.Format(
-		"cluster", c.Name,
+		"cluster", clusterName,
 		"namespace", c.Namespace,
 		"team", c.teamName(),
 		"hostedzone", c.OpConfig.DbHostedZone))

--- a/pkg/util/constants/pooler.go
+++ b/pkg/util/constants/pooler.go
@@ -2,6 +2,7 @@ package constants
 
 // Connection pooler specific constants
 const (
+	ConnectionPoolerResourceSuffix       = "pooler"
 	ConnectionPoolerUserName             = "pooler"
 	ConnectionPoolerSchemaName           = "pooler"
 	ConnectionPoolerDefaultType          = "pgbouncer"


### PR DESCRIPTION
fixes #2180 

Introduced two new functions: `generatePoolerServiceAnnotations` for the DNS annotation used for LBs and `getCustomServiceAnnotations` which is shared for all services. Because pooler unit tests need quite some refactoring, the annotations are tested in e2e suite.

Functions `masterDNSName` and `replicaDNSName` now take the cluster name as argument, to make them reusable for pooler DNS name resolving