### PR TITLE
Add support for ephemeral PostgresQL instances

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -692,6 +692,9 @@ spec:
                   enable_patroni_failsafe_mode:
                     type: boolean
                     default: false
+              allow_ephemeral_volumes:
+                type: boolean
+                default: false
           status:
             type: object
             additionalProperties:

--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -577,6 +577,9 @@ spec:
                         - PreferNoSchedule
                     tolerationSeconds:
                       type: integer
+              useEphemeralVolume:
+                type: boolean
+                default: false
               useLoadBalancer:
                 type: boolean
                 description: deprecated

--- a/charts/postgres-operator/templates/operatorconfiguration.yaml
+++ b/charts/postgres-operator/templates/operatorconfiguration.yaml
@@ -42,4 +42,5 @@ configuration:
 {{ tpl (toYaml .Values.configConnectionPooler) . | indent 4 }}
   patroni:
 {{ tpl (toYaml .Values.configPatroni) . | indent 4 }}
+  allow_ephemeral_volumes: {{ .Values.allowEphemeralVolumes }}
 {{- end }}

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -454,6 +454,9 @@ configPatroni:
 # Zalando's internal CDC stream feature
 enableStreams: false
 
+# Allow ephemeral instances
+allowEphemeralVolumes: false
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -7,6 +7,7 @@ data:
   # additional_pod_capabilities: "SYS_NICE"
   # additional_secret_mount: "some-secret-name"
   # additional_secret_mount_path: "/some/dir"
+  # allow_ephemeral_volumes: true
   api_port: "8080"
   aws_region: eu-central-1
   cluster_domain: cluster.local

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -690,6 +690,9 @@ spec:
                   enable_patroni_failsafe_mode:
                     type: boolean
                     default: false
+              allow_ephemeral_volumes:
+                type: boolean
+                default: false
           status:
             type: object
             additionalProperties:

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -220,3 +220,4 @@ configuration:
     # connection_pooler_user: "pooler"
   patroni:
     enable_patroni_failsafe_mode: false
+  allow_ephemeral_volumes: false

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -575,6 +575,9 @@ spec:
                         - PreferNoSchedule
                     tolerationSeconds:
                       type: integer
+              useEphemeralVolume:
+                type: boolean
+                default: false
               useLoadBalancer:
                 type: boolean
                 description: deprecated

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1966,6 +1966,9 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 							},
 						},
 					},
+					"allow_ephemeral_volums": {
+						Type: "boolean",
+					},
 				},
 			},
 			"status": {

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -898,6 +898,9 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 							},
 						},
 					},
+					"useEphemeralVolume": {
+						Type: "boolean",
+					},
 					"useLoadBalancer": {
 						Type:        "boolean",
 						Description: "deprecated",

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -287,6 +287,8 @@ type OperatorConfigurationData struct {
 	MinInstances                      int32  `json:"min_instances,omitempty"`
 	MaxInstances                      int32  `json:"max_instances,omitempty"`
 	IgnoreInstanceLimitsAnnotationKey string `json:"ignore_instance_limits_annotation_key,omitempty"`
+
+	AllowEphemeralVolumes *bool `json:"allow_ephemeral_volumes,omitempty"`
 }
 
 // Duration shortens this frequently used name

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -93,6 +93,9 @@ type PostgresSpec struct {
 	// deprecated json tags
 	InitContainersOld       []v1.Container `json:"init_containers,omitempty"`
 	PodPriorityClassNameOld string         `json:"pod_priority_class_name,omitempty"`
+
+	// Ephemeral settings
+	UseEphemeralVolume *bool `json:"useEphemeralVolume,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
@@ -881,6 +881,11 @@ func (in *PostgresSpec) DeepCopyInto(out *PostgresSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.UseEphemeralVolume != nil {
+		in, out := &in.UseEphemeralVolume, &out.UseEphemeralVolume
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
@@ -461,6 +461,11 @@ func (in *OperatorConfigurationData) DeepCopyInto(out *OperatorConfigurationData
 	out.LogicalBackup = in.LogicalBackup
 	in.ConnectionPooler.DeepCopyInto(&out.ConnectionPooler)
 	in.Patroni.DeepCopyInto(&out.Patroni)
+	if in.AllowEphemeralVolumes != nil {
+		in, out := &in.AllowEphemeralVolumes, &out.AllowEphemeralVolumes
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -692,6 +692,7 @@ func generateContainer(
 	privilegedMode bool,
 	privilegeEscalationMode *bool,
 	additionalPodCapabilities *v1.Capabilities,
+	useEphemeralVolumes *bool,
 ) *v1.Container {
 	return &v1.Container{
 		Name:            name,
@@ -1394,6 +1395,7 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 		c.OpConfig.Resources.SpiloPrivileged,
 		c.OpConfig.Resources.SpiloAllowPrivilegeEscalation,
 		generateCapabilities(c.OpConfig.AdditionalPodCapabilities),
+		nil,
 	)
 
 	// Patroni responds 200 to probe only if it either owns the leader lock or postgres is running and DCS is accessible
@@ -2287,6 +2289,7 @@ func (c *Cluster) generateLogicalBackupJob() (*batchv1.CronJob, error) {
 		[]v1.VolumeMount{},
 		c.OpConfig.SpiloPrivileged, // use same value as for normal DB pods
 		c.OpConfig.SpiloAllowPrivilegeEscalation,
+		nil,
 		nil,
 	)
 

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -277,5 +277,8 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 		fromCRD.ConnectionPooler.MaxDBConnections,
 		k8sutil.Int32ToPointer(constants.ConnectionPoolerMaxDBConnections))
 
+	// Ephemeral config
+	result.AllowEphemeralVolumes = util.CoalesceBool(fromCRD.AllowEphemeralVolumes, util.False())
+
 	return result
 }

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -253,6 +253,7 @@ type Config struct {
 	EnableSecretsDeletion                    *bool             `name:"enable_secrets_deletion" default:"true"`
 	EnablePersistentVolumeClaimDeletion      *bool             `name:"enable_persistent_volume_claim_deletion" default:"true"`
 	PersistentVolumeClaimRetentionPolicy     map[string]string `name:"persistent_volume_claim_retention_policy" default:"when_deleted:retain,when_scaled:retain"`
+	AllowEphemeralVolumes                    *bool             `json:"allow_ephemeral_volumes,omitempty"`
 }
 
 // MustMarshal marshals the config or panics


### PR DESCRIPTION
This PR adds support for using ephemeral volumes as a data backing for PostgresQL instances.

Fixes #618 