### PR TITLE
fix: PG 15 backups working by default

### DIFF
--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -348,7 +348,7 @@ configLogicalBackup:
   # logical_backup_memory_request: ""
 
   # image for pods of the logical backup job (example runs pg_dumpall)
-  logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.8.0"
+  logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.9.0"
   # path of google cloud service account json file
   # logical_backup_google_application_credentials: ""
 


### PR DESCRIPTION

## Problem description

In 30b612489a2a20d968262791857d1db1a85e0b36 this update was forgotten. It is needed for logical backups of postgres 15 clusters, as seen in https://github.com/zalando/postgres-operator/issues/1945#issuecomment-1425060560.

The default value documented is different to the one actually used: https://github.com/zalando/postgres-operator/blob/9973262b83507ccb16c097aef9ca56b35a1cbf4a/docs/reference/operator_parameters.md?plain=1#L753-L758


## Linked issues

Fixes https://github.com/zalando/postgres-operator/issues/1945.

@moduon MT-1075


## Checklist

Thanks for submitting a pull request to the Postgres Operator project.
Please, ensure your contribution matches the following items:

- [x] Your go code is [formatted](https://blog.golang.org/gofmt). Your IDE should do it automatically for you.
- [x] You have updated [generated code](https://github.com/zalando/postgres-operator/blob/master/docs/developer.md#code-generation) when introducing new fields to the `acid.zalan.do` api package.
- [x] New [configuration options](https://github.com/zalando/postgres-operator/blob/master/docs/developer.md#introduce-additional-configuration-parameters) are reflected in CRD validation, helm charts and sample manifests.
- [x] New functionality is covered by [unit](https://github.com/zalando/postgres-operator/blob/master/docs/developer.md#unit-tests) and/or [e2e](https://github.com/zalando/postgres-operator/blob/master/docs/developer.md#end-to-end-tests) tests.
- [x] You have checked existing open PRs for possible overlay and referenced them.
