### PR TITLE
bump pooler image to pgBouncer 1.22.0

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -655,7 +655,7 @@ spec:
                     default: "pooler"
                   connection_pooler_image:
                     type: string
-                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-27"
+                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-32"
                   connection_pooler_max_db_connections:
                     type: integer
                     default: 60

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -426,7 +426,7 @@ configConnectionPooler:
   # db user for pooler to use
   connection_pooler_user: "pooler"
   # docker image
-  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-27"
+  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-32"
   # max db connections the pooler should hold
   connection_pooler_max_db_connections: 60
   # default pooling mode

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -17,7 +17,7 @@ data:
   # connection_pooler_default_cpu_request: "500m"
   # connection_pooler_default_memory_limit: 100Mi
   # connection_pooler_default_memory_request: 100Mi
-  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-27"
+  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-32"
   # connection_pooler_max_db_connections: 60
   # connection_pooler_mode: "transaction"
   # connection_pooler_number_of_instances: 2

--- a/manifests/minimal-fake-pooler-deployment.yaml
+++ b/manifests/minimal-fake-pooler-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: postgres-operator
       containers:
       - name: postgres-operator
-        image: registry.opensource.zalan.do/acid/pgbouncer:master-27
+        image: registry.opensource.zalan.do/acid/pgbouncer:master-32
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -653,7 +653,7 @@ spec:
                     default: "pooler"
                   connection_pooler_image:
                     type: string
-                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-27"
+                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-32"
                   connection_pooler_max_db_connections:
                     type: integer
                     default: 60

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -208,7 +208,7 @@ configuration:
     connection_pooler_default_cpu_request: "500m"
     connection_pooler_default_memory_limit: 100Mi
     connection_pooler_default_memory_request: 100Mi
-    connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-27"
+    connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-32"
     # connection_pooler_max_db_connections: 60
     connection_pooler_mode: "transaction"
     connection_pooler_number_of_instances: 2


### PR DESCRIPTION
closes #2516

Bumps pgBouncer not only to 1.21.0 but to the latest 1.22.0.