### PR TITLE
Fix basic installation on non default namespaces

### DIFF
--- a/manifests/operator-service-account-rbac.yaml
+++ b/manifests/operator-service-account-rbac.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: postgres-operator
-  namespace: default
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Manifests that are used with the default installation don't have a namespace (so it uses the current context's one).

It's my first time using this software so if it's possible I've misread things ~.
