### PR TITLE
Renaming failsafe_mode to enable_patroni_failsafe_mode to match #2298

### DIFF
--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -322,7 +322,7 @@ spec:
               patroni:
                 type: object
                 properties:
-                  failsafe_mode:
+                  enable_patroni_failsafe_mode:
                     type: boolean
                   initdb:
                     type: object


### PR DESCRIPTION
The CRD needs to match the recent merge to change patroni.failsafe_mode to patroni.enable_patroni_failsafe_mode.