### PR TITLE
switch to ghcr image in helm chart and examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/postgres-operator-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/postgres-operator-issue-template.md
@@ -9,7 +9,7 @@ assignees: ''
 
 Please, answer some short questions which should help us to understand your problem / question better?
 
-- **Which image of the operator are you using?** e.g. registry.opensource.zalan.do/acid/postgres-operator:v1.11.0
+- **Which image of the operator are you using?** e.g. ghcr.io/zalando/postgres-operator:v1.11.0
 - **Where do you run it - cloud or metal? Kubernetes or OpenShift?** [AWS K8s | GCP ... | Bare Metal K8s]
 - **Are you running Postgres Operator in production?** [yes | no]
 - **Type of issue?** [Bug report, question, feature request, etc.]

--- a/charts/postgres-operator-ui/values.yaml
+++ b/charts/postgres-operator-ui/values.yaml
@@ -6,8 +6,8 @@ replicaCount: 1
 
 # configure ui image
 image:
-  registry: registry.opensource.zalan.do
-  repository: acid/postgres-operator-ui
+  registry: ghcr.io
+  repository: zalando/postgres-operator-ui
   tag: v1.11.0
   pullPolicy: "IfNotPresent"
 

--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -508,7 +508,7 @@ spec:
                     pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
                   logical_backup_docker_image:
                     type: string
-                    default: "registry.opensource.zalan.do/acid/logical-backup:v1.11.0"
+                    default: "ghcr.io/zalando/postgres-operator/logical-backup:v1.11.0"
                   logical_backup_google_application_credentials:
                     type: string
                   logical_backup_job_prefix:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -362,7 +362,7 @@ configLogicalBackup:
   # logical_backup_memory_request: ""
 
   # image for pods of the logical backup job (example runs pg_dumpall)
-  logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.11.0"
+  logical_backup_docker_image: "ghcr.io/zalando/postgres-operator/logical-backup:v1.11.0"
   # path of google cloud service account json file
   # logical_backup_google_application_credentials: ""
 

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -1,6 +1,6 @@
 image:
-  registry: registry.opensource.zalan.do
-  repository: acid/postgres-operator
+  registry: ghcr.io
+  repository: zalando/postgres-operator
   tag: v1.11.0
   pullPolicy: "IfNotPresent"
 

--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -1399,7 +1399,7 @@ make docker
 
 # build in image in minikube docker env
 eval $(minikube docker-env)
-docker build -t registry.opensource.zalan.do/acid/postgres-operator-ui:v1.8.1 .
+docker build -t ghcr.io/zalando/postgres-operator-ui:v1.11.0 .
 
 # apply UI manifests next to a running Postgres Operator
 kubectl apply -f manifests/

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -821,7 +821,7 @@ grouped under the `logical_backup` key.
   runs `pg_dumpall` on a replica if possible and uploads compressed results to
   an S3 bucket under the key `/<configured-s3-bucket-prefix>/<pg_cluster_name>/<cluster_k8s_uuid>/logical_backups`.
   The default image is the same image built with the Zalando-internal CI
-  pipeline. Default: "registry.opensource.zalan.do/acid/logical-backup:v1.11.0"
+  pipeline. Default: "ghcr.io/zalando/postgres-operator/logical-backup:v1.11.0"
 
 * **logical_backup_google_application_credentials**
   Specifies the path of the google cloud service account json file. Default is empty.

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -83,7 +83,7 @@ data:
   # logical_backup_azure_storage_account_key: ""
   # logical_backup_cpu_limit: ""
   # logical_backup_cpu_request: ""
-  logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.11.0"
+  logical_backup_docker_image: "ghcr.io/zalando/postgres-operator/logical-backup:v1.11.0"
   # logical_backup_google_application_credentials: ""
   logical_backup_job_prefix: "logical-backup-"
   # logical_backup_memory_limit: ""

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -506,7 +506,7 @@ spec:
                     pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
                   logical_backup_docker_image:
                     type: string
-                    default: "registry.opensource.zalan.do/acid/logical-backup:v1.11.0"
+                    default: "ghcr.io/zalando/postgres-operator/logical-backup:v1.11.0"
                   logical_backup_google_application_credentials:
                     type: string
                   logical_backup_job_prefix:

--- a/manifests/postgres-operator.yaml
+++ b/manifests/postgres-operator.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: postgres-operator
       containers:
       - name: postgres-operator
-        image: registry.opensource.zalan.do/acid/postgres-operator:v1.11.0
+        image: ghcr.io/zalando/postgres-operator:v1.11.0
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -167,7 +167,7 @@ configuration:
     # logical_backup_cpu_request: ""
     # logical_backup_memory_limit: ""
     # logical_backup_memory_request: ""
-    logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.11.0"
+    logical_backup_docker_image: "ghcr.io/zalando/postgres-operator/logical-backup:v1.11.0"
     # logical_backup_google_application_credentials: ""
     logical_backup_job_prefix: "logical-backup-"
     logical_backup_provider: "s3"

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -179,7 +179,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 
 	// logical backup config
 	result.LogicalBackupSchedule = util.Coalesce(fromCRD.LogicalBackup.Schedule, "30 00 * * *")
-	result.LogicalBackupDockerImage = util.Coalesce(fromCRD.LogicalBackup.DockerImage, "registry.opensource.zalan.do/acid/logical-backup:v1.11.0")
+	result.LogicalBackupDockerImage = util.Coalesce(fromCRD.LogicalBackup.DockerImage, "ghcr.io/zalando/postgres-operator/logical-backup:v1.11.0")
 	result.LogicalBackupProvider = util.Coalesce(fromCRD.LogicalBackup.BackupProvider, "s3")
 	result.LogicalBackupAzureStorageAccountName = fromCRD.LogicalBackup.AzureStorageAccountName
 	result.LogicalBackupAzureStorageAccountKey = fromCRD.LogicalBackup.AzureStorageAccountKey

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -126,7 +126,7 @@ type Scalyr struct {
 // LogicalBackup defines configuration for logical backup
 type LogicalBackup struct {
 	LogicalBackupSchedule                     string `name:"logical_backup_schedule" default:"30 00 * * *"`
-	LogicalBackupDockerImage                  string `name:"logical_backup_docker_image" default:"registry.opensource.zalan.do/acid/logical-backup:v1.11.0"`
+	LogicalBackupDockerImage                  string `name:"logical_backup_docker_image" default:"ghcr.io/zalando/postgres-operator/logical-backup:v1.11.0"`
 	LogicalBackupProvider                     string `name:"logical_backup_provider" default:"s3"`
 	LogicalBackupAzureStorageAccountName      string `name:"logical_backup_azure_storage_account_name" default:""`
 	LogicalBackupAzureStorageContainer        string `name:"logical_backup_azure_storage_container" default:""`

--- a/ui/manifests/deployment.yaml
+++ b/ui/manifests/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: postgres-operator-ui
       containers:
         - name: "service"
-          image: registry.opensource.zalan.do/acid/postgres-operator-ui:v1.11.0
+          image: ghcr.io/zalando/postgres-operator-ui:v1.11.0
           ports:
             - containerPort: 8081
               protocol: "TCP"


### PR DESCRIPTION
Since 1.11.0 we're building ghcr images for UI and logical backup too. It's time to reflect this also in configuration, manifest examples and helm chart to avoid further questions about missing arm support.

closes #2630 