### PR TITLE
Align Docker images in ghcr pipeline with images assumed in Dockerfile

### DIFF
--- a/.github/workflows/publish_ghcr_image.yaml
+++ b/.github/workflows/publish_ghcr_image.yaml
@@ -74,7 +74,7 @@ jobs:
         with:
           context: ui
           push: true
-          build-args: BASE_IMAGE=alpine:3.15
+          build-args: BASE_IMAGE=python:3.11-slim
           tags: "${{ steps.image_ui.outputs.UI_IMAGE }}"
           platforms: linux/amd64,linux/arm64
 

--- a/.github/workflows/publish_ghcr_image.yaml
+++ b/.github/workflows/publish_ghcr_image.yaml
@@ -65,7 +65,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: true
-          build-args: BASE_IMAGE=alpine:3.15
+          build-args: BASE_IMAGE=alpine:3
           tags: "${{ steps.image.outputs.OPERATOR_IMAGE }}"
           platforms: linux/amd64,linux/arm64
 


### PR DESCRIPTION
Changes:

- Change argument for Github Actions to use the same [official Python image][1] as the one used for building "postgres-operator-ui" since commit  d60b424d7957d715003d9e5597bd5b5d63b6e250.

- Align image version in Github Actions pipeline with assumed default version in Dockerfile, using latest [Alpine 3](https://hub.docker.com/_/alpine)

Should fix problem with `publish_ghcr_image` workflow. 

[1]: https://hub.docker.com/_/python