### PR TITLE
Fix synchronous_mode/synchronous_mode_strict ignored when set to false

### DIFF
--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -178,8 +178,8 @@ type Patroni struct {
 	RetryTimeout          uint32                       `json:"retry_timeout,omitempty"`
 	MaximumLagOnFailover  float32                      `json:"maximum_lag_on_failover,omitempty"` // float32 because https://github.com/kubernetes/kubernetes/issues/30213
 	Slots                 map[string]map[string]string `json:"slots,omitempty"`
-	SynchronousMode       bool                         `json:"synchronous_mode,omitempty"`
-	SynchronousModeStrict bool                         `json:"synchronous_mode_strict,omitempty"`
+	SynchronousMode       bool                         `json:"synchronous_mode"`
+	SynchronousModeStrict bool                         `json:"synchronous_mode_strict"`
 	SynchronousNodeCount  uint32                       `json:"synchronous_node_count,omitempty" defaults:"1"`
 	FailsafeMode          *bool                        `json:"failsafe_mode,omitempty"`
 }


### PR DESCRIPTION
In my use case, I import the package from https://github.com/zalando/postgres-operator/tree/master/pkg/apis/acid.zalan.do/v1 into my Golang project. In my project, I use Golang to populate the PostgreSQL resource, and then use client-go to create the resource. However, when updating the PostgreSQL resource, like setting spec.patroni.synchronousMode to false, it gets ignored after marshaling to a string because of the omitempty tag. In my opinion, these fields should not have the omitempty tag.