### PR TITLE
Add service account name in connection pooler

### DIFF
--- a/pkg/cluster/connection_pooler.go
+++ b/pkg/cluster/connection_pooler.go
@@ -406,6 +406,7 @@ func (c *Cluster) generateConnectionPoolerPodTemplate(role PostgresRole) (
 			Tolerations:                   tolerationsSpec,
 			Volumes:                       poolerVolumes,
 			SecurityContext:               &securityContext,
+			ServiceAccountName:            c.OpConfig.PodServiceAccountName,
 		},
 	}
 

--- a/pkg/cluster/connection_pooler_test.go
+++ b/pkg/cluster/connection_pooler_test.go
@@ -1000,6 +1000,7 @@ func TestPoolerTLS(t *testing.T) {
 					ConnectionPoolerDefaultMemoryRequest: "100Mi",
 					ConnectionPoolerDefaultMemoryLimit:   "100Mi",
 				},
+				PodServiceAccountName: "postgres-pod",
 			},
 		}, client, pg, logger, eventRecorder)
 
@@ -1027,6 +1028,8 @@ func TestPoolerTLS(t *testing.T) {
 
 	fsGroup := int64(103)
 	assert.Equal(t, &fsGroup, deploy.Spec.Template.Spec.SecurityContext.FSGroup, "has a default FSGroup assigned")
+
+	assert.Equal(t, "postgres-pod", deploy.Spec.Template.Spec.ServiceAccountName, "need to add a service account name")
 
 	volume := v1.Volume{
 		Name: "my-secret",


### PR DESCRIPTION
Base on PR https://github.com/zalando/postgres-operator/pull/2255
Setting runAsUser directly is not allowed on, for example, Openshift.
So we should change the serviceaccount of the pooler to `postgres-pod` as well, otherwise the pooler will not be created correctly.

```
Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount]
```