### PR TITLE
Populating crd labels and annotations in logical backup job pod manifest

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2192,10 +2192,11 @@ func (c *Cluster) generateLogicalBackupJob() (*batchv1.CronJob, error) {
 		nil,
 	)
 
-	labels := map[string]string{
-		c.OpConfig.ClusterNameLabel: c.Name,
-		"application":               "spilo-logical-backup",
+	logicalBackupJobLabel := map[string]string{
+		"application": "spilo-logical-backup",
 	}
+
+	labels := labels.Merge(c.labelsSet(true), logicalBackupJobLabel)
 
 	nodeAffinity := c.nodeAffinity(c.OpConfig.NodeReadinessLabel, nil)
 	podAffinity := podAffinity(

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2213,7 +2213,7 @@ func (c *Cluster) generateLogicalBackupJob() (*batchv1.CronJob, error) {
 	if podTemplate, err = c.generatePodTemplate(
 		c.Namespace,
 		labels,
-		annotations,
+		c.annotationsSet(annotations),
 		logicalBackupContainer,
 		[]v1.Container{},
 		[]v1.Container{},


### PR DESCRIPTION
Hello, 

Fixing https://github.com/zalando/postgres-operator/issues/1834

1. Making sure InheritedLabels set in operator settings / cluster settings are added to backup job pod manifest.
2. Making sure InheritedAnnotations set in operator settings / cluster setting are added to backup job pod manifest.

The goal is to see backup job resources in ArgoCD.  