### PR TITLE
Name containerPorts in pods

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -658,14 +658,17 @@ func generateContainer(
 			{
 				ContainerPort: patroni.ApiPort,
 				Protocol:      v1.ProtocolTCP,
+				Name:          "patroni",
 			},
 			{
 				ContainerPort: pgPort,
 				Protocol:      v1.ProtocolTCP,
+				Name:          "postgresql",
 			},
 			{
 				ContainerPort: operatorPort,
 				Protocol:      v1.ProtocolTCP,
+				Name:          "operator",
 			},
 		},
 		VolumeMounts: volumeMounts,


### PR DESCRIPTION
This allows them to be used in prometheus serviceMonitor or podMonitor CRDs. Fixes https://github.com/zalando/postgres-operator/issues/2247

I am running this in `harbor.ntppool.org/library/postgres-operator:v1.10.0-13-gf3b94ace` 
