### PR TITLE
Enable specifying sidecars via chart

### DIFF
--- a/charts/postgres-operator/templates/configmap.yaml
+++ b/charts/postgres-operator/templates/configmap.yaml
@@ -27,4 +27,5 @@ data:
 {{- include "flattenValuesForConfigMap" .Values.configTeamsApi | indent 2 }}
 {{- include "flattenValuesForConfigMap" .Values.configConnectionPooler | indent 2 }}
 {{- include "flattenValuesForConfigMap" .Values.configPatroni | indent 2 }}
+{{- include "flattenValuesForConfigMap" .Values.configSidecars | indent 2 }}
 {{- end }}

--- a/charts/postgres-operator/templates/operatorconfiguration.yaml
+++ b/charts/postgres-operator/templates/operatorconfiguration.yaml
@@ -42,4 +42,6 @@ configuration:
 {{ toYaml .Values.configConnectionPooler | indent 4 }}
   patroni:
 {{ toYaml .Values.configPatroni | indent 4 }}
+  sidecars:
+{{ toYaml .Values.configSidecars | indent 4 }}
 {{- end }}

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -437,6 +437,26 @@ configPatroni:
   # enable Patroni DCS failsafe_mode feature
   enable_patroni_failsafe_mode: false
 
+# Specifies a list of sidecars to include in all deployments
+configSidecars: {}
+  # - name: exporter
+  #   image: quay.io/prometheuscommunity/postgres-exporter
+  #   ports:
+  #   - name: exporter
+  #     containerPort: 9187
+  #     protocol: TCP
+  #   resources:
+  #     requests:
+  #       cpu: 50m
+  #       memory: 200M
+  #   env:
+  #   - name: "DATA_SOURCE_URI"
+  #     value: "$(POD_NAME)/postgres?sslmode=disable"
+  #   - name: "DATA_SOURCE_USER"
+  #     value: "$(POSTGRES_USER)"
+  #   - name: "DATA_SOURCE_PASS"
+  #     value: "$(POSTGRES_PASSWORD)"
+
 # Zalando's internal CDC stream feature
 enableStreams: false
 


### PR DESCRIPTION
Provide a way for Helm users to specify default sidecars in the Operator Configuration.

Documentation on the topic:
* https://github.com/zalando/postgres-operator/blob/master/docs/reference/operator_parameters.md#general (see "sidecars").
* https://github.com/zalando/postgres-operator/blob/409e4c78344f397d2c771129bcfb6968f84c1972/docs/administrator.md#sidecars-for-postgres-clusters

