### PR TITLE
fix sync of stream slots

### DIFF
--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -647,7 +647,12 @@ func (c *Cluster) checkAndSetGlobalPostgreSQLConfiguration(pod *v1.Pod, effectiv
 			}
 		}
 		slotsToSet[slotName] = desiredSlot
-		c.replicationSlots[slotName] = desiredSlot
+		// only add slots specified in manifest to c.replicationSlots
+		for manifestSlotName, _ := range c.Spec.Patroni.Slots {
+			if manifestSlotName == slotName {
+				c.replicationSlots[slotName] = desiredSlot
+			}
+		}
 	}
 	if len(slotsToSet) > 0 {
 		configToSet["slots"] = slotsToSet


### PR DESCRIPTION
`syncStatefulSet` and `syncStreams` both call `checkAndSetGlobalPostgreSQLConfiguration` to compare desired and effective Patroni config. Usually desired is what's specified in the manifest.

`syncStreams` however uses the config patch code to create logical replication slots that are not specified in the manifest. These slots then get added to [cluster.replicationSlots](https://github.com/zalando/postgres-operator/blob/d5251c5fc848e425258fe298655fc27cbd4035d0/pkg/cluster/sync.go#L650) (only on UPDATE events changing streams). This variable was introduced in #2089 to detect the removal of slots from the manifest. It should only contain slots specified in the manifest.

On the next SYNC `syncStatefulSet` will only compare manifest with effective config. The Postgres Operator goes over `cluster.replicationSlots` which now contains slots created for streams, but will not find them in the manifest. Thus, they will be set to `null` and get removed.

SyncStreams will then recreate them a few seconds later and so on. 