### PR TITLE
stream: slot and FES should not be created if the publication creation fails

### DIFF
--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -2075,7 +2075,7 @@ class EndToEndTestCase(unittest.TestCase):
         self.eventuallyEqual(lambda: len(self.query_database(leader.metadata.name, "foo", get_slot_query)), 1,
             "Replication slot is not created", 10, 5)
         self.eventuallyEqual(lambda: len(k8s.api.custom_objects_api.list_namespaced_custom_object(
-                "zalando.org", "v1", "default", "fabriceventstreams", label_selector="cluster-name=acid-minimal-cluster")["items"]), 2,
+                "zalando.org", "v1", "default", "fabriceventstreams", label_selector="cluster-name=acid-minimal-cluster")["items"]), 1,
                 "Could not find Fabric Event Stream resource", 10, 5)
 
         # check if the non-existing table in the stream section does not create a publication and slot

--- a/pkg/cluster/streams.go
+++ b/pkg/cluster/streams.go
@@ -134,7 +134,6 @@ func (c *Cluster) syncPublication(dbName string, databaseSlotsList map[string]za
 		} else if currentTables != tableList {
 			alterPublications[slotName] = tableList
 		}
-		(*slotsToSync)[slotName] = slotAndPublication.Slot
 	}
 
 	// check if there is any deletion
@@ -152,17 +151,19 @@ func (c *Cluster) syncPublication(dbName string, databaseSlotsList map[string]za
 		if err = c.executeCreatePublication(publicationName, tables); err != nil {
 			return fmt.Errorf("creation of publication %q failed: %v", publicationName, err)
 		}
+		(*slotsToSync)[publicationName] = databaseSlotsList[publicationName].Slot
 	}
 	for publicationName, tables := range alterPublications {
 		if err = c.executeAlterPublication(publicationName, tables); err != nil {
 			return fmt.Errorf("update of publication %q failed: %v", publicationName, err)
 		}
+		(*slotsToSync)[publicationName] = databaseSlotsList[publicationName].Slot
 	}
 	for _, publicationName := range deletePublications {
-		(*slotsToSync)[publicationName] = nil
 		if err = c.executeDropPublication(publicationName); err != nil {
 			return fmt.Errorf("deletion of publication %q failed: %v", publicationName, err)
 		}
+		(*slotsToSync)[publicationName] = nil
 	}
 
 	return nil

--- a/pkg/cluster/streams.go
+++ b/pkg/cluster/streams.go
@@ -147,26 +147,30 @@ func (c *Cluster) syncPublication(dbName string, databaseSlotsList map[string]za
 		return nil
 	}
 
+	var errorMessage error = nil
 	for publicationName, tables := range createPublications {
 		if err = c.executeCreatePublication(publicationName, tables); err != nil {
-			return fmt.Errorf("creation of publication %q failed: %v", publicationName, err)
+			errorMessage = fmt.Errorf("creation of publication %q failed: %v", publicationName, err)
+			continue
 		}
 		(*slotsToSync)[publicationName] = databaseSlotsList[publicationName].Slot
 	}
 	for publicationName, tables := range alterPublications {
 		if err = c.executeAlterPublication(publicationName, tables); err != nil {
-			return fmt.Errorf("update of publication %q failed: %v", publicationName, err)
+			errorMessage = fmt.Errorf("update of publication %q failed: %v", publicationName, err)
+			continue
 		}
 		(*slotsToSync)[publicationName] = databaseSlotsList[publicationName].Slot
 	}
 	for _, publicationName := range deletePublications {
 		if err = c.executeDropPublication(publicationName); err != nil {
-			return fmt.Errorf("deletion of publication %q failed: %v", publicationName, err)
+			errorMessage = fmt.Errorf("deletion of publication %q failed: %v", publicationName, err)
+			continue
 		}
 		(*slotsToSync)[publicationName] = nil
 	}
 
-	return nil
+	return errorMessage
 }
 
 func (c *Cluster) generateFabricEventStream(appId string) *zalandov1.FabricEventStream {
@@ -391,7 +395,7 @@ func (c *Cluster) syncStreams() error {
 	}
 
 	// finally sync stream CRDs
-	err = c.createOrUpdateStreams()
+	err = c.createOrUpdateStreams(slotsToSync)
 	if err != nil {
 		return err
 	}
@@ -399,7 +403,7 @@ func (c *Cluster) syncStreams() error {
 	return nil
 }
 
-func (c *Cluster) createOrUpdateStreams() error {
+func (c *Cluster) createOrUpdateStreams(createdSlots map[string]map[string]string) error {
 
 	// fetch different application IDs from streams section
 	// there will be a separate event stream resource for each ID
@@ -414,7 +418,7 @@ func (c *Cluster) createOrUpdateStreams() error {
 		return fmt.Errorf("could not list of FabricEventStreams: %v", err)
 	}
 
-	for _, appId := range appIds {
+	for idx, appId := range appIds {
 		streamExists := false
 
 		// update stream when it exists and EventStreams array differs
@@ -436,6 +440,12 @@ func (c *Cluster) createOrUpdateStreams() error {
 		}
 
 		if !streamExists {
+			// check if there is any slot with the applicationId
+			slotName := getSlotName(c.Spec.Streams[idx].Database, appId)
+			if _, exists := createdSlots[slotName]; !exists {
+				c.logger.Warningf("no slot %s with applicationId %s exists, skipping event stream creation", slotName, appId)
+				continue
+			}
 			c.logger.Infof("event streams with applicationId %s do not exist, create it", appId)
 			streamCRD, err := c.createStreams(appId)
 			if err != nil {

--- a/pkg/cluster/streams_test.go
+++ b/pkg/cluster/streams_test.go
@@ -41,6 +41,10 @@ var (
 	fesUser     string = fmt.Sprintf("%s%s", constants.EventStreamSourceSlotPrefix, constants.UserRoleNameSuffix)
 	slotName    string = fmt.Sprintf("%s_%s_%s", constants.EventStreamSourceSlotPrefix, dbName, strings.Replace(appId, "-", "_", -1))
 
+	fakeCreatedSlots map[string]map[string]string = map[string]map[string]string{
+		slotName: {},
+	}
+
 	pg = acidv1.Postgresql{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Postgresql",
@@ -222,7 +226,7 @@ func TestGenerateFabricEventStream(t *testing.T) {
 	assert.NoError(t, err)
 
 	// create the streams
-	err = cluster.createOrUpdateStreams()
+	err = cluster.createOrUpdateStreams(fakeCreatedSlots)
 	assert.NoError(t, err)
 
 	// compare generated stream with expected stream
@@ -248,7 +252,7 @@ func TestGenerateFabricEventStream(t *testing.T) {
 	}
 
 	// sync streams once again
-	err = cluster.createOrUpdateStreams()
+	err = cluster.createOrUpdateStreams(fakeCreatedSlots)
 	assert.NoError(t, err)
 
 	streams, err = cluster.KubeClient.FabricEventStreams(namespace).List(context.TODO(), listOptions)
@@ -397,7 +401,7 @@ func TestUpdateFabricEventStream(t *testing.T) {
 	assert.NoError(t, err)
 
 	// now create the stream
-	err = cluster.createOrUpdateStreams()
+	err = cluster.createOrUpdateStreams(fakeCreatedSlots)
 	assert.NoError(t, err)
 
 	// change specs of streams and patch CRD
@@ -419,7 +423,7 @@ func TestUpdateFabricEventStream(t *testing.T) {
 	assert.NoError(t, err)
 
 	cluster.Postgresql.Spec = pgPatched.Spec
-	err = cluster.createOrUpdateStreams()
+	err = cluster.createOrUpdateStreams(fakeCreatedSlots)
 	assert.NoError(t, err)
 
 	// compare stream returned from API with expected stream
@@ -448,7 +452,7 @@ func TestUpdateFabricEventStream(t *testing.T) {
 	assert.NoError(t, err)
 
 	cluster.Postgresql.Spec = pgPatched.Spec
-	err = cluster.createOrUpdateStreams()
+	err = cluster.createOrUpdateStreams(fakeCreatedSlots)
 	assert.NoError(t, err)
 
 	result = cluster.generateFabricEventStream(appId)
@@ -466,7 +470,7 @@ func TestUpdateFabricEventStream(t *testing.T) {
 	assert.NoError(t, err)
 
 	cluster.Postgresql.Spec = pgUpdated.Spec
-	cluster.createOrUpdateStreams()
+	cluster.createOrUpdateStreams(fakeCreatedSlots)
 
 	streamList, err := cluster.KubeClient.FabricEventStreams(namespace).List(context.TODO(), listOptions)
 	if len(streamList.Items) > 0 || err != nil {


### PR DESCRIPTION
This pull request addresses two related issues regarding the stream section during publication and slot creation:

1. Conditional FES Resource Creation:
    The FES (Fabric Event Stream) resource will no longer be created if the logical slot does not exist. Previously, there was a bug causing the FES resource to be created regardless of the existence of the logical slot. This was not the expected behavior because creating the FES resource would trigger the FES operator to create publications and slots if they were missing. If publication and slot creation were not possible (e.g., due to missing tables), it would result in failures.

2. Logical Slot Creation/Deletion Based on Publication Modification:
    The logical slot will now only be created or deleted if the publication modification is successful. Following the changes in #2684, a logical slot was being created regardless of whether the publication creation was successful. This change ensures that logical slot creation is consistent with the success of publication modification, preventing potential issues related to dangling slots that accumulate WAL (Write-Ahead Logging) entries, which could result in risk to the cluster.
    
    
