### PR TITLE
ppc64le multiarch support

### DIFF
--- a/.github/workflows/publish_ghcr_image.yaml
+++ b/.github/workflows/publish_ghcr_image.yaml
@@ -53,4 +53,4 @@ jobs:
           push: true
           build-args: BASE_IMAGE=alpine:3.15
           tags: "${{ steps.image.outputs.NAME }}"
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le

--- a/docker/build_operator.sh
+++ b/docker/build_operator.sh
@@ -4,7 +4,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 arch=$(dpkg --print-architecture)
 if [ "$arch" = "ppc64el" ]; then
-    arch = "ppc64le"
+    arch="ppc64le"
 fi
 
 set -ex

--- a/docker/build_operator.sh
+++ b/docker/build_operator.sh
@@ -4,7 +4,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 arch=$(dpkg --print-architecture)
 if [ "$arch" = "ppc64el" ]; then
-    arch" = "ppc64le"
+    arch = "ppc64le"
 fi
 
 set -ex

--- a/docker/build_operator.sh
+++ b/docker/build_operator.sh
@@ -3,6 +3,9 @@
 export DEBIAN_FRONTEND=noninteractive
 
 arch=$(dpkg --print-architecture)
+if [ "$arch" = "ppc64el" ]; then
+    arch" = "ppc64le"
+fi
 
 set -ex
 


### PR DESCRIPTION
*The multiarch image build has been performed successfully (locally) in an Intel Ubuntu 22.04 container.
*A recent version of the image has been tested on a production ppc64le Openshift cluster.