### PR TITLE
chore: add "macedigital" as codeowner & maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # global owners
-*        @sdudoladov @Jan-M @FxKu @jopadi @idanovinda @hughcapet
+*        @sdudoladov @Jan-M @FxKu @jopadi @idanovinda @hughcapet @macedigital

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -4,3 +4,4 @@ Jan Mussler <jan.mussler@zalando.de>
 Jociele Padilha <jociele.padilha@zalando.de>
 Ida Novindasari <ida.novindasari@zalando.de>
 Polina Bungina <polina.bungina@zalando.de>
+Matthias Adler <matthias.adler@zalando.de>


### PR DESCRIPTION
Add 'macedigital' to `CODEOWNERS` and `MAINTAINERS` files

## Problem description

I cannot contribute to the codebase nor to the project in a meaningful way at the moment.

Merging this PR should enable me to get notified on new issues and pull-requests for maintaining the project.

## Checklist

Thanks for submitting a pull request to the Postgres Operator project.
Please, ensure your contribution matches the following items:

- [x] You have checked existing open PRs for possible overlay and referenced them.
