### PR TITLE
return create and sync error, not setStatus error

### DIFF
--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -339,10 +339,11 @@ configuration they are grouped under the `kubernetes` key.
   cannot fully sync it, there can be leftovers. By enabling finalizers the
   operator will ensure all managed resources are deleted prior to the
   Postgresql resource. There is a trade-off though: The deletion is only
-  performed at the next cluster SYNC cycle when finding a `deletionTimestamp`
-  in the metadata and not immediately after issueing a delete command. The
-  final removal of the custom resource will add a DELETE event to the worker
-  queue but the child resources are already gone at this point.
+  performed after the next two SYNC cycles with the first one updating the
+  internal spec and the latter reacting on the `deletionTimestamp` while
+  processing the SYNC event. The final removal of the custom resource will
+  add a DELETE event to the worker queue but the child resources are already
+  gone at this point.
   The default is `false`.
 
 * **enable_pod_disruption_budget**

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -254,14 +254,18 @@ func (c *Cluster) Create() (err error) {
 	)
 
 	defer func() {
-		var pgUpdatedStatus *acidv1.Postgresql
+		var (
+			pgUpdatedStatus *acidv1.Postgresql
+			errStatus       error
+		)
 		if err == nil {
-			pgUpdatedStatus, err = c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusRunning) //TODO: are you sure it's running?
+			pgUpdatedStatus, errStatus = c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusRunning) //TODO: are you sure it's running?
 		} else {
-			pgUpdatedStatus, err = c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusAddFailed)
+			c.logger.Warningf("cluster created failed: %v", err)
+			pgUpdatedStatus, errStatus = c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusAddFailed)
 		}
-		if err != nil {
-			c.logger.Warningf("could not set cluster status: %v", err)
+		if errStatus != nil {
+			c.logger.Warningf("could not set cluster status: %v", errStatus)
 		}
 		if pgUpdatedStatus != nil {
 			c.setSpec(pgUpdatedStatus)

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -41,15 +41,18 @@ func (c *Cluster) Sync(newSpec *acidv1.Postgresql) error {
 	c.setSpec(newSpec)
 
 	defer func() {
-		var pgUpdatedStatus *acidv1.Postgresql
+		var (
+			pgUpdatedStatus *acidv1.Postgresql
+			errStatus       error
+		)
 		if err != nil {
 			c.logger.Warningf("error while syncing cluster state: %v", err)
-			pgUpdatedStatus, err = c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusSyncFailed)
+			pgUpdatedStatus, errStatus = c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusSyncFailed)
 		} else if !c.Status.Running() {
-			pgUpdatedStatus, err = c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusRunning)
+			pgUpdatedStatus, errStatus = c.KubeClient.SetPostgresCRDStatus(c.clusterName(), acidv1.ClusterStatusRunning)
 		}
-		if err != nil {
-			c.logger.Warningf("could not set cluster status: %v", err)
+		if errStatus != nil {
+			c.logger.Warningf("could not set cluster status: %v", errStatus)
 		}
 		if pgUpdatedStatus != nil {
 			c.setSpec(pgUpdatedStatus)

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -331,7 +331,6 @@ func (c *Controller) processEvent(event ClusterEvent) {
 		c.curWorkerCluster.Store(event.WorkerID, cl)
 
 		// has this cluster been marked as deleted already, then we shall start cleaning up
-		lg.Infof("cluster DeletionTimestamp is %s", cl.ObjectMeta.DeletionTimestamp)
 		if !cl.ObjectMeta.DeletionTimestamp.IsZero() {
 			lg.Infof("cluster has a DeletionTimestamp of %s, starting deletion now.", cl.ObjectMeta.DeletionTimestamp.Format(time.RFC3339))
 			if err = cl.Delete(); err != nil {
@@ -340,7 +339,6 @@ func (c *Controller) processEvent(event ClusterEvent) {
 				lg.Error(cl.Error)
 				return
 			}
-			lg.Infof("cluster has been deleted")
 		} else {
 			if err = cl.Sync(event.NewSpec); err != nil {
 				cl.Error = fmt.Sprintf("could not sync cluster: %v", err)

--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -331,6 +331,7 @@ func (c *Controller) processEvent(event ClusterEvent) {
 		c.curWorkerCluster.Store(event.WorkerID, cl)
 
 		// has this cluster been marked as deleted already, then we shall start cleaning up
+		lg.Infof("cluster DeletionTimestamp is %s", cl.ObjectMeta.DeletionTimestamp)
 		if !cl.ObjectMeta.DeletionTimestamp.IsZero() {
 			lg.Infof("cluster has a DeletionTimestamp of %s, starting deletion now.", cl.ObjectMeta.DeletionTimestamp.Format(time.RFC3339))
 			if err = cl.Delete(); err != nil {


### PR DESCRIPTION
Yet another follow-up to adding finalizers on existing clusters. If you cancel the kubectl delete command the controller does not find the deletionTimestamp and keeps on syncing the cluster. Only after restarting the operator by removing the pod the timestamp gets picked up.

I wanted to repeat the experiment but the cluster recreation failed, but I could not see why. With the changes made in #2546 I'm no longer returning the actual error on cluster creation but overriding it with the error returned from setting the status. This is wrong and is fixed with this PR.