### PR TITLE
chore: simplify delivery-yaml for building operator

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -5,27 +5,18 @@ pipeline:
       vm_config:
         type: linux
         size: large
+        image: cdp-runtime/go
       cache:
         paths:
-          - /go/pkg/mod
+          - /go/pkg/mod       # pkg cache for Go modules
+          - ~/.cache/go-build # Go build cache
       commands:
-        - desc: 'Update'
+        - desc: Run unit tests
           cmd: |
-            apt-get update
-        - desc: 'Install required build software'
+            make deps mocks test
+
+        - desc: Build Docker image
           cmd: |
-            apt-get install -y make git apt-transport-https ca-certificates curl build-essential python3 python3-pip
-        - desc: 'Install go'
-          cmd: |
-            cd /tmp
-            wget -q https://storage.googleapis.com/golang/go1.22.3.linux-amd64.tar.gz -O go.tar.gz
-            tar -xf go.tar.gz
-            mv go /usr/local
-            ln -s /usr/local/go/bin/go /usr/bin/go
-            go version
-        - desc: 'Build docker image'
-          cmd: |
-            export PATH=$PATH:$HOME/go/bin
             IS_PR_BUILD=${CDP_PULL_REQUEST_NUMBER+"true"}
             if [[ ${CDP_TARGET_BRANCH} == "master" && ${IS_PR_BUILD} != "true" ]]
             then
@@ -34,23 +25,7 @@ pipeline:
               IMAGE=registry-write.opensource.zalan.do/acid/postgres-operator-test
             fi
             export IMAGE
-            make deps mocks docker
-        - desc: 'Run unit tests'
-          cmd: |
-            export PATH=$PATH:$HOME/go/bin
-            go test ./...
-        - desc: 'Push docker image'
-          cmd: |
-            export PATH=$PATH:$HOME/go/bin
-            IS_PR_BUILD=${CDP_PULL_REQUEST_NUMBER+"true"}
-            if [[ ${CDP_TARGET_BRANCH} == "master" && ${IS_PR_BUILD} != "true" ]]
-            then
-              IMAGE=registry-write.opensource.zalan.do/acid/postgres-operator
-            else
-              IMAGE=registry-write.opensource.zalan.do/acid/postgres-operator-test
-            fi
-            export IMAGE
-            make push
+            make docker push
 
     - id: build-operator-ui
       type: script


### PR DESCRIPTION
Commit switches builder image to `cdp-runtime/go`, removing the need to install `go` manually.

Also, commit splits "build-postgres-operator" pipeline into 2 distinct steps.

1. Run unit tests based on locally checked out code including set up of dependencies and generated code.
2. Build Docker image if tests are successful
