### PR TITLE
Add pipeline to publish ghcr multi-arch image

### DIFF
--- a/.github/workflows/publish_ghcr_image.yaml
+++ b/.github/workflows/publish_ghcr_image.yaml
@@ -1,0 +1,56 @@
+name: Publish multiarch postgres-operator image on ghcr.io
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  publish:
+    name: Build, test and push image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "^1.18.9"
+
+      - name: Run unit tests
+        run: make deps mocks test
+
+      - name: Define image name
+        id: image
+        run: |
+            IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF/refs\/tags\//}"
+            echo "NAME=$IMAGE" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multiarch image to ghcr
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          build-args: BASE_IMAGE=alpine:3.15
+          tags: "${{ steps.image.outputs.NAME }}"
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/run_e2e.yaml
+++ b/.github/workflows/run_e2e.yaml
@@ -19,8 +19,6 @@ jobs:
       run: make deps mocks
     - name: Code generation
       run: make codegen
-    - name: Compile
-      run: make linux
     - name: Run unit tests
       run: make test
     - name: Run end-2-end tests

--- a/Makefile
+++ b/Makefile
@@ -60,17 +60,13 @@ linux: ${SOURCES}
 macos: ${SOURCES}
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=${CGO_ENABLED} go build -o build/macos/${BINARY} ${BUILD_FLAGS} -ldflags "$(LDFLAGS)" $^
 
-docker-context: scm-source.json linux
-	mkdir -p docker/build/
-	cp build/linux/${BINARY} scm-source.json docker/build/
-
-docker: ${DOCKERDIR}/${DOCKERFILE} docker-context
+docker: ${DOCKERDIR}/${DOCKERFILE} scm-source.json
 	echo `(env)`
 	echo "Tag ${TAG}"
 	echo "Version ${VERSION}"
 	echo "CDP tag ${CDP_TAG}"
 	echo "git describe $(shell git describe --tags --always --dirty)"
-	cd "${DOCKERDIR}" && docker build --rm -t "$(IMAGE):$(TAG)$(CDP_TAG)$(DEBUG_FRESH)$(DEBUG_POSTFIX)" -f "${DOCKERFILE}" .
+	docker build --rm -t "$(IMAGE):$(TAG)$(CDP_TAG)$(DEBUG_FRESH)$(DEBUG_POSTFIX)" -f "${DOCKERDIR}/${DOCKERFILE}" .
 
 indocker-race:
 	docker run --rm -v "${GOPATH}":"${GOPATH}" -e GOPATH="${GOPATH}" -e RACE=1 -w ${PWD} golang:1.18.9 bash -c "make linux"

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ docker: ${DOCKERDIR}/${DOCKERFILE} scm-source.json
 	echo "Version ${VERSION}"
 	echo "CDP tag ${CDP_TAG}"
 	echo "git describe $(shell git describe --tags --always --dirty)"
-	docker build --rm -t "$(IMAGE):$(TAG)$(CDP_TAG)$(DEBUG_FRESH)$(DEBUG_POSTFIX)" -f "${DOCKERDIR}/${DOCKERFILE}" .
+	docker build --rm -t "$(IMAGE):$(TAG)$(CDP_TAG)$(DEBUG_FRESH)$(DEBUG_POSTFIX)" -f "${DOCKERDIR}/${DOCKERFILE}" --build-arg VERSION="${VERSION}" .
 
 indocker-race:
 	docker run --rm -v "${GOPATH}":"${GOPATH}" -e GOPATH="${GOPATH}" -e RACE=1 -w ${PWD} golang:1.18.9 bash -c "make linux"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ LABEL maintainer="Team ACID @ Zalando <team-acid@zalando.de>"
 RUN apk --no-cache add curl
 RUN apk --no-cache add ca-certificates
 
-COPY --from=builder /go/src/github.com/zalando/postgres-operator/build/postgres-operator /
+COPY --from=builder /go/src/github.com/zalando/postgres-operator/build/* /
 
 RUN addgroup -g 1000 pgo
 RUN adduser -D -u 1000 -G pgo -g 'Postgres Operator' pgo

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,20 @@
-FROM registry.opensource.zalan.do/library/alpine-3.15:latest
+ARG BASE_IMAGE=registry.opensource.zalan.do/library/alpine-3.15:latest
+
+FROM ubuntu:20.04 as builder
+
+COPY  . /go/src/github.com/zalando/postgres-operator
+WORKDIR /go/src/github.com/zalando/postgres-operator
+
+RUN bash docker/build_operator.sh
+
+FROM ${BASE_IMAGE}
 LABEL maintainer="Team ACID @ Zalando <team-acid@zalando.de>"
 
 # We need root certificates to deal with teams api over https
 RUN apk --no-cache add curl
 RUN apk --no-cache add ca-certificates
 
-COPY build/* /
+COPY --from=builder /go/src/github.com/zalando/postgres-operator/build/postgres-operator /
 
 RUN addgroup -g 1000 pgo
 RUN adduser -D -u 1000 -G pgo -g 'Postgres Operator' pgo

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,14 @@
 ARG BASE_IMAGE=registry.opensource.zalan.do/library/alpine-3.15:latest
+ARG VERSION=latest
 
 FROM ubuntu:20.04 as builder
+
+ARG VERSION
 
 COPY  . /go/src/github.com/zalando/postgres-operator
 WORKDIR /go/src/github.com/zalando/postgres-operator
 
+ENV OPERATOR_LDFLAGS="-X=main.version=${VERSION}"
 RUN bash docker/build_operator.sh
 
 FROM ${BASE_IMAGE}

--- a/docker/build_operator.sh
+++ b/docker/build_operator.sh
@@ -24,8 +24,8 @@ apt-get install -y wget
 
 export PATH="$PATH:$HOME/go/bin"
 export GOPATH="$HOME/go"
-mkdir -p docker/build/
-cp scm-source.json docker/build/
+mkdir -p build
+cp scm-source.json build/
 
 GO111MODULE=on go mod vendor
 CGO_ENABLED=0 go build -o build/postgres-operator -v -ldflags "-X=main.version=e1fbdd9" cmd/main.go

--- a/docker/build_operator.sh
+++ b/docker/build_operator.sh
@@ -28,4 +28,4 @@ mkdir -p build
 cp scm-source.json build/
 
 GO111MODULE=on go mod vendor
-CGO_ENABLED=0 go build -o build/postgres-operator -v -ldflags "-X=main.version=e1fbdd9" cmd/main.go
+CGO_ENABLED=0 go build -o build/postgres-operator -v -ldflags "$OPERATOR_LDFLAGS" cmd/main.go

--- a/docker/build_operator.sh
+++ b/docker/build_operator.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+export DEBIAN_FRONTEND=noninteractive
+
+arch=$(dpkg --print-architecture)
+
+set -ex
+
+# Install dependencies
+
+apt-get update
+apt-get install -y wget
+
+(
+    cd /tmp
+    wget -q "https://storage.googleapis.com/golang/go1.18.9.linux-${arch}.tar.gz" -O go.tar.gz
+    tar -xf go.tar.gz
+    mv go /usr/local
+    ln -s /usr/local/go/bin/go /usr/bin/go
+    go version
+)
+
+# Build
+
+export PATH="$PATH:$HOME/go/bin"
+export GOPATH="$HOME/go"
+mkdir -p docker/build/
+cp scm-source.json docker/build/
+
+GO111MODULE=on go mod vendor
+CGO_ENABLED=0 go build -o build/postgres-operator -v -ldflags "-X=main.version=e1fbdd9" cmd/main.go


### PR DESCRIPTION
Refactor operator image build process to allow multi-arch builds
Add a pipeline to build and publish arm64/amd64 image in ghcr on every pushed tag