### PR TITLE
Enable build image when push to master

### DIFF
--- a/.github/workflows/publish_ghcr_image.yaml
+++ b/.github/workflows/publish_ghcr_image.yaml
@@ -9,6 +9,8 @@ on:
   push:
     tags:
       - '*'
+    branches:
+      - master
 
 jobs:
   publish:


### PR DESCRIPTION
Currently, our operator only build image when there is tag release. It should also build image when on merge to master. 