### PR TITLE
in sync mode select only syncStandby as switchover candidate

### DIFF
--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -469,10 +469,23 @@ func (c *Cluster) getSwitchoverCandidate(master *v1.Pod) (spec.NamespacedName, e
 		func() (bool, error) {
 			var err error
 			members, err = c.patroni.GetClusterMembers(master)
-
 			if err != nil {
 				return false, err
 			}
+
+			// look for SyncStandby candidates
+			for _, member := range members {
+				if PostgresRole(member.Role) == SyncStandby {
+					syncCandidates = append(syncCandidates, member)
+				}
+			}
+
+			// if synchronous mode is enabled and no SyncStandy was found
+			// return false for retry - cannot failover with no sync candidate
+			if c.Spec.Patroni.SynchronousMode && len(syncCandidates) == 0 {
+				return false, fmt.Errorf("no sync standby found")
+			}
+
 			return true, nil
 		},
 	)
@@ -480,28 +493,26 @@ func (c *Cluster) getSwitchoverCandidate(master *v1.Pod) (spec.NamespacedName, e
 		return spec.NamespacedName{}, fmt.Errorf("failed to get Patroni cluster members: %s", err)
 	}
 
-	for _, member := range members {
-		if PostgresRole(member.Role) != Leader && PostgresRole(member.Role) != StandbyLeader && member.State == "running" {
-			candidates = append(candidates, member)
-			if PostgresRole(member.Role) == SyncStandby {
-				syncCandidates = append(syncCandidates, member)
-			}
-		}
-	}
-
 	// pick candidate with lowest lag
-	// if sync_standby replicas were found assume synchronous_mode is enabled and ignore other candidates list
 	if len(syncCandidates) > 0 {
 		sort.Slice(syncCandidates, func(i, j int) bool {
 			return syncCandidates[i].Lag < syncCandidates[j].Lag
 		})
 		return spec.NamespacedName{Namespace: master.Namespace, Name: syncCandidates[0].Name}, nil
-	}
-	if len(candidates) > 0 {
-		sort.Slice(candidates, func(i, j int) bool {
-			return candidates[i].Lag < candidates[j].Lag
-		})
-		return spec.NamespacedName{Namespace: master.Namespace, Name: candidates[0].Name}, nil
+	} else {
+		// in asynchronous mode find running replicas
+		for _, member := range members {
+			if PostgresRole(member.Role) != Leader && PostgresRole(member.Role) != StandbyLeader && member.State == "running" {
+				candidates = append(candidates, member)
+			}
+		}
+
+		if len(candidates) > 0 {
+			sort.Slice(candidates, func(i, j int) bool {
+				return candidates[i].Lag < candidates[j].Lag
+			})
+			return spec.NamespacedName{Namespace: master.Namespace, Name: candidates[0].Name}, nil
+		}
 	}
 
 	return spec.NamespacedName{}, fmt.Errorf("no switchover candidate found")

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -483,7 +483,8 @@ func (c *Cluster) getSwitchoverCandidate(master *v1.Pod) (spec.NamespacedName, e
 			// if synchronous mode is enabled and no SyncStandy was found
 			// return false for retry - cannot failover with no sync candidate
 			if c.Spec.Patroni.SynchronousMode && len(syncCandidates) == 0 {
-				return false, fmt.Errorf("no sync standby found")
+				c.logger.Errorf("no sync standby found")
+				return false, nil
 			}
 
 			return true, nil

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -473,7 +473,7 @@ func (c *Cluster) getSwitchoverCandidate(master *v1.Pod) (spec.NamespacedName, e
 				return false, err
 			}
 
-			// look for SyncStandby candidates
+			// look for SyncStandby candidates (which also implies pod is in running state)
 			for _, member := range members {
 				if PostgresRole(member.Role) == SyncStandby {
 					syncCandidates = append(syncCandidates, member)
@@ -483,7 +483,7 @@ func (c *Cluster) getSwitchoverCandidate(master *v1.Pod) (spec.NamespacedName, e
 			// if synchronous mode is enabled and no SyncStandy was found
 			// return false for retry - cannot failover with no sync candidate
 			if c.Spec.Patroni.SynchronousMode && len(syncCandidates) == 0 {
-				c.logger.Errorf("no sync standby found")
+				c.logger.Warnf("no sync standby found - retrying fetching cluster members")
 				return false, nil
 			}
 

--- a/pkg/cluster/pod_test.go
+++ b/pkg/cluster/pod_test.go
@@ -52,7 +52,7 @@ func TestGetSwitchoverCandidate(t *testing.T) {
 			clusterJson:       `{"members": [{"name": "acid-test-cluster-0", "role": "leader", "state": "running", "api_url": "http://192.168.100.1:8008/patroni", "host": "192.168.100.1", "port": 5432, "timeline": 1}, {"name": "acid-test-cluster-1", "role": "replica", "state": "running", "api_url": "http://192.168.100.2:8008/patroni", "host": "192.168.100.2", "port": 5432, "timeline": 1, "lag": 0}]}`,
 			syncModeEnabled:   true,
 			expectedCandidate: spec.NamespacedName{},
-			expectedError:     fmt.Errorf("failed to get Patroni cluster members: no sync standby found"),
+			expectedError:     fmt.Errorf("failed to get Patroni cluster members: unexpected end of JSON input"),
 		},
 		{
 			subtest:           "choose replica with lowest lag",

--- a/pkg/cluster/pod_test.go
+++ b/pkg/cluster/pod_test.go
@@ -36,30 +36,42 @@ func TestGetSwitchoverCandidate(t *testing.T) {
 	tests := []struct {
 		subtest           string
 		clusterJson       string
+		syncModeEnabled   bool
 		expectedCandidate spec.NamespacedName
 		expectedError     error
 	}{
 		{
 			subtest:           "choose sync_standby over replica",
 			clusterJson:       `{"members": [{"name": "acid-test-cluster-0", "role": "leader", "state": "running", "api_url": "http://192.168.100.1:8008/patroni", "host": "192.168.100.1", "port": 5432, "timeline": 1}, {"name": "acid-test-cluster-1", "role": "sync_standby", "state": "running", "api_url": "http://192.168.100.2:8008/patroni", "host": "192.168.100.2", "port": 5432, "timeline": 1, "lag": 0}, {"name": "acid-test-cluster-2", "role": "replica", "state": "running", "api_url": "http://192.168.100.3:8008/patroni", "host": "192.168.100.3", "port": 5432, "timeline": 1, "lag": 0}]}`,
+			syncModeEnabled:   true,
 			expectedCandidate: spec.NamespacedName{Namespace: namespace, Name: "acid-test-cluster-1"},
 			expectedError:     nil,
 		},
 		{
+			subtest:           "no running sync_standby available",
+			clusterJson:       `{"members": [{"name": "acid-test-cluster-0", "role": "leader", "state": "running", "api_url": "http://192.168.100.1:8008/patroni", "host": "192.168.100.1", "port": 5432, "timeline": 1}, {"name": "acid-test-cluster-1", "role": "replica", "state": "running", "api_url": "http://192.168.100.2:8008/patroni", "host": "192.168.100.2", "port": 5432, "timeline": 1, "lag": 0}]}`,
+			syncModeEnabled:   true,
+			expectedCandidate: spec.NamespacedName{},
+			expectedError:     fmt.Errorf("failed to get Patroni cluster members: no sync standby found"),
+		},
+		{
 			subtest:           "choose replica with lowest lag",
 			clusterJson:       `{"members": [{"name": "acid-test-cluster-0", "role": "leader", "state": "running", "api_url": "http://192.168.100.1:8008/patroni", "host": "192.168.100.1", "port": 5432, "timeline": 1}, {"name": "acid-test-cluster-1", "role": "replica", "state": "running", "api_url": "http://192.168.100.2:8008/patroni", "host": "192.168.100.2", "port": 5432, "timeline": 1, "lag": 5}, {"name": "acid-test-cluster-2", "role": "replica", "state": "running", "api_url": "http://192.168.100.3:8008/patroni", "host": "192.168.100.3", "port": 5432, "timeline": 1, "lag": 2}]}`,
+			syncModeEnabled:   false,
 			expectedCandidate: spec.NamespacedName{Namespace: namespace, Name: "acid-test-cluster-2"},
 			expectedError:     nil,
 		},
 		{
 			subtest:           "choose first replica when lag is equal evrywhere",
 			clusterJson:       `{"members": [{"name": "acid-test-cluster-0", "role": "leader", "state": "running", "api_url": "http://192.168.100.1:8008/patroni", "host": "192.168.100.1", "port": 5432, "timeline": 1}, {"name": "acid-test-cluster-1", "role": "replica", "state": "running", "api_url": "http://192.168.100.2:8008/patroni", "host": "192.168.100.2", "port": 5432, "timeline": 1, "lag": 5}, {"name": "acid-test-cluster-2", "role": "replica", "state": "running", "api_url": "http://192.168.100.3:8008/patroni", "host": "192.168.100.3", "port": 5432, "timeline": 1, "lag": 5}]}`,
+			syncModeEnabled:   false,
 			expectedCandidate: spec.NamespacedName{Namespace: namespace, Name: "acid-test-cluster-1"},
 			expectedError:     nil,
 		},
 		{
 			subtest:           "no running replica available",
 			clusterJson:       `{"members": [{"name": "acid-test-cluster-0", "role": "leader", "state": "running", "api_url": "http://192.168.100.1:8008/patroni", "host": "192.168.100.1", "port": 5432, "timeline": 2}, {"name": "acid-test-cluster-1", "role": "replica", "state": "starting", "api_url": "http://192.168.100.2:8008/patroni", "host": "192.168.100.2", "port": 5432, "timeline": 2}]}`,
+			syncModeEnabled:   false,
 			expectedCandidate: spec.NamespacedName{},
 			expectedError:     fmt.Errorf("no switchover candidate found"),
 		},
@@ -81,6 +93,7 @@ func TestGetSwitchoverCandidate(t *testing.T) {
 		cluster.patroni = p
 		mockMasterPod := newMockPod("192.168.100.1")
 		mockMasterPod.Namespace = namespace
+		cluster.Spec.Patroni.SynchronousMode = tt.syncModeEnabled
 
 		candidate, err := cluster.getSwitchoverCandidate(mockMasterPod)
 		if err != nil && err.Error() != tt.expectedError.Error() {

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -458,7 +458,7 @@ func (c *Cluster) syncPatroniConfig(pods []v1.Pod, requiredPatroniConfig acidv1.
 	// get Postgres config, compare with manifest and update via Patroni PATCH endpoint if it differs
 	for i, pod := range pods {
 		podName := util.NameFromMeta(pods[i].ObjectMeta)
-		effectivePatroniConfig, effectivePgParameters, err = c.patroni.GetConfig(&pod)
+		effectivePatroniConfig, effectivePgParameters, err = c.getPatroniConfig(&pod)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("could not get Postgres config from pod %s: %v", podName, err))
 			continue


### PR DESCRIPTION
fixes #2276 

On a two node clusters when performing a rolling update, it turned out that the recreated replica is chosen as switchover target before Patroni assigns it the synchronous status. Therefore, the switchover will fail with the following error:

```
2023-03-30 16:05:24,606 INFO: Updating synchronous privilege temporarily from ['test-sync-mode-0'] to []
2023-03-30 16:05:24,653 INFO: Assigning synchronous standby status to []
server signaled
2023-03-30 16:05:24,828 INFO: no action. I am (test-sync-mode-1), the leader with the lock
2023-03-30 16:05:34,670 INFO: no action. I am (test-sync-mode-1), the leader with the lock
2023-03-30 16:05:42.106 UTC [36] LOG {ticks: 0, maint: 0, retry: 0}
2023-03-30 16:05:44,682 INFO: no action. I am (test-sync-mode-1), the leader with the lock
2023-03-30 16:05:50,665 INFO: received failover request with leader=test-sync-mode-1 candidate=test-sync-mode-0 scheduled_at=None
2023-03-30 16:05:50,679 INFO: Got response from test-sync-mode-0 http://10.2.24.81:8008/patroni: {"state": "running", "postmaster_start_time": "2023-03-30 16:05:49.540527+00:00", "role": "replica", "server_version": 140007, "xlog": {"received_location": 134368768, "replayed_location": 134368768, "replayed_timestamp": "2023-03-30 16:05:24.756947+00:00", "paused": false}, "timeline": 2, "dcs_last_seen": 1680192350, "database_system_identifier": "7216365118537531469", "patroni": {"version": "3.0.1", "scope": "test-sync-mode"}}
2023-03-30 16:05:50,730 INFO: Lock owner: test-sync-mode-1; I am test-sync-mode-1
2023-03-30 16:05:50,778 WARNING: Failover candidate=test-sync-mode-0 does not match with sync_standbys=None
2023-03-30 16:05:50,778 WARNING: manual failover: members list is empty
2023-03-30 16:05:50,778 WARNING: manual failover: no healthy members found, failover is not possible
2023-03-30 16:05:50,778 INFO: Cleaning up failover key
2023-03-30 16:05:50,829 INFO: Assigning synchronous standby status to ['test-sync-mode-0']
server signaled
```

It would only work on the next sync. Therefore, this PR suggest to include a check if a SyncStandby candidate was found in the retry loop that calls the members endpoint. If synchronous mode is enabled the members call should be repeated when there's no syncStandby candidate.