### PR TITLE
let operator fix publications without tables

### DIFF
--- a/pkg/cluster/database.go
+++ b/pkg/cluster/database.go
@@ -46,7 +46,7 @@ const (
 	createExtensionSQL      = `CREATE EXTENSION IF NOT EXISTS "%s" SCHEMA "%s"`
 	alterExtensionSQL       = `ALTER EXTENSION "%s" SET SCHEMA "%s"`
 
-	getPublicationsSQL = `SELECT p.pubname, string_agg(pt.schemaname || '.' || pt.tablename, ', ' ORDER BY pt.schemaname, pt.tablename)
+	getPublicationsSQL = `SELECT p.pubname, COALESCE(string_agg(pt.schemaname || '.' || pt.tablename, ', ' ORDER BY pt.schemaname, pt.tablename), '') AS pubtables
 	        FROM pg_publication p
 			LEFT JOIN pg_publication_tables pt ON pt.pubname = p.pubname
 			WHERE p.pubowner = 'postgres'::regrole


### PR DESCRIPTION
We had the situation that a publication, slot and stream CRD were there but no publication tables. Not sure, how we ended up there. Maybe the stream operator created it after our operator did not block the slot and crd creation even when the table did not exist yet.

No publication tables leads to the following error in the operator:
```
could not sync publications in database "my_db": could not get current publications: error when processing row: sql: Scan error on column index 1, name "string_agg": converting NULL to string is unsupported
```

To support NULL values one can use go.sql's NullString implementation to catch this. But what to do next then? Set publications[pubName] = nil? This would make a later [comparison](https://github.com/zalando/postgres-operator/blob/master/pkg/cluster/streams.go#L134) between desired and current tables impossible.

Instead, this PR suggest to return an empty string. On sync the diff should be noticed and the operator would alter the publication and set a new table list.