### PR TITLE
Fix PVC retention

### DIFF
--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -261,8 +261,12 @@ func (c *Cluster) deleteStatefulSet() error {
 		return fmt.Errorf("could not delete pods: %v", err)
 	}
 
-	if err := c.deletePersistentVolumeClaims(); err != nil {
-		return fmt.Errorf("could not delete PersistentVolumeClaims: %v", err)
+	if c.OpConfig.PersistentVolumeClaimRetentionPolicy["when_deleted"] == "delete" {
+		if err := c.deletePersistentVolumeClaims(); err != nil {
+			return fmt.Errorf("could not delete PersistentVolumeClaims: %v", err)
+		}
+	} else {
+		c.logger.Info("not deleting PersistentVolumeClaims because of the retention policy")
 	}
 
 	return nil


### PR DESCRIPTION
As it is now, the [`persistent_volume_claim_retention_policy`](https://github.com/zalando/postgres-operator/blob/a63a0758dec1cb29b1a13ef42fa6a62c096ec556/charts/postgres-operator/values.yaml#L173) feature doesn't work properly: the PVCs are **always** deleted (not by Kubernetes, but by the operator itself).

Evidence:

```
time="2024-03-07T12:46:32Z" level=debug msg="pods have been deleted" cluster-name=default/mypgcluster pkg=cluster worker=0
time="2024-03-07T12:46:32Z" level=debug msg="deleting PVCs" cluster-name=default/mypgcluster pkg=cluster worker=0
time="2024-03-07T12:46:32Z" level=debug msg="deleting PVC \"default/pgdata-mypgcluster-0\"" cluster-name=default/mypgcluster pkg=cluster worker=0
time="2024-03-07T12:46:32Z" level=debug msg="deleting PVC \"default/pgdata-mypgcluster-1\"" cluster-name=default/mypgcluster pkg=cluster worker=0
time="2024-03-07T12:46:32Z" level=debug msg="deleting PVC \"default/pgdata-mypgcluster-2\"" cluster-name=default/mypgcluster pkg=cluster worker=0
time="2024-03-07T12:46:32Z" level=debug msg="PVCs have been deleted" cluster-name=default/mypgcluster pkg=cluster worker=0
```

And this was my config:

```
$ helm get values zalando-postgres-operator
USER-SUPPLIED VALUES:
...
configKubernetes:
  persistent_volume_claim_retention_policy:
    when_deleted: retain
    when_scaled: retain
...
```

This PR aims to fix this issue, by introducing a check before the call to the `deletePersistentVolumeClaims` function.