### PR TITLE
patch event stream CRD instead of update

### DIFF
--- a/pkg/cluster/streams_test.go
+++ b/pkg/cluster/streams_test.go
@@ -294,6 +294,21 @@ func TestSameStreams(t *testing.T) {
 		},
 	}
 
+	stream3 := zalandov1.EventStream{
+		EventStreamFlow: zalandov1.EventStreamFlow{},
+		EventStreamRecovery: zalandov1.EventStreamRecovery{
+			Type: constants.EventStreamRecoveryNoneType,
+		},
+		EventStreamSink: zalandov1.EventStreamSink{
+			EventType: "stream-type-b",
+		},
+		EventStreamSource: zalandov1.EventStreamSource{
+			EventStreamTable: zalandov1.EventStreamTable{
+				Name: "bar",
+			},
+		},
+	}
+
 	tests := []struct {
 		subTest  string
 		streamsA []zalandov1.EventStream
@@ -335,6 +350,13 @@ func TestSameStreams(t *testing.T) {
 			streamsB: fes.Spec.EventStreams,
 			match:    false,
 			reason:   "number of defined streams is different",
+		},
+		{
+			subTest:  "event stream recovery specs differ",
+			streamsA: []zalandov1.EventStream{stream2},
+			streamsB: []zalandov1.EventStream{stream3},
+			match:    false,
+			reason:   "event stream specs differ",
 		},
 	}
 
@@ -409,6 +431,28 @@ func TestUpdateFabricEventStream(t *testing.T) {
 
 	result := cluster.generateFabricEventStream(appId)
 	if match, _ := sameStreams(streams.Items[0].Spec.EventStreams, result.Spec.EventStreams); !match {
-		t.Errorf("Malformed FabricEventStream, expected %#v, got %#v", streams.Items[0], result)
+		t.Errorf("Malformed FabricEventStream after updating manifest, expected %#v, got %#v", streams.Items[0], result)
+	}
+
+	// disable recovery
+	for _, stream := range pg.Spec.Streams {
+		if stream.ApplicationId == appId {
+			stream.EnableRecovery = util.False()
+		}
+	}
+	patchData, err = specPatch(pg.Spec)
+	assert.NoError(t, err)
+
+	pgPatched, err = cluster.KubeClient.Postgresqls(namespace).Patch(
+		context.TODO(), cluster.Name, types.MergePatchType, patchData, metav1.PatchOptions{}, "spec")
+	assert.NoError(t, err)
+
+	cluster.Postgresql.Spec = pgPatched.Spec
+	err = cluster.createOrUpdateStreams()
+	assert.NoError(t, err)
+
+	result = cluster.generateFabricEventStream(appId)
+	if match, _ := sameStreams(streams.Items[0].Spec.EventStreams, result.Spec.EventStreams); !match {
+		t.Errorf("Malformed FabricEventStream after disabling event recovery, expected %#v, got %#v", streams.Items[0], result)
 	}
 }


### PR DESCRIPTION
If streams were already used before the introduction of recovery in #2421 the operator will detect a diff because it sets recovery to `type: None` when it's not enabled. Using the `Update` endpoint results in the following error:

```
could not sync cluster: could not sync streams: failed updating event stream my-stream: FabricEventStream.zalando.org "my-stream" is invalid: spec.eventStreams[0].recovery.sink: Invalid value: "null": spec.eventStreams[0].recovery.sink in body must be of type object: "null"
```

The operator does not specify the sink when `type: None` but it's part of the [recovery struct](https://github.com/zalando/postgres-operator/blob/29ea863faf115396a3ca3184d3aa813f0a349030/pkg/apis/zalando.org/v1/fabriceventstream.go#L56) and will be `nil` (because of pointer type). The `Update` endpoint is replacing the K8s resource with the stream that has the `nil` field. If we would use the Patch endpoint, however, only the fields with values are applied which is what `updateStreams` was always meant to do.