### PR TITLE
Logical Backup: Configurable s3 chunksize

### DIFF
--- a/docker/logical-backup/dump.sh
+++ b/docker/logical-backup/dump.sh
@@ -111,6 +111,7 @@ function aws_upload {
     [[ ! -z "$LOGICAL_BACKUP_S3_ENDPOINT" ]] && args+=("--endpoint-url=$LOGICAL_BACKUP_S3_ENDPOINT")
     [[ ! -z "$LOGICAL_BACKUP_S3_REGION" ]] && args+=("--region=$LOGICAL_BACKUP_S3_REGION")
     [[ ! -z "$LOGICAL_BACKUP_S3_SSE" ]] && args+=("--sse=$LOGICAL_BACKUP_S3_SSE")
+    [[ ! -z "$LOGICAL_BACKUP_S3_MULTIPART_CHUNKSIZE" ]] && aws configure set default.s3.multipart_chunksize $LOGICAL_BACKUP_S3_MULTIPART_CHUNKSIZE
 
     aws s3 cp - "$PATH_TO_BACKUP" "${args[@]//\'/}"
 }


### PR DESCRIPTION
The default S3 chunksize according to https://docs.aws.amazon.com/cli/latest/topic/s3-config.html#multipart-chunksize is 8MB and the limit of chunks is <= 10000 https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html

Therefore somewhere around the 80GB mark of backup size the logical backup fails. Setting the chunksize to a higher value e.g. `128MB` fixes it. We are currently seeing the problem and have mitigated it like this.
