### PR TITLE
Add Pod Service Account Annotation update option

### DIFF
--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -128,6 +128,7 @@ data:
   # pod_priority_class_name: "postgres-pod-priority"
   pod_role_label: spilo-role
   # pod_service_account_definition: ""
+  # pod_service_account_annotation_per_cluster: "eks.amazonaws.com/role-arn"
   pod_service_account_name: "postgres-pod"
   # pod_service_account_role_binding_definition: ""
   pod_terminate_grace_period: 5m

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -178,6 +178,7 @@ type Config struct {
 	PodServiceAccountName   string            `name:"pod_service_account_name" default:"postgres-pod"`
 	// value of this string must be valid JSON or YAML; see initPodServiceAccount
 	PodServiceAccountDefinition              string            `name:"pod_service_account_definition" default:""`
+	PodServiceAccountAnnotationPerCluster    []string          `name:"pod_service_account_annotation_per_cluster" default:""`
 	PodServiceAccountRoleBindingDefinition   string            `name:"pod_service_account_role_binding_definition" default:""`
 	MasterPodMoveTimeout                     time.Duration     `name:"master_pod_move_timeout" default:"20m"`
 	DbHostedZone                             string            `name:"db_hosted_zone" default:"db.example.com"`


### PR DESCRIPTION
Adding option to specify list of annotation keys, for example: `eks.amazonaws.com/role-arn` - that will be appended with the cluster name. It will allow to use unique IAM Role per cluster.

To fix: https://github.com/zalando/postgres-operator/issues/2459