### PR TITLE
update spec when updating status

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -254,11 +254,16 @@ func (c *Cluster) Create() (err error) {
 	)
 
 	defer func() {
+		var pgUpdatedStatus *acidv1.Postgresql
 		if err == nil {
-			c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusRunning) //TODO: are you sure it's running?
+			pgUpdatedStatus, err = c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusRunning) //TODO: are you sure it's running?
 		} else {
-			c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusAddFailed)
+			pgUpdatedStatus, err = c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusAddFailed)
 		}
+		if err != nil {
+			c.logger.Warningf("could not set cluster status: %v", err)
+		}
+		c.setSpec(pgUpdatedStatus)
 	}()
 
 	pgCreateStatus, err = c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusCreating)
@@ -790,6 +795,7 @@ func (c *Cluster) addFinalizer() error {
 
 	// update the spec, maintaining the new resourceVersion
 	c.setSpec(newSpec)
+
 	return nil
 }
 
@@ -838,11 +844,19 @@ func (c *Cluster) Update(oldSpec, newSpec *acidv1.Postgresql) error {
 	c.setSpec(newSpec)
 
 	defer func() {
+		var (
+			pgUpdatedStatus *acidv1.Postgresql
+			err             error
+		)
 		if updateFailed {
-			c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusUpdateFailed)
+			pgUpdatedStatus, err = c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusUpdateFailed)
 		} else {
-			c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusRunning)
+			pgUpdatedStatus, err = c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusRunning)
 		}
+		if err != nil {
+			c.logger.Warningf("could not set cluster status: %v", err)
+		}
+		c.setSpec(pgUpdatedStatus)
 	}()
 
 	logNiceDiff(c.logger, oldSpec, newSpec)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -263,7 +263,9 @@ func (c *Cluster) Create() (err error) {
 		if err != nil {
 			c.logger.Warningf("could not set cluster status: %v", err)
 		}
-		c.setSpec(pgUpdatedStatus)
+		if pgUpdatedStatus != nil {
+			c.setSpec(pgUpdatedStatus)
+		}
 	}()
 
 	pgCreateStatus, err = c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusCreating)
@@ -856,7 +858,9 @@ func (c *Cluster) Update(oldSpec, newSpec *acidv1.Postgresql) error {
 		if err != nil {
 			c.logger.Warningf("could not set cluster status: %v", err)
 		}
-		c.setSpec(pgUpdatedStatus)
+		if pgUpdatedStatus != nil {
+			c.setSpec(pgUpdatedStatus)
+		}
 	}()
 
 	logNiceDiff(c.logger, oldSpec, newSpec)

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -51,7 +51,9 @@ func (c *Cluster) Sync(newSpec *acidv1.Postgresql) error {
 		if err != nil {
 			c.logger.Warningf("could not set cluster status: %v", err)
 		}
-		c.setSpec(pgUpdatedStatus)
+		if pgUpdatedStatus != nil {
+			c.setSpec(pgUpdatedStatus)
+		}
 	}()
 
 	if err = c.syncFinalizer(); err != nil {

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -209,7 +209,6 @@ func (client *KubernetesClient) SetPostgresCRDStatus(clusterName spec.Namespaced
 		return pg, fmt.Errorf("could not update status: %v", err)
 	}
 
-	// update the spec, maintaining the new resourceVersion.
 	return pg, nil
 }
 
@@ -220,7 +219,7 @@ func (client *KubernetesClient) SetFinalizer(clusterName spec.NamespacedName, pg
 		patch     []byte
 		err       error
 	)
-	pg.ObjectMeta.SetFinalizers(finalizers)
+	pg.ObjectMeta.Finalizers = finalizers
 
 	if len(finalizers) > 0 {
 		patch, err = json.Marshal(struct {


### PR DESCRIPTION
[Four years ago](https://github.com/zalando/postgres-operator/commit/0c6655a22dffce9c2388e6ca6a69bc29c26e7c6b) I moved the `setStatus` code to the `k8sutil` package in order to update the status also in the `controller` scope and not only inside `cluster`. For this I removed the line `c.setSpec(newspec)` and left it to the caller to update Spec struct.

However, it was not reflected by all callers which leads to the situation that further `Update` calls during DELETE events (like removing the finalizer) can be blocked because
1. the `resourceVersion` is already higher that it what is stored in c.Spec, in case the status changed (e.g. Running -> UpdateFailed).
2. [Delete()](https://github.com/zalando/postgres-operator/blob/master/pkg/cluster/cluster.go#L1067) func is not calling c.setSpec unlike the [Update()](https://github.com/zalando/postgres-operator/blob/master/pkg/cluster/cluster.go#L838) and [Create()](https://github.com/zalando/postgres-operator/blob/master/pkg/cluster/cluster.go#L268) because without finalizer the Postgresql resource is already gone.

Instead of implementing extra logic to Delete() this PR attempts to bring back the behavior from 4 years ago to update the spec when updating the status.