### PR TITLE
fix: db row close error be ignored

### DIFF
--- a/pkg/cluster/database.go
+++ b/pkg/cluster/database.go
@@ -205,7 +205,11 @@ func (c *Cluster) readPgUsersFromDatabase(userNames []string) (users spec.PgUser
 	}
 	defer func() {
 		if err2 := rows.Close(); err2 != nil {
-			err = fmt.Errorf("error when closing query cursor: %v", err2)
+			if err != nil {
+				err = fmt.Errorf("error when closing query cursor: %v, previous error: %v", err2, err)
+			} else {
+				err = fmt.Errorf("error when closing query cursor: %v", err2)
+			}
 		}
 	}()
 
@@ -252,7 +256,11 @@ func findUsersFromRotation(rotatedUsers []string, db *sql.DB) (map[string]string
 	}
 	defer func() {
 		if err2 := rows.Close(); err2 != nil {
-			err = fmt.Errorf("error when closing query cursor: %v", err2)
+			if err != nil {
+				err = fmt.Errorf("error when closing query cursor: %v, previous error: %v", err2, err)
+			} else {
+				err = fmt.Errorf("error when closing query cursor: %v", err2)
+			}
 		}
 	}()
 


### PR DESCRIPTION
We should wrap error like:
https://github.com/zalando/postgres-operator/blob/a5663da64f7a94af8dde395852cb2cf309ae27bc/pkg/cluster/database.go#L537-L545