### PR TITLE
on PVC when_scaled:retain check pod count, too

### DIFF
--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -1254,11 +1254,13 @@ class EndToEndTestCase(unittest.TestCase):
         k8s.api.custom_objects_api.patch_namespaced_custom_object(
             'acid.zalan.do', 'v1', 'default', 'postgresqls', 'acid-minimal-cluster', pg_patch_scale_down_instances)
         self.eventuallyEqual(lambda: k8s.get_operator_state(), {"0": "idle"},"Operator does not get in sync")
+        self.eventuallyEqual(lambda: k8s.count_running_pods(), 1, "Scale down to 1 failed")
         self.eventuallyEqual(lambda: k8s.count_pvcs_with_label(cluster_label), 2, "PVCs is deleted when scaled down")
 
         k8s.api.custom_objects_api.patch_namespaced_custom_object(
             'acid.zalan.do', 'v1', 'default', 'postgresqls', 'acid-minimal-cluster', pg_patch_scale_up_instances)
         self.eventuallyEqual(lambda: k8s.get_operator_state(), {"0": "idle"},"Operator does not get in sync")
+        self.eventuallyEqual(lambda: k8s.count_running_pods(), 2, "Scale up to 2 failed")
         self.eventuallyEqual(lambda: k8s.count_pvcs_with_label(cluster_label), 2, "PVCs is not equal to number of instances")
 
     @timeout_decorator.timeout(TEST_TIMEOUT_SEC)

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -1260,7 +1260,7 @@ class EndToEndTestCase(unittest.TestCase):
         k8s.api.custom_objects_api.patch_namespaced_custom_object(
             'acid.zalan.do', 'v1', 'default', 'postgresqls', 'acid-minimal-cluster', pg_patch_scale_up_instances)
         self.eventuallyEqual(lambda: k8s.get_operator_state(), {"0": "idle"},"Operator does not get in sync")
-        self.eventuallyEqual(lambda: k8s.count_running_pods(), 2, "Scale up to 2 failed")
+        k8s.wait_for_pod_start('spilo-role=replica,' + cluster_label)
         self.eventuallyEqual(lambda: k8s.count_pvcs_with_label(cluster_label), 2, "PVCs is not equal to number of instances")
 
     @timeout_decorator.timeout(TEST_TIMEOUT_SEC)


### PR DESCRIPTION
With #2343 merged the e2e pipeline is not passing anymore. At the moment, I suspect that scaling down the cluster to one instance but only checking PVC count happens very quickly so that we run without replicas into the subsequent e2e test which leads to:

```
======================================================================
FAIL: test_resource_generation (test_e2e.EndToEndTestCase)
Lower resource limits below configured minimum and let operator fix it.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/timeout_decorator/timeout_decorator.py", line 82, in new_function
    return function(*args, **kwargs)
  File "/tests/test_e2e.py", line 1275, in test_resource_generation
    self.assertNotEqual(replica_nodes, [])
AssertionError: [] == []
```