### PR TITLE
bump spilo to 16-3.3, drop support for pg11

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -68,7 +68,7 @@ spec:
                   type: string
               docker_image:
                 type: string
-                default: "ghcr.io/zalando/spilo-16:3.2-p3"
+                default: "ghcr.io/zalando/spilo-16:3.3-p1"
               enable_crd_registration:
                 type: boolean
                 default: true

--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -375,7 +375,6 @@ spec:
                   version:
                     type: string
                     enum:
-                      - "11"
                       - "12"
                       - "13"
                       - "14"

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -38,7 +38,7 @@ configGeneral:
   # etcd connection string for Patroni. Empty uses K8s-native DCS.
   etcd_host: ""
   # Spilo docker image
-  docker_image: ghcr.io/zalando/spilo-16:3.2-p3
+  docker_image: ghcr.io/zalando/spilo-16:3.3-p1
 
   # key name for annotation to ignore globally configured instance limits
   # ignore_instance_limits_annotation_key: ""

--- a/manifests/complete-postgres-manifest.yaml
+++ b/manifests/complete-postgres-manifest.yaml
@@ -10,7 +10,7 @@ metadata:
 #    "delete-date": "2020-08-31"  # can only be deleted on that day if "delete-date "key is configured
 #    "delete-clustername": "acid-test-cluster"  # can only be deleted when name matches if "delete-clustername" key is configured
 spec:
-  dockerImage: ghcr.io/zalando/spilo-16:3.2-p3
+  dockerImage: ghcr.io/zalando/spilo-16:3.3-p1
   teamId: "acid"
   numberOfInstances: 2
   users:  # Application/Robot users

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -34,7 +34,7 @@ data:
   default_memory_request: 100Mi
   # delete_annotation_date_key: delete-date
   # delete_annotation_name_key: delete-clustername
-  docker_image: ghcr.io/zalando/spilo-16:3.2-p3
+  docker_image: ghcr.io/zalando/spilo-16:3.3-p1
   # downscaler_annotations: "deployment-time,downscaler/*"
   # enable_admin_role_for_users: "true"
   # enable_crd_registration: "true"

--- a/manifests/minimal-postgres-manifest.yaml
+++ b/manifests/minimal-postgres-manifest.yaml
@@ -15,6 +15,7 @@ spec:
   databases:
     foo: zalando  # dbname: owner
   preparedDatabases:
-    bar: {}
+    bar:
+      defaultUsers: true
   postgresql:
-    version: "16"
+    version: "14"

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -66,7 +66,7 @@ spec:
                   type: string
               docker_image:
                 type: string
-                default: "ghcr.io/zalando/spilo-16:3.2-p3"
+                default: "ghcr.io/zalando/spilo-16:3.3-p1"
               enable_crd_registration:
                 type: boolean
                 default: true

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -3,7 +3,7 @@ kind: OperatorConfiguration
 metadata:
   name: postgresql-operator-default-configuration
 configuration:
-  docker_image: ghcr.io/zalando/spilo-16:3.2-p3
+  docker_image: ghcr.io/zalando/spilo-16:3.3-p1
   # enable_crd_registration: true
   # crd_categories:
   # - all

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -373,7 +373,6 @@ spec:
                   version:
                     type: string
                     enum:
-                      - "11"
                       - "12"
                       - "13"
                       - "14"

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -596,9 +596,6 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 								Type: "string",
 								Enum: []apiextv1.JSON{
 									{
-										Raw: []byte(`"11"`),
-									},
-									{
 										Raw: []byte(`"12"`),
 									},
 									{

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -11,7 +11,6 @@ import (
 
 // VersionMap Map of version numbers
 var VersionMap = map[string]int{
-	"11": 110000,
 	"12": 120000,
 	"13": 130000,
 	"14": 140000,

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -39,7 +39,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.EnableTeamIdClusternamePrefix = fromCRD.EnableTeamIdClusternamePrefix
 	result.EtcdHost = fromCRD.EtcdHost
 	result.KubernetesUseConfigMaps = fromCRD.KubernetesUseConfigMaps
-	result.DockerImage = util.Coalesce(fromCRD.DockerImage, "ghcr.io/zalando/spilo-16:3.2-p3")
+	result.DockerImage = util.Coalesce(fromCRD.DockerImage, "ghcr.io/zalando/spilo-16:3.3-p1")
 	result.Workers = util.CoalesceUInt32(fromCRD.Workers, 8)
 	result.MinInstances = fromCRD.MinInstances
 	result.MaxInstances = fromCRD.MaxInstances

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -174,7 +174,7 @@ type Config struct {
 	WatchedNamespace        string            `name:"watched_namespace"` // special values: "*" means 'watch all namespaces', the empty string "" means 'watch a namespace where operator is deployed to'
 	KubernetesUseConfigMaps bool              `name:"kubernetes_use_configmaps" default:"false"`
 	EtcdHost                string            `name:"etcd_host" default:""` // special values: the empty string "" means Patroni will use K8s as a DCS
-	DockerImage             string            `name:"docker_image" default:"ghcr.io/zalando/spilo-16:3.2-p3"`
+	DockerImage             string            `name:"docker_image" default:"ghcr.io/zalando/spilo-16:3.3-p1"`
 	SidecarImages           map[string]string `name:"sidecar_docker_images"` // deprecated in favour of SidecarContainers
 	SidecarContainers       []v1.Container    `name:"sidecars"`
 	PodServiceAccountName   string            `name:"pod_service_account_name" default:"postgres-pod"`

--- a/ui/operator_ui/spiloutils.py
+++ b/ui/operator_ui/spiloutils.py
@@ -305,7 +305,7 @@ def read_versions(
         if uid == 'wal' or defaulting(lambda: UUID(uid))
     ]
 
-BACKUP_VERSION_PREFIXES = ['', '9.6/', '10/', '11/', '12/', '13/', '14/', '15/', '16/']
+BACKUP_VERSION_PREFIXES = ['', '10/', '11/', '12/', '13/', '14/', '15/', '16/']
 
 def read_basebackups(
     pg_cluster,


### PR DESCRIPTION
Newest Spilo image does not support Pg 11 anymore. Thus, we drop support from operator to.