### PR TITLE
Omit Namespace from ServiceAccount

### DIFF
--- a/manifests/operator-service-account-rbac.yaml
+++ b/manifests/operator-service-account-rbac.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: postgres-operator
-  namespace: default
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
When trying to deploy the operator using kustomize we had to omit the namespace so that we can deploy it in any namespace.