### PR TITLE
[UI] revert index.html base url and provide USE_AWS_INSTANCE_PROFILE example

### DIFF
--- a/charts/postgres-operator-ui/templates/ingress.yaml
+++ b/charts/postgres-operator-ui/templates/ingress.yaml
@@ -44,7 +44,7 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             {{ if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion -}}
-            pathType: ImplementationSpecific
+            pathType: Prefix
             backend:
               service:
                 name: {{ $fullName }}

--- a/charts/postgres-operator-ui/values.yaml
+++ b/charts/postgres-operator-ui/values.yaml
@@ -82,6 +82,8 @@ extraEnvs:
   #       key: AWS_DEFAULT_REGION
   # - name: SPILO_S3_BACKUP_BUCKET
   #   value: <s3 bucket used by the operator>
+  # - name: "USE_AWS_INSTANCE_PROFILE"
+  #   value: "true"
 
 # configure UI service
 service:
@@ -102,8 +104,8 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   ingressClassName: ""
   hosts:
-    - host: ui.example.org
-      paths: [""]
+    - host: localhost
+      paths: ["/"]
   tls: []
   #  - secretName: ui-tls
   #    hosts:

--- a/charts/postgres-operator-ui/values.yaml
+++ b/charts/postgres-operator-ui/values.yaml
@@ -104,7 +104,7 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   ingressClassName: ""
   hosts:
-    - host: localhost
+    - host: ui.example.org
       paths: ["/"]
   tls: []
   #  - secretName: ui-tls

--- a/ui/manifests/deployment.yaml
+++ b/ui/manifests/deployment.yaml
@@ -101,3 +101,5 @@ spec:
             #       key: AWS_DEFAULT_REGION
             # - name: SPILO_S3_BACKUP_BUCKET
             #   value: <s3 bucket used by the operator>
+            # - name: "USE_AWS_INSTANCE_PROFILE"
+            #   value: "true"

--- a/ui/manifests/ingress.yaml
+++ b/ui/manifests/ingress.yaml
@@ -12,7 +12,7 @@ spec:
       http:
         paths:
           - path: /
-            pathType: ImplementationSpecific
+            pathType: Prefix
             backend:
               service:
                 name: "postgres-operator-ui"

--- a/ui/operator_ui/main.py
+++ b/ui/operator_ui/main.py
@@ -311,7 +311,7 @@ def send_js(path):
 @app.route('/')
 @authorize
 def index():
-    return render_template('index.html', google_analytics=GOOGLE_ANALYTICS, app_url=APP_URL)
+    return render_template('index.html', google_analytics=GOOGLE_ANALYTICS)
 
 
 DEFAULT_UI_CONFIG = {

--- a/ui/operator_ui/templates/index.html
+++ b/ui/operator_ui/templates/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <base href="{{app_url}}">
     <title>PostgreSQL Operator UI</title>
 
 


### PR DESCRIPTION
Attempts to fix breaking change introduced by #2195 to fix #2302.
APP_URL is only needed for authentication endpoints `/login` and `/logout`. The rest is relative paths. No need to set `<base href="{{app_url}}">` in UI's index.html.

I also noticed that the ingress spec differs from what we use. Changed the `pathType` to `Prefix` and `paths` to `["/"]`. Still people need to set an existing host.

This PR also adds an example for `USE_AWS_INSTANCE_PROFILE` which the UI supports but we forgot to expose it. Closes #2381