### PR TITLE
Allow scheduling constraints for operator-ui pods

### DIFF
--- a/charts/postgres-operator-ui/templates/deployment.yaml
+++ b/charts/postgres-operator-ui/templates/deployment.yaml
@@ -94,3 +94,12 @@ spec:
             {{- if .Values.extraEnvs }}
             {{- .Values.extraEnvs | toYaml | nindent 12 }}
             {{- end }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}

--- a/charts/postgres-operator-ui/values.yaml
+++ b/charts/postgres-operator-ui/values.yaml
@@ -108,3 +108,18 @@ ingress:
   #  - secretName: ui-tls
   #    hosts:
   #      - ui.exmaple.org
+
+# priority class for operator-ui pod
+priorityClassName: ""
+
+# Affinity for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+# Node labels for pod assignment
+# Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+# Tolerations for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []


### PR DESCRIPTION
This PR is a simple update to the `postgres-operator-ui` chart allows the following scheduling constraints to the **`operator-ui`** pods:  

- `affinity`
-  `nodeSelector`
-  `tolerations`
- `priorityClassName`

To clarify, this change **only** affects the `operator-ui` pods themselves and isn't a change to the actual UI.

This has come up before in the following issues: 

https://github.com/zalando/postgres-operator/issues/1921
https://github.com/zalando/postgres-operator/issues/1885