### PR TITLE
Fix deprecated zone label

### DIFF
--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -521,7 +521,7 @@ you can switch to  `preferredDuringSchedulingIgnoredDuringExecution` by setting 
 
 By default the topology key for the pod anti affinity is set to
 `kubernetes.io/hostname`, you can set another topology key e.g.
-`failure-domain.beta.kubernetes.io/zone`. See [built-in node labels](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#interlude-built-in-node-labels) for available topology keys.
+`topology.kubernetes.io/zone`. See [built-in node labels](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#interlude-built-in-node-labels) for available topology keys.
 
 ## Pod Disruption Budget
 


### PR DESCRIPTION
From the k8s doc:
> Starting in v1.17, this label [failure-domain.beta.kubernetes.io/zone] is deprecated in favor of topology.kubernetes.io/zone.