### PR TITLE
bump go version to 1.22.5

### DIFF
--- a/.github/workflows/publish_ghcr_image.yaml
+++ b/.github/workflows/publish_ghcr_image.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.22.3"
+          go-version: "^1.22.5"
 
       - name: Run unit tests
         run: make deps mocks test

--- a/.github/workflows/run_e2e.yaml
+++ b/.github/workflows/run_e2e.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-go@v2
       with:
-          go-version: "^1.22.3"
+          go-version: "^1.22.5"
     - name: Make dependencies
       run: make deps mocks
     - name: Code generation

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-          go-version: "^1.22.3"
+          go-version: "^1.22.5"
     - name: Make dependencies
       run: make deps mocks
     - name: Compile

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ docker: ${DOCKERDIR}/${DOCKERFILE}
 	docker build --rm -t "$(IMAGE):$(TAG)$(CDP_TAG)$(DEBUG_FRESH)$(DEBUG_POSTFIX)" -f "${DOCKERDIR}/${DOCKERFILE}" --build-arg VERSION="${VERSION}" .
 
 indocker-race:
-	docker run --rm -v "${GOPATH}":"${GOPATH}" -e GOPATH="${GOPATH}" -e RACE=1 -w ${PWD} golang:1.22.3 bash -c "make linux"
+	docker run --rm -v "${GOPATH}":"${GOPATH}" -e GOPATH="${GOPATH}" -e RACE=1 -w ${PWD} golang:1.22.5 bash -c "make linux"
 
 push:
 	docker push "$(IMAGE):$(TAG)$(CDP_TAG)"

--- a/README.md
+++ b/README.md
@@ -57,12 +57,14 @@ production for over five years.
 
 | Release   | Postgres versions | K8s versions      | Golang  |
 | :-------- | :---------------: | :---------------: | :-----: |
+| v1.13.0*  | 12 &rarr; 16      | 1.27+             | 1.22.5  |
 | v1.12.2   | 11 &rarr; 16      | 1.27+             | 1.22.3  |
 | v1.11.0   | 11 &rarr; 16      | 1.27+             | 1.21.7  |
 | v1.10.1   | 10 &rarr; 15      | 1.21+             | 1.19.8  |
 | v1.9.0    | 10 &rarr; 15      | 1.21+             | 1.18.9  |
 | v1.8.2    | 9.5 &rarr; 14     | 1.20 &rarr; 1.24  | 1.17.4  |
 
+*not yet released
 
 ## Getting started
 

--- a/docker/build_operator.sh
+++ b/docker/build_operator.sh
@@ -13,7 +13,7 @@ apt-get install -y wget
 
 (
     cd /tmp
-    wget -q "https://storage.googleapis.com/golang/go1.22.3.linux-${arch}.tar.gz" -O go.tar.gz
+    wget -q "https://storage.googleapis.com/golang/go1.22.5.linux-${arch}.tar.gz" -O go.tar.gz
     tar -xf go.tar.gz
     mv go /usr/local
     ln -s /usr/local/go/bin/go /usr/bin/go


### PR DESCRIPTION
to close open vulnerabilities with current go version