### PR TITLE
allow users to opt out from globally enabled secret rotation

### DIFF
--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -612,6 +612,11 @@ spec:
                     - SUPERUSER
                     - nosuperuser
                     - NOSUPERUSER
+              usersIgnoringSecretRotation:
+                type: array
+                nullable: true
+                items:
+                  type: string
               usersWithInPlaceSecretRotation:
                 type: array
                 nullable: true

--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -355,6 +355,23 @@ This would be the recommended option to enable rotation in secrets of database
 owners, but only if they are not used as application users for regular read
 and write operations.
 
+### Ignore rotation for certain users
+
+If you wish to globally enable password rotation but need certain users to
+opt out from it there are two ways. First, you can remove the user from the
+manifest's `users` section. The corresponding secret to this user will no
+longer be synced by the operator then.
+
+Secondly, if you want the operator to continue syncing the secret (e.g. to
+recreate if it got accidentally removed) but cannot allow it being rotated,
+add the user to the following list in your manifest:
+
+```
+spec:
+  usersIgnoringSecretRotation:
+  - bar_user
+```
+
 ### Turning off password rotation
 
 When password rotation is turned off again the operator will check if the

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -142,6 +142,14 @@ These parameters are grouped directly under  the `spec` key in the manifest.
   database, like a flyway user running a migration on Pod start. See more
   details in the [administrator docs](https://github.com/zalando/postgres-operator/blob/master/docs/administrator.md#password-replacement-without-extra-users).
 
+* **usersIgnoringSecretRotation**
+  if you have secret rotation enabled globally you can define a list of
+  of users that should opt out from it, for example if you store credentials
+  outside of K8s, too, and corresponding deployments cannot dynamically
+  reference secrets. Note, you can also opt out from the rotation by removing
+  users from the manifest's `users` section. The operator will not drop them
+  from the database. Optional.
+
 * **databases**
   a map of database names to database owners for the databases that should be
   created by the operator. The owner users should already exist on the cluster

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -1679,7 +1679,7 @@ class EndToEndTestCase(unittest.TestCase):
             "Could not connect to the database with rotation user {}".format(rotation_user), 10, 5)
 
         # check if rotation has been ignored for user from test_cross_namespace_secrets test
-        db_user_secret = k8s.get_secret(username="db_user", namepsace="test")
+        db_user_secret = k8s.get_secret(username="db_user", namespace="test")
         secret_username = str(base64.b64decode(db_user_secret.data["username"]), 'utf-8')
 
         self.assertEqual("test.db_user", secret_username,

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -1679,7 +1679,7 @@ class EndToEndTestCase(unittest.TestCase):
             "Could not connect to the database with rotation user {}".format(rotation_user), 10, 5)
 
         # check if rotation has been ignored for user from test_cross_namespace_secrets test
-        db_user_secret = k8s.get_secret(username="db_user", namespace="test")
+        db_user_secret = k8s.get_secret(username="test.db_user", namespace="test")
         secret_username = str(base64.b64decode(db_user_secret.data["username"]), 'utf-8')
 
         self.assertEqual("test.db_user", secret_username,

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -1581,7 +1581,7 @@ class EndToEndTestCase(unittest.TestCase):
         pg_patch_rotation_single_users = {
             "spec": {
                 "usersIgnoringSecretRotation": [
-                    "bar_user"
+                    "test.db_user"
                 ],
                 "usersWithInPlaceSecretRotation": [
                     "zalando"
@@ -1678,12 +1678,12 @@ class EndToEndTestCase(unittest.TestCase):
         self.eventuallyEqual(lambda: len(self.query_database_with_user(leader.metadata.name, "postgres", "SELECT 1", "foo_user")), 1,
             "Could not connect to the database with rotation user {}".format(rotation_user), 10, 5)
 
-        # check if rotation has been ignored for prepared bar_user
-        bar_user_secret = k8s.get_secret("bar_user")
-        secret_username = str(base64.b64decode(bar_user_secret.data["username"]), 'utf-8')
+        # check if rotation has been ignored for user from test_cross_namespace_secrets test
+        db_user_secret = k8s.get_secret(username="db_user", namepsace="test")
+        secret_username = str(base64.b64decode(db_user_secret.data["username"]), 'utf-8')
 
-        self.assertEqual("bar_user", secret_username,
-                        "Unexpected username in secret of bar_user: expected {}, got {}".format("bar_user", secret_username))
+        self.assertEqual("test.db_user", secret_username,
+                        "Unexpected username in secret of test.db_user: expected {}, got {}".format("test.db_user", secret_username))
 
         # disable password rotation for all other users (foo_user)
         # and pick smaller intervals to see if the third fake rotation user is dropped 

--- a/manifests/complete-postgres-manifest.yaml
+++ b/manifests/complete-postgres-manifest.yaml
@@ -19,6 +19,8 @@ spec:
     - createdb
     foo_user: []
 #    flyway: []
+#  usersIgnoringSecretRotation:
+#  - bar_user
 #  usersWithSecretRotation:
 #  - foo_user
 #  usersWithInPlaceSecretRotation:

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -610,6 +610,11 @@ spec:
                     - SUPERUSER
                     - nosuperuser
                     - NOSUPERUSER
+              usersIgnoringSecretRotation:
+                type: array
+                nullable: true
+                items:
+                  type: string
               usersWithInPlaceSecretRotation:
                 type: array
                 nullable: true

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -996,6 +996,15 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 							},
 						},
 					},
+					"usersIgnoringSecretRotation": {
+						Type:     "array",
+						Nullable: true,
+						Items: &apiextv1.JSONSchemaPropsOrArray{
+							Schema: &apiextv1.JSONSchemaProps{
+								Type: "string",
+							},
+						},
+					},
 					"usersWithInPlaceSecretRotation": {
 						Type:     "array",
 						Nullable: true,

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -59,6 +59,7 @@ type PostgresSpec struct {
 	AllowedSourceRanges []string `json:"allowedSourceRanges"`
 
 	Users                          map[string]UserFlags `json:"users,omitempty"`
+	UsersIgnoringSecretRotation    []string             `json:"usersIgnoringSecretRotation,omitempty"`
 	UsersWithSecretRotation        []string             `json:"usersWithSecretRotation,omitempty"`
 	UsersWithInPlaceSecretRotation []string             `json:"usersWithInPlaceSecretRotation,omitempty"`
 

--- a/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
@@ -718,6 +718,11 @@ func (in *PostgresSpec) DeepCopyInto(out *PostgresSpec) {
 			(*out)[key] = outVal
 		}
 	}
+	if in.UsersIgnoringSecretRotation != nil {
+		in, out := &in.UsersIgnoringSecretRotation, &out.UsersIgnoringSecretRotation
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.UsersWithSecretRotation != nil {
 		in, out := &in.UsersWithSecretRotation, &out.UsersWithSecretRotation
 		*out = make([]string, len(*in))


### PR DESCRIPTION
closes #1994

Introducing another slice to define users that should be ignored from secret rotation when it's globally enabled.