### PR TITLE
fix: update logical-backup image to support backups of postgres v15

### DIFF
--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -348,7 +348,7 @@ configLogicalBackup:
   # logical_backup_memory_request: ""
 
   # image for pods of the logical backup job (example runs pg_dumpall)
-  logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.8.0"
+  logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.9.0"
   # path of google cloud service account json file
   # logical_backup_google_application_credentials: ""
 


### PR DESCRIPTION
The v1.8.0 image does not include Postgres v15, so backups of clusters of that version fail with:
```
/dump.sh: line 31: /usr/lib/postgresql/15/bin/psql: No such file or directory
```