### PR TITLE
Apply template on all keys of operatorconfiguration

### DIFF
--- a/charts/postgres-operator/templates/operatorconfiguration.yaml
+++ b/charts/postgres-operator/templates/operatorconfiguration.yaml
@@ -14,7 +14,7 @@ configuration:
   users:
 {{ tpl (toYaml .Values.configUsers) . | indent 4 }}
   major_version_upgrade:
-{{ toYaml .Values.configMajorVersionUpgrade | indent 4 }}
+{{ tpl (toYaml .Values.configMajorVersionUpgrade) . | indent 4 }}
   kubernetes:
     {{- if .Values.podPriorityClassName.name }}
     pod_priority_class_name: {{ .Values.podPriorityClassName.name }}
@@ -23,23 +23,23 @@ configuration:
     oauth_token_secret_name: {{ template "postgres-operator.fullname" . }}
 {{ tpl (toYaml .Values.configKubernetes) . | indent 4 }}
   postgres_pod_resources:
-{{ toYaml .Values.configPostgresPodResources | indent 4 }}
+{{ tpl (toYaml .Values.configPostgresPodResources) . | indent 4 }}
   timeouts:
-{{ toYaml .Values.configTimeouts | indent 4 }}
+{{ tpl (toYaml .Values.configTimeouts) . | indent 4 }}
   load_balancer:
-{{ toYaml .Values.configLoadBalancer | indent 4 }}
+{{ tpl (toYaml .Values.configLoadBalancer) . | indent 4 }}
   aws_or_gcp:
-{{ toYaml .Values.configAwsOrGcp | indent 4 }}
+{{ tpl (toYaml .Values.configAwsOrGcp) . | indent 4 }}
   logical_backup:
-{{ toYaml .Values.configLogicalBackup | indent 4 }}
+{{ tpl (toYaml .Values.configLogicalBackup) . | indent 4 }}
   debug:
-{{ toYaml .Values.configDebug | indent 4 }}
+{{ tpl (toYaml .Values.configDebug) . | indent 4 }}
   teams_api:
 {{ tpl (toYaml .Values.configTeamsApi) . | indent 4 }}
   logging_rest_api:
-{{ toYaml .Values.configLoggingRestApi | indent 4 }}
+{{ tpl (toYaml .Values.configLoggingRestApi) . | indent 4 }}
   connection_pooler:
-{{ toYaml .Values.configConnectionPooler | indent 4 }}
+{{ tpl (toYaml .Values.configConnectionPooler) . | indent 4 }}
   patroni:
-{{ toYaml .Values.configPatroni | indent 4 }}
+{{ tpl (toYaml .Values.configPatroni) . | indent 4 }}
 {{- end }}


### PR DESCRIPTION
This allows one to specify go templates in every setting applied to the OperatorConfiguration. This in turn allows me to do something like this:

```yaml
global:
    s3:
        endpoint: https://s3.example.com
        access_key_id: xxx
        secret_access_key: xxx
        bucket: xxx
postgres-operator:
    configLogicalBackup:
        logical_backup_s3_endpoint: '{{ .Values.global.s3.endpoint }}'
        logical_backup_s3_access_key_id: '{{ .Values.global.s3.access_key_id }}'
        logical_backup_s3_secret_access_key: '{{ .Values.global.s3.secret_access_key }}'
        logical_backup_s3_bucket: '{{ .Values.global.s3.bucket }}'
some-other-chart:
    some-other-key: '{{ .Values.global.s3.bucket }}'
```

I applied `tpl` to all keys, because even though I only required logical backup for my use case, I see no reason to not add this to all keys.