### PR TITLE
Document that `*` can be used for UI `TARGET_NAMESPACE` option

### DIFF
--- a/charts/postgres-operator-ui/values.yaml
+++ b/charts/postgres-operator-ui/values.yaml
@@ -45,6 +45,7 @@ envs:
   operatorApiUrl: "http://postgres-operator:8080"
   operatorClusterNameLabel: "cluster-name"
   resourcesVisible: "False"
+  # Set to "*" to allow viewing/creation of clusters in all namespaces
   targetNamespace: "default"
   teams:
     - "acid"

--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -1348,6 +1348,8 @@ You can also expose the operator API through a [service](https://github.com/zala
 Some displayed options can be disabled from UI using simple flags under the
 `OPERATOR_UI_CONFIG` field in the deployment.
 
+The viewing and creation of clusters within the UI is limited to the namespace specified by the `TARGET_NAMESPACE` option. To allow the creation and viewing of clusters in all namespaces, set `TARGET_NAMESPACE` to `*`.
+
 ### Deploy the UI on K8s
 
 Now, apply all manifests from the `ui/manifests` folder to deploy the Postgres

--- a/ui/manifests/deployment.yaml
+++ b/ui/manifests/deployment.yaml
@@ -45,6 +45,7 @@ spec:
             - name: "RESOURCES_VISIBLE"
               value: "False"
             - name: "TARGET_NAMESPACE"
+              # Set to "*" to allow viewing/creation of clusters in all namespaces
               value: "default"
             - name: "TEAMS"
               value: |-


### PR DESCRIPTION
Similar to `WATCHED_NAMESPACE` for the operator itself, `*` is a valid option for the UI. Without it clusters in multiple namespaces - rather, those not in the `TARGET_NAMESPACE` - will not show in the UI. Which can be confusing for users.

Mentioned in: https://github.com/zalando/postgres-operator/issues/1373