### PR TITLE
Handle retry connect to Postgres when ping return EOF error.

### DIFF
--- a/pkg/cluster/database.go
+++ b/pkg/cluster/database.go
@@ -154,7 +154,10 @@ func (c *Cluster) initDbConnWithName(dbname string) error {
 				return false, err2
 			}
 
-			return false, err
+			// Ping verifies a connection to the database return EOF error.
+			// Retry open connection until succeeded.
+			c.logger.Warningf("could not connect to Postgres database: %v", err)
+			return false, nil
 		})
 
 	if finalerr != nil {

--- a/pkg/cluster/database.go
+++ b/pkg/cluster/database.go
@@ -154,7 +154,6 @@ func (c *Cluster) initDbConnWithName(dbname string) error {
 				return false, err2
 			}
 
-			// Ping verifies a connection to the database return EOF error.
 			// Retry open connection until succeeded.
 			c.logger.Warningf("could not connect to Postgres database: %v", err)
 			return false, nil


### PR DESCRIPTION
After the ping function is called, it returns an EOF error. 
https://github.com/zalando/postgres-operator/blob/master/pkg/cluster/database.go#L138-L141
```
conn, err = sql.Open("postgres", connstring)
if err == nil {
        err = conn.Ping()
}
```

These if statements will be false.
https://github.com/zalando/postgres-operator/blob/master/pkg/cluster/database.go#L143-L150
```
if err == nil {
	return true, nil
}

if _, ok := err.(*net.OpError); ok {
	c.logger.Warningf("could not connect to Postgres database: %v", err)
	return false, nil
}
```

Then the func will return false, err.
https://github.com/zalando/postgres-operator/blob/master/pkg/cluster/database.go#L157
```
return false, err
```

Take a look at the `Retry` function and `RetryWorker` function.
https://github.com/zalando/postgres-operator/blob/master/pkg/util/retryutil/retry_util.go#L27-L63
```
// Retry is a wrapper around RetryWorker that provides a real RetryTicker
func Retry(interval time.Duration, timeout time.Duration, f func() (bool, error)) error {
	//TODO: make the retry exponential
	if timeout < interval {
		return fmt.Errorf("timeout(%s) should be greater than interval(%v)", timeout, interval)
	}
	tick := &Ticker{time.NewTicker(interval)}
	return RetryWorker(interval, timeout, tick, f)
}

// RetryWorker calls ConditionFunc until either:
// * it returns boolean true
// * a timeout expires
// * an error occurs
func RetryWorker(
	interval time.Duration,
	timeout time.Duration,
	tick RetryTicker,
	f func() (bool, error)) error {

	maxRetries := int(timeout / interval)
	defer tick.Stop()

	for i := 0; ; i++ {
		ok, err := f()
		if err != nil {
			return err
		}
		if ok {
			return nil
		}
		if i+1 == maxRetries {
			break
		}
		tick.Tick()
	}
	return fmt.Errorf("still failing after %d retries", maxRetries)
}
```

In the `RetryWorker` function, the f() function returns false, err. Then this if statement will be true.
https://github.com/zalando/postgres-operator/blob/master/pkg/util/retryutil/retry_util.go#L54-L56
```
if ok {
	return nil
}
```
So, none retry at all. But I think it should retry if an error occurs, right?

Posgres Operator's log before this commit:
```
time="2023-05-19T04:07:03Z" level=debug msg="created new statefulset \"namespace/sts-name\", uid: \"uid-of-this-pod\"" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-19T04:07:03Z" level=info msg="statefulset \"namespace/sts-name\" has been successfully created" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-19T04:07:03Z" level=info msg="waiting for the cluster being ready" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-19T04:08:03Z" level=debug msg="Waiting for 1 pods to become ready" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-19T04:08:03Z" level=info msg="pods are ready" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-19T04:08:03Z" level=info msg="Create roles" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-19T04:08:18Z" level=error msg="could not create cluster: could not create users: could not init db connection: could not init db connection: EOF" cluster-name=namespace/sts-name pkg=controller worker=0
```

Postgres Operator's log after this commit:
```
time="2023-05-26T16:08:58Z" level=debug msg="created new statefulset \"namespace/sts-name\", uid: \"uid-of-this-pod\"" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-26T16:08:58Z" level=info msg="statefulset \"namespace/sts-name\" has been successfully created" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-26T16:08:58Z" level=info msg="waiting for the cluster being ready" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-26T16:09:58Z" level=debug msg="Waiting for 1 pods to become ready" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-26T16:09:58Z" level=info msg="pods are ready" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-26T16:09:58Z" level=info msg="Create roles" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-26T16:09:58Z" level=warning msg="could not connect to Postgres database: EOF" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-26T16:10:13Z" level=warning msg="could not connect to Postgres database: read tcp xx.xxx.xxx.xxx:yyyyy->aa.bbb.ccc.dd:5432: read: connection reset by peer" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-26T16:10:28Z" level=warning msg="could not connect to Postgres database: read tcp xx.xxx.xxx.xxx:yyyyy->aa.bbb.ccc.dd:5432: read: connection reset by peer" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-26T16:10:43Z" level=warning msg="could not connect to Postgres database: EOF" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-26T16:10:58Z" level=warning msg="could not connect to Postgres database: read tcp xx.xxx.xxx.xxx:yyyyy->aa.bbb.ccc.dd:5432: read: connection reset by peer" cluster-name=namespace/sts-name pkg=cluster worker=0
time="2023-05-26T16:11:13Z" level=debug msg="closing database connection" cluster-name=namespace/sts-name pkg=cluster worker=0
```

I think the retry function lacks this case. So, I commit to this solution. Can you help me to review and merge this PR?
Thank you, guys.
Best regards
