### PR TITLE
chore(build): Add OCI label for container image source

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,7 @@ RUN bash docker/build_operator.sh
 
 FROM ${BASE_IMAGE}
 LABEL maintainer="Team ACID @ Zalando <team-acid@zalando.de>"
+LABEL org.opencontainers.image.source="https://github.com/zalando/postgres-operator"
 
 # We need root certificates to deal with teams api over https
 RUN apk --no-cache add curl


### PR DESCRIPTION
As specified in the OpenContainers Annotations Spec: https://specs.opencontainers.org/image-spec/annotations/

---

## Problem description

Automated tooling which checks container registries for new tags might not be able to find release notes (this is often via source code/parsing a CHANGELOG file) since this is not included in the container registry. Adding this annotation will allow tooling to follow the link to the source code, and look for release notes there. The tooling can then include these release notes in e.g. PRs with container image version bumps.

Dependabot and Renovatebot both use this annotation for this purpose:

* Dependabot: https://github.blog/changelog/2023-04-13-dependabot-now-supports-fetching-release-notes-and-changelogs-for-docker-images/
* Renovatebot: https://docs.renovatebot.com/key-concepts/changelogs/ (and https://docs.renovatebot.com/modules/datasource/docker/)

## Linked issues

N/A

## Checklist

Please, ensure your contribution matches the following items:

- [x] Your go code is [formatted](https://blog.golang.org/gofmt). Your IDE should do it automatically for you.
- [x] You have updated [generated code](https://github.com/zalando/postgres-operator/blob/master/docs/developer.md#code-generation) when introducing new fields to the `acid.zalan.do` api package.
- [x] New [configuration options](https://github.com/zalando/postgres-operator/blob/master/docs/developer.md#introduce-additional-configuration-parameters) are reflected in CRD validation, helm charts and sample manifests.
- [x] New functionality is covered by [unit](https://github.com/zalando/postgres-operator/blob/master/docs/developer.md#unit-tests) and/or [e2e](https://github.com/zalando/postgres-operator/blob/master/docs/developer.md#end-to-end-tests) tests.
- [x] You have checked existing open PRs for possible overlay and referenced them.

---

If this change is accepted I can follow up and add it to some other repositories related to the postgres-operator as well, where I've experienced this to be missing :-)