### PR TITLE
Feat: support priorityClassName for pooler pods

### DIFF
--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -148,6 +148,8 @@ spec:
                   numberOfInstances:
                     type: integer
                     minimum: 1
+                  priorityClassName:
+                    type: string
                   resources:
                     type: object
                     properties:

--- a/manifests/complete-postgres-manifest.yaml
+++ b/manifests/complete-postgres-manifest.yaml
@@ -158,6 +158,7 @@ spec:
 #    schema: "pooler"
 #    user: "pooler"
 #    maxDBConnections: 60
+#    priorityClassName: ""
 #    resources:
 #      requests:
 #        cpu: 300m

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -23,6 +23,7 @@ data:
   # connection_pooler_number_of_instances: 2
   # connection_pooler_schema: "pooler"
   # connection_pooler_user: "pooler"
+  # connection_pooler_priority_class_name: ""
   crd_categories: "all"
   # custom_service_annotations: "keyx:valuez,keya:valuea"
   # custom_pod_annotations: "keya:valuea,keyb:valueb"

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -146,6 +146,8 @@ spec:
                   numberOfInstances:
                     type: integer
                     minimum: 1
+                  priorityClassName:
+                    type: string
                   resources:
                     type: object
                     properties:

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -237,6 +237,10 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 								Type:    "integer",
 								Minimum: &min1,
 							},
+
+							"priorityClassName": {
+								Type: "string",
+							},
 							"resources": {
 								Type: "object",
 								Properties: map[string]apiextv1.JSONSchemaProps{

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -214,6 +214,7 @@ type ConnectionPoolerConfiguration struct {
 	DefaultMemoryRequest string `json:"connection_pooler_default_memory_request,omitempty"`
 	DefaultCPULimit      string `json:"connection_pooler_default_cpu_limit,omitempty"`
 	DefaultMemoryLimit   string `json:"connection_pooler_default_memory_limit,omitempty"`
+	PriorityClassName    string `json:"connection_pooler_priority_class_name,omitempty"`
 }
 
 // OperatorLogicalBackupConfiguration defines configuration for logical backup

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -241,6 +241,7 @@ type ConnectionPooler struct {
 	Mode              string `json:"mode,omitempty"`
 	DockerImage       string `json:"dockerImage,omitempty"`
 	MaxDBConnections  *int32 `json:"maxDBConnections,omitempty"`
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 
 	*Resources `json:"resources,omitempty"`
 }

--- a/pkg/cluster/connection_pooler.go
+++ b/pkg/cluster/connection_pooler.go
@@ -394,6 +394,10 @@ func (c *Cluster) generateConnectionPoolerPodTemplate(role PostgresRole) (
 		securityContext.FSGroup = effectiveFSGroup
 	}
 
+	effectivePriorityClassName := util.Coalesce(
+		connectionPoolerSpec.PriorityClassName,
+		c.OpConfig.ConnectionPooler.ConnectionPoolerPriorityClassName)
+
 	podTemplate := &v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      c.connectionPoolerLabels(role, true).MatchLabels,
@@ -407,6 +411,7 @@ func (c *Cluster) generateConnectionPoolerPodTemplate(role PostgresRole) (
 			Volumes:                       poolerVolumes,
 			SecurityContext:               &securityContext,
 			ServiceAccountName:            c.OpConfig.PodServiceAccountName,
+			PriorityClassName:             effectivePriorityClassName,
 		},
 	}
 

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -282,5 +282,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 		fromCRD.ConnectionPooler.MaxDBConnections,
 		k8sutil.Int32ToPointer(constants.ConnectionPoolerMaxDBConnections))
 
+	result.ConnectionPooler.ConnectionPoolerPriorityClassName = fromCRD.ConnectionPooler.PriorityClassName
+
 	return result
 }

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -158,6 +158,7 @@ type ConnectionPooler struct {
 	ConnectionPoolerDefaultMemoryRequest string `name:"connection_pooler_default_memory_request" default:"100Mi"`
 	ConnectionPoolerDefaultCPULimit      string `name:"connection_pooler_default_cpu_limit" default:"1"`
 	ConnectionPoolerDefaultMemoryLimit   string `name:"connection_pooler_default_memory_limit" default:"100Mi"`
+	ConnectionPoolerPriorityClassName    string `name:"connection_pooler_priority_class_name"`
 }
 
 // Config describes operator config


### PR DESCRIPTION
Hello,

To solve this issue https://github.com/zalando/postgres-operator/issues/2496, I present this solution. 
The objective is to add the priorityClassName for the poolers with two options : a default priorityClassName can be defined in the operator config or a specific one can be defined in a postgres cluster manifest.
It has been tested through the minikube script avaible on the repository.


