### PR TITLE
adding finalizer option in all manifests and rework its docs

### DIFF
--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -333,11 +333,16 @@ configuration they are grouped under the `kubernetes` key.
   will not add the `spilo-role=master` selector to the PDB.
 
 * **enable_finalizers**
-  By default, a deletion of the Postgresql resource will trigger a cleanup of
-  all child resources. However, if the database cluster is in a broken state
-  (e.g. failed initialization) and the operator cannot fully sync it, there can
-  be leftovers from a DELETE event. By enabling finalizers the Operator will
-  ensure all managed resources are deleted prior to the Postgresql resource.
+  By default, a deletion of the Postgresql resource will trigger an event
+  that leads to a cleanup of all child resources. However, if the database
+  cluster is in a broken state (e.g. failed initialization) and the operator
+  cannot fully sync it, there can be leftovers. By enabling finalizers the
+  operator will ensure all managed resources are deleted prior to the
+  Postgresql resource. There is a trade-off though: The deletion is only
+  performed at the next cluster SYNC cycle when finding a `deletionTimestamp`
+  in the metadata and not immediately after issueing a delete command. The
+  final removal of the custom resource will add a DELETE event to the worker
+  queue but the child resources are already gone at this point.
   The default is `false`.
 
 * **enable_pod_disruption_budget**

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.42.18
-	github.com/evanphx/json-patch v4.12.0+incompatible
 	github.com/golang/mock v1.6.0
 	github.com/lib/pq v1.10.4
 	github.com/motomux/pretty v0.0.0-20161209205251-b2aad2c9a95d
@@ -27,6 +26,7 @@ require (
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -39,6 +39,7 @@ data:
   # enable_admin_role_for_users: "true"
   # enable_crd_registration: "true"
   # enable_cross_namespace_secret: "false"
+  enable_finalizers: "false"
   # enable_database_access: "true"
   enable_ebs_gp3_migration: "false"
   # enable_ebs_gp3_migration_max_size: "1000"

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -203,6 +203,9 @@ spec:
                   enable_cross_namespace_secret:
                     type: boolean
                     default: false
+                  enable_finalizers:
+                    type: boolean
+                    default: false
                   enable_init_containers:
                     type: boolean
                     default: true

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -57,6 +57,7 @@ configuration:
     # - deployment-time
     # - downscaler/*
     # enable_cross_namespace_secret: "false"
+    enable_finalizers: false
     enable_init_containers: true
     enable_pod_antiaffinity: false
     enable_pod_disruption_budget: true

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1305,6 +1305,9 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 							"enable_cross_namespace_secret": {
 								Type: "boolean",
 							},
+							"enable_finalizers": {
+								Type: "boolean",
+							},
 							"enable_init_containers": {
 								Type: "boolean",
 							},


### PR DESCRIPTION
The `enable_finalizers` option added in #941 was still missing in the example manifests. I also felt I had to add two more sentences to its docs.