### PR TITLE
Fix some errors be ignored

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -241,12 +241,11 @@ func (c *Cluster) initUsers() error {
 }
 
 // Create creates the new kubernetes objects associated with the cluster.
-func (c *Cluster) Create() error {
+func (c *Cluster) Create() (err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	var (
-		err error
 
+	var (
 		service *v1.Service
 		ep      *v1.Endpoints
 		ss      *appsv1.StatefulSet


### PR DESCRIPTION
In `Create()` function, some errors not been check. It will cause cluster status to unexpected.

For example:
https://github.com/zalando/postgres-operator/blob/0e7beb5fe50920cef82ce6e908ac52a9feaa3aa0/pkg/cluster/cluster.go#L271-L273