### PR TITLE
Feat: add flags for podPriorityClassName to support external priorityclasses

### DIFF
--- a/charts/postgres-operator/templates/_helpers.tpl
+++ b/charts/postgres-operator/templates/_helpers.tpl
@@ -39,6 +39,13 @@ Create a pod service account name.
 {{- end -}}
 
 {{/*
+Create a pod priority class name.
+*/}}
+{{- define "postgres-pod.priorityClassName" -}}
+{{ default (printf "%s-%v" (include "postgres-operator.fullname" .) "pod") .Values.podPriorityClassName.name }}
+{{- end -}}
+
+{{/*
 Create a controller ID.
 */}}
 {{- define "postgres-operator.controllerID" -}}

--- a/charts/postgres-operator/templates/configmap.yaml
+++ b/charts/postgres-operator/templates/configmap.yaml
@@ -10,9 +10,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 data:
-  {{- if .Values.podPriorityClassName }}
-  pod_priority_class_name: {{ .Values.podPriorityClassName }}
-  {{- end }}
+{{- if or .Values.podPriorityClassName.create .Values.podPriorityClassName.name }}
+  pod_priority_class_name: {{ include "postgres-pod.priorityClassName" . }}
+{{- end }}
   pod_service_account_name: {{ include "postgres-pod.serviceAccountName" . }}
 {{- include "flattenValuesForConfigMap" .Values.configGeneral | indent 2 }}
 {{- include "flattenValuesForConfigMap" .Values.configUsers | indent 2 }}

--- a/charts/postgres-operator/templates/operatorconfiguration.yaml
+++ b/charts/postgres-operator/templates/operatorconfiguration.yaml
@@ -16,8 +16,8 @@ configuration:
   major_version_upgrade:
 {{ toYaml .Values.configMajorVersionUpgrade | indent 4 }}
   kubernetes:
-    {{- if .Values.podPriorityClassName }}
-    pod_priority_class_name: {{ .Values.podPriorityClassName }}
+    {{- if .Values.podPriorityClassName.name }}
+    pod_priority_class_name: {{ .Values.podPriorityClassName.name }}
     {{- end }}
     pod_service_account_name: {{ include "postgres-pod.serviceAccountName" . }}
     oauth_token_secret_name: {{ template "postgres-operator.fullname" . }}

--- a/charts/postgres-operator/templates/postgres-pod-priority-class.yaml
+++ b/charts/postgres-operator/templates/postgres-pod-priority-class.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podPriorityClassName }}
+{{- if .Values.podPriorityClassName.create }}
 apiVersion: scheduling.k8s.io/v1
 description: 'Use only for databases controlled by Postgres operator'
 kind: PriorityClass
@@ -8,9 +8,9 @@ metadata:
     helm.sh/chart: {{ template "postgres-operator.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-  name: {{ .Values.podPriorityClassName }}
+  name: {{ include "postgres-pod.priorityClassName" . }}
   namespace: {{ .Release.Namespace }}
 preemptionPolicy: PreemptLowerPriority
 globalDefault: false
-value: 1000000
+value: {{ .Values.podPriorityClassName.priority }}
 {{- end }}

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -468,7 +468,14 @@ podServiceAccount:
 priorityClassName: ""
 
 # priority class for database pods
-podPriorityClassName: ""
+podPriorityClassName:
+  # If create is false with no name set, no podPriorityClassName is specified.
+  # Hence, the pod priorityClass is the one with globalDefault set. 
+  # If there is no PriorityClass with globalDefault set, the priority of Pods with no priorityClassName is zero.
+  create: true
+  # If not set a name is generated using the fullname template and "-pod" suffix
+  name: ""
+  priority: 1000000
 
 resources:
   limits:


### PR DESCRIPTION
Hello,

To solve this issue https://github.com/zalando/postgres-operator/issues/2441, I present a possible solution by adding flags to create the PriorityClass (or not) and to set the priority. In case of a use of an external priorityclass, only the name should be set.
