### PR TITLE
Secrets deletion config

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -211,6 +211,9 @@ spec:
                   enable_init_containers:
                     type: boolean
                     default: true
+                  enable_secrets_deletion:
+                    type: boolean
+                    default: true
                   enable_persistent_volume_claim_deletion:
                     type: boolean
                     default: true

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -129,6 +129,8 @@ configKubernetes:
   enable_finalizers: false
   # enables initContainers to run actions before Spilo is started
   enable_init_containers: true
+  # toggles if operator should delete secrets on cluster deletion
+  enable_secrets_deletion: true
   # toggles if operator should delete PVCs on cluster deletion
   enable_persistent_volume_claim_deletion: true
   # toggles pod anti affinity on the Postgres pods

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -360,6 +360,10 @@ configuration they are grouped under the `kubernetes` key.
   `"retain"` - or `when_scaled` - default is also `"retain"`. The other possible
   option is `delete`.
 
+* **enable_secrets_deletion**
+  By default, the operator deletes secrets when removing the Postgres cluster
+  manifest. To keep secrets, set this option to `false`. The default is `true`.
+
 * **enable_persistent_volume_claim_deletion**
   By default, the operator deletes PersistentVolumeClaims when removing the
   Postgres cluster manifest, no matter if `persistent_volume_claim_retention_policy`

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -2110,7 +2110,7 @@ class EndToEndTestCase(unittest.TestCase):
             self.eventuallyEqual(lambda: k8s.count_statefulsets_with_label(cluster_label), 0, "Statefulset not deleted")
             self.eventuallyEqual(lambda: k8s.count_deployments_with_label(cluster_label), 0, "Deployments not deleted")
             self.eventuallyEqual(lambda: k8s.count_pdbs_with_label(cluster_label), 0, "Pod disruption budget not deleted")
-            self.eventuallyEqual(lambda: k8s.count_secrets_with_label(cluster_label), 3, "Secrets were deleted although disabled in config")
+            self.eventuallyEqual(lambda: k8s.count_secrets_with_label(cluster_label), 7, "Secrets were deleted although disabled in config")
             self.eventuallyEqual(lambda: k8s.count_pvcs_with_label(cluster_label), 3, "PVCs were deleted although disabled in config")
 
         except timeout_decorator.TimeoutError:

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -2049,6 +2049,7 @@ class EndToEndTestCase(unittest.TestCase):
             "data": {
                 "delete_annotation_date_key": "delete-date",
                 "delete_annotation_name_key": "delete-clustername",
+                "enable_secrets_deletion": "false",
                 "enable_persistent_volume_claim_deletion": "false"
             }
         }
@@ -2109,7 +2110,7 @@ class EndToEndTestCase(unittest.TestCase):
             self.eventuallyEqual(lambda: k8s.count_statefulsets_with_label(cluster_label), 0, "Statefulset not deleted")
             self.eventuallyEqual(lambda: k8s.count_deployments_with_label(cluster_label), 0, "Deployments not deleted")
             self.eventuallyEqual(lambda: k8s.count_pdbs_with_label(cluster_label), 0, "Pod disruption budget not deleted")
-            self.eventuallyEqual(lambda: k8s.count_secrets_with_label(cluster_label), 0, "Secrets not deleted")
+            self.eventuallyEqual(lambda: k8s.count_secrets_with_label(cluster_label), 3, "Secrets were deleted although disabled in config")
             self.eventuallyEqual(lambda: k8s.count_pvcs_with_label(cluster_label), 3, "PVCs were deleted although disabled in config")
 
         except timeout_decorator.TimeoutError:

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -49,6 +49,7 @@ data:
   enable_master_pooler_load_balancer: "false"
   enable_password_rotation: "false"
   enable_patroni_failsafe_mode: "false"
+  enable_secrets_deletion: "true"
   enable_persistent_volume_claim_deletion: "true"
   enable_pgversion_env_var: "true"
   # enable_pod_antiaffinity: "false"

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -209,6 +209,9 @@ spec:
                   enable_init_containers:
                     type: boolean
                     default: true
+                  enable_secrets_deletion:
+                    type: boolean
+                    default: true
                   enable_persistent_volume_claim_deletion:
                     type: boolean
                     default: true

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -59,6 +59,7 @@ configuration:
     # enable_cross_namespace_secret: "false"
     enable_finalizers: false
     enable_init_containers: true
+    enable_secrets_deletion: true
     enable_persistent_volume_claim_deletion: true
     enable_pod_antiaffinity: false
     enable_pod_disruption_budget: true

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1320,6 +1320,9 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 							"enable_init_containers": {
 								Type: "boolean",
 							},
+							"enable_secrets_deletion": {
+								Type: "boolean",
+							},
 							"enable_persistent_volume_claim_deletion": {
 								Type: "boolean",
 							},

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -102,6 +102,7 @@ type KubernetesMetaConfiguration struct {
 	PodAntiAffinityTopologyKey               string              `json:"pod_antiaffinity_topology_key,omitempty"`
 	PodManagementPolicy                      string              `json:"pod_management_policy,omitempty"`
 	PersistentVolumeClaimRetentionPolicy     map[string]string   `json:"persistent_volume_claim_retention_policy,omitempty"`
+	EnableSecretsDeletion                    *bool               `json:"enable_secrets_deletion,omitempty"`
 	EnablePersistentVolumeClaimDeletion      *bool               `json:"enable_persistent_volume_claim_deletion,omitempty"`
 	EnableReadinessProbe                     bool                `json:"enable_readiness_probe,omitempty"`
 	EnableCrossNamespaceSecret               bool                `json:"enable_cross_namespace_secret,omitempty"`

--- a/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
@@ -272,6 +272,11 @@ func (in *KubernetesMetaConfiguration) DeepCopyInto(out *KubernetesMetaConfigura
 			(*out)[key] = val
 		}
 	}
+	if in.EnableSecretsDeletion != nil {
+		in, out := &in.EnableSecretsDeletion, &out.EnableSecretsDeletion
+		*out = new(bool)
+		**out = **in
+	}
 	if in.EnablePersistentVolumeClaimDeletion != nil {
 		in, out := &in.EnablePersistentVolumeClaimDeletion, &out.EnablePersistentVolumeClaimDeletion
 		*out = new(bool)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1112,10 +1112,14 @@ func (c *Cluster) Delete() error {
 		c.eventRecorder.Eventf(c.GetReference(), v1.EventTypeWarning, "Delete", "could not delete statefulset: %v", err)
 	}
 
-	if err := c.deleteSecrets(); err != nil {
-		anyErrors = true
-		c.logger.Warningf("could not delete secrets: %v", err)
-		c.eventRecorder.Eventf(c.GetReference(), v1.EventTypeWarning, "Delete", "could not delete secrets: %v", err)
+	if c.OpConfig.EnableSecretsDeletion != nil && *c.OpConfig.EnableSecretsDeletion {
+		if err := c.deleteSecrets(); err != nil {
+			anyErrors = true
+			c.logger.Warningf("could not delete secrets: %v", err)
+			c.eventRecorder.Eventf(c.GetReference(), v1.EventTypeWarning, "Delete", "could not delete secrets: %v", err)
+		}
+	} else {
+		c.logger.Info("not deleting secrets because disabled in configuration")
 	}
 
 	if err := c.deletePodDisruptionBudget(); err != nil {

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -122,6 +122,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.PodPriorityClassName = fromCRD.Kubernetes.PodPriorityClassName
 	result.PodManagementPolicy = util.Coalesce(fromCRD.Kubernetes.PodManagementPolicy, "ordered_ready")
 	result.PersistentVolumeClaimRetentionPolicy = fromCRD.Kubernetes.PersistentVolumeClaimRetentionPolicy
+	result.EnableSecretsDeletion = util.CoalesceBool(fromCRD.Kubernetes.EnableSecretsDeletion, util.True())
 	result.EnablePersistentVolumeClaimDeletion = util.CoalesceBool(fromCRD.Kubernetes.EnablePersistentVolumeClaimDeletion, util.True())
 	result.EnableReadinessProbe = fromCRD.Kubernetes.EnableReadinessProbe
 	result.MasterPodMoveTimeout = util.CoalesceDuration(time.Duration(fromCRD.Kubernetes.MasterPodMoveTimeout), "10m")

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -249,6 +249,7 @@ type Config struct {
 	PatroniAPICheckInterval                  time.Duration     `name:"patroni_api_check_interval" default:"1s"`
 	PatroniAPICheckTimeout                   time.Duration     `name:"patroni_api_check_timeout" default:"5s"`
 	EnablePatroniFailsafeMode                *bool             `name:"enable_patroni_failsafe_mode" default:"false"`
+	EnableSecretsDeletion                    *bool             `name:"enable_secrets_deletion" default:"true"`
 	EnablePersistentVolumeClaimDeletion      *bool             `name:"enable_persistent_volume_claim_deletion" default:"true"`
 	PersistentVolumeClaimRetentionPolicy     map[string]string `name:"persistent_volume_claim_retention_policy" default:"when_deleted:retain,when_scaled:retain"`
 }


### PR DESCRIPTION
This PR introduces a configuration option to provide a way to disable the **deletion** of Kubernetes **secrets**: `enable_secrets_deletion` (default `true`).

Ratio: see https://github.com/zalando/postgres-operator/issues/1736#issuecomment-1999567249

I think many people would love this feature. This also relates to #2579, which otherwise wouldn't make much sense, because attaching already-existing volumes to a brand new cluster doesn't work due to different secrets.

Inspired by #2579 (huge thanks to @FxKu)