### PR TITLE
Fix duplicate key issue when using configmap config target

### DIFF
--- a/charts/postgres-operator/templates/_helpers.tpl
+++ b/charts/postgres-operator/templates/_helpers.tpl
@@ -70,8 +70,8 @@ Flatten nested config options when ConfigMap is used as ConfigTarget
         {{- $list := list }}
         {{- range $subKey, $subValue := $value }}
             {{- $list = append $list (printf "%s:%s" $subKey $subValue) }}
-{{ $key }}: {{ join "," $list | quote }}
         {{- end }}
+{{ $key }}: {{ join "," $list | quote }}
     {{- else }}
 {{ $key }}: {{ $value | quote }}
     {{- end }}


### PR DESCRIPTION
When using the `configTarget: "ConfigMap"` option, the rendered configmap fails to install due to 
```
  line 52: mapping key "persistent_volume_claim_retention_policy" already defined at line 51
```

This is caused by the flatten helper adding the config option too early causing duplicate keys like these to be created:

```
  persistent_volume_claim_retention_policy: "when_deleted:retain"
  persistent_volume_claim_retention_policy: "when_deleted:retain,when_scaled:retain"
``` 

This pr fixes this issue.