### PR TITLE
rename failsafe_mode option in opconfig CRD

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -670,7 +670,7 @@ spec:
               patroni:
                 type: object
                 properties:
-                  failsafe_mode:
+                  enable_patroni_failsafe_mode:
                     type: boolean
                     default: false
           status:

--- a/charts/postgres-operator/templates/configmap.yaml
+++ b/charts/postgres-operator/templates/configmap.yaml
@@ -26,4 +26,5 @@ data:
 {{- include "flattenValuesForConfigMap" .Values.configLoggingRestApi | indent 2 }}
 {{- include "flattenValuesForConfigMap" .Values.configTeamsApi | indent 2 }}
 {{- include "flattenValuesForConfigMap" .Values.configConnectionPooler | indent 2 }}
+{{- include "flattenValuesForConfigMap" .Values.configPatroni | indent 2 }}
 {{- end }}

--- a/charts/postgres-operator/templates/operatorconfiguration.yaml
+++ b/charts/postgres-operator/templates/operatorconfiguration.yaml
@@ -40,4 +40,6 @@ configuration:
 {{ toYaml .Values.configLoggingRestApi | indent 4 }}
   connection_pooler:
 {{ toYaml .Values.configConnectionPooler | indent 4 }}
+  patroni:
+{{ toYaml .Values.configPatroni | indent 4 }}
 {{- end }}

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -431,7 +431,7 @@ configConnectionPooler:
 
 configPatroni:
   # enable Patroni DCS failsafe_mode feature
-  failsafe_mode: false
+  enable_patroni_failsafe_mode: false
 
 # Zalando's internal CDC stream feature
 enableStreams: false

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -334,9 +334,12 @@ explanation of `ttl` and `loop_wait` parameters.
   Patroni `synchronous_node_count` parameter value. Note, this option is only available for Spilo images with Patroni 2.0+. The default is set to `1`. Optional.
 
 * **failsafe_mode**
-  Patroni `failsafe_mode` parameter value. If enabled, allows Patroni to cope with DCS outages and avoid leader demotion. See the Patroni documentation
-  [here](https://patroni.readthedocs.io/en/master/dcs_failsafe_mode.html) for more details. This feature is included since Patroni 3.0.0. 
-  Hence, check the container image in use if this feature is included in the used Patroni version. The default is set to `false`. Optional.
+  Patroni `failsafe_mode` parameter value. If enabled, Patroni will cope
+  with DCS outages by avoiding leader demotion. See the Patroni documentation
+  [here](https://patroni.readthedocs.io/en/master/dcs_failsafe_mode.html) for more details.
+  This feature is included since Patroni 3.0.0. Hence, check the container
+  image in use if this feature is included in the used Patroni version. The
+  default is set to `false`. Optional. 
   
 ## Postgres container resources
 

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -549,6 +549,19 @@ CRD-based configuration.
   hard memory minimum what we consider to be required to properly run Postgres
   clusters with Patroni on Kubernetes. The default is `250Mi`.
 
+## Patroni options
+
+Parameters configuring Patroni. In the CRD-based configuration they are grouped
+under the `patroni` key.
+
+* **enable_patroni_failsafe_mode**
+  If enabled, Patroni copes with DCS outages by avoiding leader demotion.
+  See the Patroni documentation [here](https://patroni.readthedocs.io/en/master/dcs_failsafe_mode.html) for more details.
+  This feature is included since Patroni 3.0.0. Hence, check the container image
+  in use if this feature is included in the used Patroni version. It can also be
+  enabled cluster-wise with the `failsafe_mode` flag under the `patroni` section
+  in the manifest. The default for the global config option is set to `false`.
+
 ## Operator timeouts
 
 This set of parameters define various timeouts related to some operator

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -47,7 +47,7 @@ data:
   enable_master_load_balancer: "false"
   enable_master_pooler_load_balancer: "false"
   enable_password_rotation: "false"
-  # enable_patroni_failsafe_mode: "false"
+  enable_patroni_failsafe_mode: "false"
   enable_pgversion_env_var: "true"
   # enable_pod_antiaffinity: "false"
   # enable_pod_disruption_budget: "true"

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -668,7 +668,7 @@ spec:
               patroni:
                 type: object
                 properties:
-                  failsafe_mode:
+                  enable_patroni_failsafe_mode:
                     type: boolean
                     default: false
           status:

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -209,5 +209,5 @@ configuration:
     connection_pooler_number_of_instances: 2
     # connection_pooler_schema: "pooler"
     # connection_pooler_user: "pooler"
-  # patroni:
-    # failsafe_mode: "false"
+  patroni:
+    enable_patroni_failsafe_mode: false

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1483,7 +1483,7 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 					"patroni": {
 						Type: "object",
 						Properties: map[string]apiextv1.JSONSchemaProps{
-							"failsafe_mode": {
+							"enable_patroni_failsafe_mode": {
 								Type: "boolean",
 							},
 						},

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -240,7 +240,7 @@ type OperatorLogicalBackupConfiguration struct {
 
 // PatroniConfiguration defines configuration for Patroni
 type PatroniConfiguration struct {
-	FailsafeMode *bool `json:"failsafe_mode,omitempty"`
+	FailsafeMode *bool `json:"enable_patroni_failsafe_mode,omitempty"`
 }
 
 // OperatorConfigurationData defines the operation config


### PR DESCRIPTION
There is an inconsistency in the naming of the global config option for Patroni's failsafe mode. `enable_patroni_failsafe_mode` in configmap and `failsafe_mode` in OpeartorConfiguration CRD. In #2297 we noticed that this option is still missing in the helm chart templates, but the difference in the naming would make it a bit harder to add it to the both configmap and CRD templates.

Therefore, this PR will change the name in the CRD to `enable_patroni_failsafe_mode` as well albeit being listed under the `patroni` key. It also adds documentation which was still missing in the config reference. As the next release will the first version to support failsafe_mode by default, I do not think this renaming would break the setups of people out there.