### PR TITLE
Remove logicalBackupSchedule pattern spec from the postgresql CRD.

### DIFF
--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -215,7 +215,6 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
               logicalBackupSchedule:
                 type: string
-                pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
               maintenanceWindows:
                 type: array
                 items:


### PR DESCRIPTION
The pattern only validates the most basic cron schedules, and fail with the use of intervals, lists, ranges, etc.