### PR TITLE
Update logical backup environment variables for GCS

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -503,6 +503,8 @@ spec:
                   logical_backup_docker_image:
                     type: string
                     default: "registry.opensource.zalan.do/acid/logical-backup:v1.10.1"
+                  logical_backup_gs_bucket:
+                    type: string
                   logical_backup_google_application_credentials:
                     type: string
                   logical_backup_job_prefix:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -355,6 +355,9 @@ configLogicalBackup:
   logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.10.1"
   # path of google cloud service account json file
   # logical_backup_google_application_credentials: ""
+  # GS bucket to store backup results
+  # logical_backup_gs_bucket: "my-bucket-url"
+
 
   # prefix for the backup job name
   logical_backup_job_prefix: "logical-backup-"

--- a/docker/logical-backup/dump.sh
+++ b/docker/logical-backup/dump.sh
@@ -120,7 +120,7 @@ function aws_upload {
 }
 
 function gcs_upload {
-    PATH_TO_BACKUP=gs://$LOGICAL_BACKUP_S3_BUCKET"/spilo/"$SCOPE$LOGICAL_BACKUP_S3_BUCKET_SCOPE_SUFFIX"/logical_backups/"$(date +%s).sql.gz
+    PATH_TO_BACKUP=gs://$LOGICAL_BACKUP_GS_BUCKET"/spilo/"$SCOPE$LOGICAL_BACKUP_GS_BUCKET_SCOPE_SUFFIX"/logical_backups/"$(date +%s).sql.gz
 
     gsutil -o Credentials:gs_service_key_file=$LOGICAL_BACKUP_GOOGLE_APPLICATION_CREDENTIALS cp - "$PATH_TO_BACKUP"
 }

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -779,6 +779,10 @@ grouped under the `logical_backup` key.
 * **logical_backup_google_application_credentials**
   Specifies the path of the google cloud service account json file. Default is empty.
 
+* **logical_backup_gs_bucket**
+  GS bucket to store backup results. The bucket has to be present and
+  accessible by Postgres pods. Default: empty.
+
 * **logical_backup_job_prefix**
   The prefix to be prepended to the name of a k8s CronJob running the backups. Beware the prefix counts towards the name length restrictions imposed by k8s. Empty string is a legitimate value. Operator does not do the actual renaming: It simply creates the job with the new prefix. You will have to delete the old cron job manually. Default: "logical-backup-".
 

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2325,6 +2325,14 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 			Value: getBucketScopeSuffix(string(c.Postgresql.GetUID())),
 		},
 		{
+			Name:  "LOGICAL_BACKUP_GS_BUCKET",
+			Value: c.OpConfig.LogicalBackup.LogicalBackupGSBucket,
+		},
+		{
+			Name:  "LOGICAL_BACKUP_GS_BUCKET_SCOPE_SUFFIX",
+			Value: getBucketScopeSuffix(string(c.Postgresql.GetUID())),
+		},
+		{
 			Name:  "LOGICAL_BACKUP_GOOGLE_APPLICATION_CREDENTIALS",
 			Value: c.OpConfig.LogicalBackup.LogicalBackupGoogleApplicationCredentials,
 		},

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -138,6 +138,7 @@ type LogicalBackup struct {
 	LogicalBackupS3SecretAccessKey            string `name:"logical_backup_s3_secret_access_key" default:""`
 	LogicalBackupS3SSE                        string `name:"logical_backup_s3_sse" default:""`
 	LogicalBackupS3RetentionTime              string `name:"logical_backup_s3_retention_time" default:""`
+	LogicalBackupGSBucket                     string `name:"logical_backup_gs_bucket" default:""`
 	LogicalBackupGoogleApplicationCredentials string `name:"logical_backup_google_application_credentials" default:""`
 	LogicalBackupJobPrefix                    string `name:"logical_backup_job_prefix" default:"logical-backup-"`
 	LogicalBackupCPURequest                   string `name:"logical_backup_cpu_request"`


### PR DESCRIPTION
Per #1838 break GCS logical backup bucket environment variable into its own variable "LOGICAL_BACKUP_GS_BUCKET" (currently using LOGICAL_BACKUP_S3_BUCKET).

While here, update dump.sh to utilize the new GCS logical backup environment variable and document where required.

I looked at cloning aws_delete_outdated in dump.sh as well, but given gsutil doesn't currently have a mechanism for easily listing files older than a given cutoff date, I felt it better to defer on this.  Suggestions welcome for implementing gcs_delete_outdated in dump.sh if there is sufficient interest.