### PR TITLE
replace deprecated ioutil

### DIFF
--- a/kubectl-pg/cmd/create.go
+++ b/kubectl-pg/cmd/create.go
@@ -25,8 +25,8 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 	v1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
@@ -56,7 +56,7 @@ func create(fileName string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	ymlFile, err := ioutil.ReadFile(fileName)
+	ymlFile, err := os.ReadFile(fileName)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/kubectl-pg/cmd/delete.go
+++ b/kubectl-pg/cmd/delete.go
@@ -25,8 +25,8 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 	v1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
@@ -77,7 +77,7 @@ func deleteByFile(file string) {
 		log.Fatal(err)
 	}
 
-	ymlFile, err := ioutil.ReadFile(file)
+	ymlFile, err := os.ReadFile(file)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/kubectl-pg/cmd/update.go
+++ b/kubectl-pg/cmd/update.go
@@ -25,8 +25,8 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 	v1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
@@ -60,7 +60,7 @@ func updatePgResources(fileName string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	ymlFile, err := ioutil.ReadFile(fileName)
+	ymlFile, err := os.ReadFile(fileName)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/cluster/pod_test.go
+++ b/pkg/cluster/pod_test.go
@@ -3,7 +3,7 @@ package cluster
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -86,7 +86,7 @@ func TestGetSwitchoverCandidate(t *testing.T) {
 
 	for _, tt := range tests {
 		// mocking cluster members
-		r := ioutil.NopCloser(bytes.NewReader([]byte(tt.clusterJson)))
+		r := io.NopCloser(bytes.NewReader([]byte(tt.clusterJson)))
 
 		response := http.Response{
 			StatusCode: 200,

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -3,7 +3,7 @@ package cluster
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -201,7 +201,7 @@ func TestCheckAndSetGlobalPostgreSQLConfiguration(t *testing.T) {
 
 	// mocking a config after setConfig is called
 	configJson := `{"postgresql": {"parameters": {"log_min_duration_statement": 200, "max_connections": 50}}}, "ttl": 20}`
-	r := ioutil.NopCloser(bytes.NewReader([]byte(configJson)))
+	r := io.NopCloser(bytes.NewReader([]byte(configJson)))
 
 	response := http.Response{
 		StatusCode: 200,
@@ -531,7 +531,7 @@ func TestSyncStandbyClusterConfiguration(t *testing.T) {
 	// mocking a config after getConfig is called
 	mockClient := mocks.NewMockHTTPClient(ctrl)
 	configJson := `{"ttl": 20}`
-	r := ioutil.NopCloser(bytes.NewReader([]byte(configJson)))
+	r := io.NopCloser(bytes.NewReader([]byte(configJson)))
 	response := http.Response{
 		StatusCode: 200,
 		Body:       r,
@@ -540,7 +540,7 @@ func TestSyncStandbyClusterConfiguration(t *testing.T) {
 
 	// mocking a config after setConfig is called
 	standbyJson := `{"standby_cluster":{"create_replica_methods":["bootstrap_standby_with_wale","basebackup_fast_xlog"],"restore_command":"envdir \"/run/etc/wal-e.d/env-standby\" /scripts/restore_command.sh \"%f\" \"%p\""}}`
-	r = ioutil.NopCloser(bytes.NewReader([]byte(standbyJson)))
+	r = io.NopCloser(bytes.NewReader([]byte(standbyJson)))
 	response = http.Response{
 		StatusCode: 200,
 		Body:       r,
@@ -582,7 +582,7 @@ func TestSyncStandbyClusterConfiguration(t *testing.T) {
 	assert.NoError(t, err)
 
 	configJson = `{"standby_cluster":{"create_replica_methods":["bootstrap_standby_with_wale","basebackup_fast_xlog"],"restore_command":"envdir \"/run/etc/wal-e.d/env-standby\" /scripts/restore_command.sh \"%f\" \"%p\""}, "ttl": 20}`
-	r = ioutil.NopCloser(bytes.NewReader([]byte(configJson)))
+	r = io.NopCloser(bytes.NewReader([]byte(configJson)))
 	response = http.Response{
 		StatusCode: 200,
 		Body:       r,

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -210,7 +209,7 @@ func GetOperatorNamespace() string {
 		if namespaceFromEnvironment := os.Getenv("OPERATOR_NAMESPACE"); namespaceFromEnvironment != "" {
 			return namespaceFromEnvironment
 		}
-		operatorNamespaceBytes, err := ioutil.ReadFile(fileWithNamespace)
+		operatorNamespaceBytes, err := os.ReadFile(fileWithNamespace)
 		if err != nil {
 			log.Fatalf("Unable to detect operator namespace from within its pod due to: %v", err)
 		}

--- a/pkg/util/patroni/patroni.go
+++ b/pkg/util/patroni/patroni.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net"
 	"net/http"
@@ -104,7 +104,7 @@ func (p *Patroni) httpPostOrPatch(method string, url string, body *bytes.Buffer)
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("could not read response: %v", err)
 		}
@@ -123,7 +123,7 @@ func (p *Patroni) httpGet(url string) (string, error) {
 	}
 	defer response.Body.Close()
 
-	bodyBytes, err := ioutil.ReadAll(response.Body)
+	bodyBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", fmt.Errorf("could not read response: %v", err)
 	}

--- a/pkg/util/patroni/patroni_test.go
+++ b/pkg/util/patroni/patroni_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"reflect"
@@ -122,7 +122,7 @@ func TestGetClusterMembers(t *testing.T) {
 		{"name": "acid-test-cluster-2", "role": "replica", "state": "running", "api_url": "http://192.168.100.3:8008/patroni", "host": "192.168.100.3", "port": 5432, "timeline": 1, "lag": "unknown"},
 		{"name": "acid-test-cluster-3", "role": "replica", "state": "running", "api_url": "http://192.168.100.3:8008/patroni", "host": "192.168.100.3", "port": 5432, "timeline": 1, "lag": 3000000000}
 		]}`
-	r := ioutil.NopCloser(bytes.NewReader([]byte(json)))
+	r := io.NopCloser(bytes.NewReader([]byte(json)))
 
 	response := http.Response{
 		StatusCode: 200,
@@ -161,7 +161,7 @@ func TestGetMemberData(t *testing.T) {
 	}
 
 	json := `{"state": "running", "postmaster_start_time": "2021-02-19 14:31:50.053 CET", "role": "master", "server_version": 130004, "cluster_unlocked": false, "xlog": {"location": 123456789}, "timeline": 1, "database_system_identifier": "6462555844314089962", "pending_restart": true, "patroni": {"version": "2.1.1", "scope": "acid-test-cluster"}}`
-	r := ioutil.NopCloser(bytes.NewReader([]byte(json)))
+	r := io.NopCloser(bytes.NewReader([]byte(json)))
 
 	response := http.Response{
 		StatusCode: 200,
@@ -230,7 +230,7 @@ func TestGetConfig(t *testing.T) {
 	}
 
 	configJson := `{"loop_wait": 10, "maximum_lag_on_failover": 33554432, "postgresql": {"parameters": {"archive_mode": "on", "archive_timeout": "1800s", "autovacuum_analyze_scale_factor": 0.02, "autovacuum_max_workers": 5, "autovacuum_vacuum_scale_factor": 0.05, "checkpoint_completion_target": 0.9, "hot_standby": "on", "log_autovacuum_min_duration": 0, "log_checkpoints": "on", "log_connections": "on", "log_disconnections": "on", "log_line_prefix": "%t [%p]: [%l-1] %c %x %d %u %a %h ", "log_lock_waits": "on", "log_min_duration_statement": 500, "log_statement": "ddl", "log_temp_files": 0, "max_connections": 100, "max_replication_slots": 10, "max_wal_senders": 10, "tcp_keepalives_idle": 900, "tcp_keepalives_interval": 100, "track_functions": "all", "wal_level": "hot_standby", "wal_log_hints": "on"}, "use_pg_rewind": true, "use_slots": true}, "retry_timeout": 10, "slots": {"cdc": {"database": "foo", "plugin": "pgoutput", "type": "logical"}}, "ttl": 30}`
-	r := ioutil.NopCloser(bytes.NewReader([]byte(configJson)))
+	r := io.NopCloser(bytes.NewReader([]byte(configJson)))
 
 	response := http.Response{
 		StatusCode: 200,
@@ -265,7 +265,7 @@ func TestSetPostgresParameters(t *testing.T) {
 	}
 
 	configJson := `{"loop_wait": 10, "maximum_lag_on_failover": 33554432, "postgresql": {"parameters": {"archive_mode": "on", "archive_timeout": "1800s", "autovacuum_analyze_scale_factor": 0.02, "autovacuum_max_workers": 5, "autovacuum_vacuum_scale_factor": 0.05, "checkpoint_completion_target": 0.9, "hot_standby": "on", "log_autovacuum_min_duration": 0, "log_checkpoints": "on", "log_connections": "on", "log_disconnections": "on", "log_line_prefix": "%t [%p]: [%l-1] %c %x %d %u %a %h ", "log_lock_waits": "on", "log_min_duration_statement": 500, "log_statement": "ddl", "log_temp_files": 0, "max_connections": 50, "max_replication_slots": 10, "max_wal_senders": 10, "tcp_keepalives_idle": 900, "tcp_keepalives_interval": 100, "track_functions": "all", "wal_level": "logical", "wal_log_hints": "on"}, "use_pg_rewind": true, "use_slots": true}, "retry_timeout": 10, "slots": {"cdc": {"database": "foo", "plugin": "pgoutput", "type": "logical"}}, "ttl": 30}`
-	r := ioutil.NopCloser(bytes.NewReader([]byte(configJson)))
+	r := io.NopCloser(bytes.NewReader([]byte(configJson)))
 
 	response := http.Response{
 		StatusCode: 200,


### PR DESCRIPTION
ioutil is deprecated since go 1.16. Time to remove it.

This is a follow up to #2480 
Thanks @testwill for bringing it up.