### PR TITLE
add prefix EBS volume

### DIFF
--- a/pkg/util/volumes/ebs.go
+++ b/pkg/util/volumes/ebs.go
@@ -41,6 +41,9 @@ func (r *EBSVolumeResizer) VolumeBelongsToProvider(pv *v1.PersistentVolume) bool
 
 // ExtractVolumeID extracts volumeID
 func (r *EBSVolumeResizer) ExtractVolumeID(volumeID string) (string, error) {
+	if !(strings.Contains(volumeID, "/vol")) {
+		volumeID = "/" + volumeID
+	}
 	idx := strings.LastIndex(volumeID, constants.EBSVolumeIDStart) + 1
 	if idx == 0 {
 		return "", fmt.Errorf("malformed EBS volume id %q", volumeID)


### PR DESCRIPTION
add prefix `/vol-` on when EBS volumes  to have to fix the error on changing the IOPS and throughput:
`populating EBS meta data failed, skippinq potential adiustements: MissinqParameter: The request must contain the parameter volumes status code: 400`