### PR TITLE
chore: update package dependencies when building image

### DIFF
--- a/docker/DebugDockerfile
+++ b/docker/DebugDockerfile
@@ -1,17 +1,13 @@
-FROM registry.opensource.zalan.do/library/alpine-3.15:latest
+FROM golang:1.22-alpine
 LABEL maintainer="Team ACID @ Zalando <team-acid@zalando.de>"
 
 # We need root certificates to deal with teams api over https
-RUN apk --no-cache add ca-certificates go git musl-dev
+RUN  apk -U add --no-cache ca-certificates delve
 
 COPY build/* /
 
 RUN addgroup -g 1000 pgo
 RUN adduser -D -u 1000 -G pgo -g 'Postgres Operator' pgo
-
-RUN go get -d github.com/derekparker/delve/cmd/dlv
-RUN cp /root/go/bin/dlv /dlv
-RUN chown -R pgo:pgo /dlv
 
 USER pgo:pgo
 RUN ls -l /

--- a/docker/DebugDockerfile
+++ b/docker/DebugDockerfile
@@ -2,7 +2,7 @@ FROM golang:1.22-alpine
 LABEL maintainer="Team ACID @ Zalando <team-acid@zalando.de>"
 
 # We need root certificates to deal with teams api over https
-RUN  apk -U add --no-cache ca-certificates delve
+RUN apk -U add --no-cache ca-certificates delve
 
 COPY build/* /
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,23 +1,20 @@
 ARG BASE_IMAGE=registry.opensource.zalan.do/library/alpine-3:latest
+FROM golang:1.22-alpine AS builder
 ARG VERSION=latest
-
-FROM ubuntu:20.04 as builder
-
-ARG VERSION
 
 COPY  . /go/src/github.com/zalando/postgres-operator
 WORKDIR /go/src/github.com/zalando/postgres-operator
 
-ENV OPERATOR_LDFLAGS="-X=main.version=${VERSION}"
-RUN bash docker/build_operator.sh
+RUN GO111MODULE=on go mod vendor \
+    && CGO_ENABLED=0 go build -o build/postgres-operator -v -ldflags "-X=main.version=${VERSION}" cmd/main.go
 
 FROM ${BASE_IMAGE}
 LABEL maintainer="Team ACID @ Zalando <team-acid@zalando.de>"
 LABEL org.opencontainers.image.source="https://github.com/zalando/postgres-operator"
 
 # We need root certificates to deal with teams api over https
-RUN apk --no-cache add curl
-RUN apk --no-cache add ca-certificates
+RUN apk -U upgrade --no-cache \
+    && apk add --no-cache curl ca-certificates
 
 COPY --from=builder /go/src/github.com/zalando/postgres-operator/build/* /
 


### PR DESCRIPTION
Install available updates alongside installation of packages to remove known vulnerabilities from images.

Example for issues in plain alpine:3 image (v3.20):

```sh
$ grype alpine:3
 ✔ Vulnerability DB                [updated]
 ✔ Loaded image                                                            alpine:3
 ✔ Parsed image                    sha256:1d34ffeaf190be23d3de5a8de0a436676b758f48f
 ✔ Cataloged contents              dac15f325cac528994a5efe78787cd03bdd796979bda52fd
   ├── ✔ Packages                        [14 packages]
   ├── ✔ File digests                    [77 files]
   ├── ✔ File metadata                   [77 locations]
   └── ✔ Executables                     [17 executables]
 ✔ Scanned for vulnerabilities     [8 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 6 medium, 0 low, 0 negligible (2 unknown)
   └── by status:   8 fixed, 0 not-fixed, 0 ignored
NAME           INSTALLED   FIXED-IN    TYPE  VULNERABILITY   SEVERITY
busybox        1.36.1-r28  1.36.1-r29  apk   CVE-2023-42365  Medium
busybox        1.36.1-r28  1.36.1-r29  apk   CVE-2023-42364  Medium
busybox-binsh  1.36.1-r28  1.36.1-r29  apk   CVE-2023-42365  Medium
busybox-binsh  1.36.1-r28  1.36.1-r29  apk   CVE-2023-42364  Medium
libcrypto3     3.3.0-r2    3.3.0-r3    apk   CVE-2024-4741   Unknown
libssl3        3.3.0-r2    3.3.0-r3    apk   CVE-2024-4741   Unknown
ssl_client     1.36.1-r28  1.36.1-r29  apk   CVE-2023-42365  Medium
ssl_client     1.36.1-r28  1.36.1-r29  apk   CVE-2023-42364  Medium
```

Issue would be solved by also upgrading installed packages:

```sh
$ apk -U upgrade --no-cache
fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/community/x86_64/APKINDEX.tar.gz
(1/5) Upgrading busybox (1.36.1-r28 -> 1.36.1-r29)
Executing busybox-1.36.1-r29.post-upgrade
(2/5) Upgrading busybox-binsh (1.36.1-r28 -> 1.36.1-r29)
(3/5) Upgrading libcrypto3 (3.3.0-r2 -> 3.3.1-r0)
(4/5) Upgrading libssl3 (3.3.0-r2 -> 3.3.1-r0)
(5/5) Upgrading ssl_client (1.36.1-r28 -> 1.36.1-r29)
Executing busybox-1.36.1-r29.trigger
OK: 8 MiB in 14 packages
```

Furthermore, this commit reduces accidental complexity from the Docker build process.
Most notably, use pre-made official golang images for building postgres-operator.
