### PR TITLE
fix sync streams and add diffs for annotations and owner references

### DIFF
--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -73,7 +73,7 @@ func (c *Cluster) majorVersionUpgrade() error {
 		return nil
 	}
 
-	if !c.isInMainternanceWindow() {
+	if !isInMainternanceWindow(c.Spec.MaintenanceWindows) {
 		c.logger.Infof("skipping major version upgrade, not in maintenance window")
 		return nil
 	}

--- a/pkg/cluster/streams.go
+++ b/pkg/cluster/streams.go
@@ -128,6 +128,8 @@ func (c *Cluster) syncPublication(dbName string, databaseSlotsList map[string]za
 			createPublications[slotName] = tableList
 		} else if currentTables != tableList {
 			alterPublications[slotName] = tableList
+		} else {
+			(*slotsToSync)[slotName] = slotAndPublication.Slot
 		}
 	}
 
@@ -142,30 +144,34 @@ func (c *Cluster) syncPublication(dbName string, databaseSlotsList map[string]za
 		return nil
 	}
 
-	var errorMessage error = nil
+	errors := make([]string, 0)
 	for publicationName, tables := range createPublications {
 		if err = c.executeCreatePublication(publicationName, tables); err != nil {
-			errorMessage = fmt.Errorf("creation of publication %q failed: %v", publicationName, err)
+			errors = append(errors, fmt.Sprintf("creation of publication %q failed: %v", publicationName, err))
 			continue
 		}
 		(*slotsToSync)[publicationName] = databaseSlotsList[publicationName].Slot
 	}
 	for publicationName, tables := range alterPublications {
 		if err = c.executeAlterPublication(publicationName, tables); err != nil {
-			errorMessage = fmt.Errorf("update of publication %q failed: %v", publicationName, err)
+			errors = append(errors, fmt.Sprintf("update of publication %q failed: %v", publicationName, err))
 			continue
 		}
 		(*slotsToSync)[publicationName] = databaseSlotsList[publicationName].Slot
 	}
 	for _, publicationName := range deletePublications {
 		if err = c.executeDropPublication(publicationName); err != nil {
-			errorMessage = fmt.Errorf("deletion of publication %q failed: %v", publicationName, err)
+			errors = append(errors, fmt.Sprintf("deletion of publication %q failed: %v", publicationName, err))
 			continue
 		}
 		(*slotsToSync)[publicationName] = nil
 	}
 
-	return errorMessage
+	if len(errors) > 0 {
+		return fmt.Errorf("%v", strings.Join(errors, `', '`))
+	}
+
+	return nil
 }
 
 func (c *Cluster) generateFabricEventStream(appId string) *zalandov1.FabricEventStream {
@@ -370,7 +376,7 @@ func (c *Cluster) syncStreams() error {
 	for dbName, databaseSlotsList := range databaseSlots {
 		err := c.syncPublication(dbName, databaseSlotsList, &slotsToSync)
 		if err != nil {
-			c.logger.Warningf("could not sync publications in database %q: %v", dbName, err)
+			c.logger.Warningf("could not sync all publications in database %q: %v", dbName, err)
 			continue
 		}
 	}
@@ -393,12 +399,12 @@ func (c *Cluster) syncStreams() error {
 	// there will be a separate event stream resource for each ID
 	appIds := getDistinctApplicationIds(c.Spec.Streams)
 	for _, appId := range appIds {
-		if c.hasSlotsInSync(appId, databaseSlots, slotsToSync) {
+		if hasSlotsInSync(appId, databaseSlots, slotsToSync) {
 			if err = c.syncStream(appId); err != nil {
 				c.logger.Warningf("could not sync event streams with applicationId %s: %v", appId, err)
 			}
 		} else {
-			c.logger.Warningf("database replication slots for streams with applicationId %s not in sync, skipping event stream sync", appId)
+			c.logger.Warningf("database replication slots %#v for streams with applicationId %s not in sync, skipping event stream sync", slotsToSync, appId)
 		}
 	}
 
@@ -410,14 +416,13 @@ func (c *Cluster) syncStreams() error {
 	return nil
 }
 
-func (c *Cluster) hasSlotsInSync(appId string, databaseSlots map[string]map[string]zalandov1.Slot, slotsToSync map[string]map[string]string) bool {
+func hasSlotsInSync(appId string, databaseSlots map[string]map[string]zalandov1.Slot, slotsToSync map[string]map[string]string) bool {
 	allSlotsInSync := true
 	for dbName, slots := range databaseSlots {
 		for slotName := range slots {
 			if slotName == getSlotName(dbName, appId) {
-				if _, exists := slotsToSync[slotName]; !exists {
+				if slot, exists := slotsToSync[slotName]; !exists || slot == nil {
 					allSlotsInSync = false
-					c.logger.Warnf("replication slot %q for applicationId %s not found in database", slotName, appId)
 					continue
 				}
 			}
@@ -434,7 +439,17 @@ func (c *Cluster) syncStream(appId string) error {
 		if appId == stream.Spec.ApplicationId {
 			streamExists = true
 			desiredStreams := c.generateFabricEventStream(appId)
-			if match, reason := sameStreams(stream.Spec.EventStreams, desiredStreams.Spec.EventStreams); !match {
+			if !reflect.DeepEqual(stream.ObjectMeta.OwnerReferences, desiredStreams.ObjectMeta.OwnerReferences) {
+				c.logger.Infof("owner references of event streams with applicationId %s do not match the current ones", appId)
+				stream.ObjectMeta.OwnerReferences = desiredStreams.ObjectMeta.OwnerReferences
+				c.setProcessName("updating event streams with applicationId %s", appId)
+				stream, err := c.KubeClient.FabricEventStreams(stream.Namespace).Update(context.TODO(), stream, metav1.UpdateOptions{})
+				if err != nil {
+					return fmt.Errorf("could not update event streams with applicationId %s: %v", appId, err)
+				}
+				c.Streams[appId] = stream
+			}
+			if match, reason := c.compareStreams(stream, desiredStreams); !match {
 				c.logger.Debugf("updating event streams with applicationId %s: %s", appId, reason)
 				desiredStreams.ObjectMeta = stream.ObjectMeta
 				updatedStream, err := c.updateStreams(desiredStreams)
@@ -461,7 +476,24 @@ func (c *Cluster) syncStream(appId string) error {
 	return nil
 }
 
-func sameStreams(curEventStreams, newEventStreams []zalandov1.EventStream) (match bool, reason string) {
+func (c *Cluster) compareStreams(curEventStreams, newEventStreams *zalandov1.FabricEventStream) (match bool, reason string) {
+	reasons := make([]string, 0)
+	match = true
+
+	if changed, reason := c.compareAnnotations(curEventStreams.ObjectMeta.Annotations, newEventStreams.ObjectMeta.Annotations); changed {
+		match = false
+		reasons = append(reasons, fmt.Sprintf("new streams annotations do not match: %s", reason))
+	}
+
+	if changed, reason := sameEventStreams(curEventStreams.Spec.EventStreams, newEventStreams.Spec.EventStreams); !changed {
+		match = false
+		reasons = append(reasons, fmt.Sprintf("new streams EventStreams array does not match : %s", reason))
+	}
+
+	return match, strings.Join(reasons, ", ")
+}
+
+func sameEventStreams(curEventStreams, newEventStreams []zalandov1.EventStream) (match bool, reason string) {
 	if len(newEventStreams) != len(curEventStreams) {
 		return false, "number of defined streams is different"
 	}

--- a/pkg/cluster/streams.go
+++ b/pkg/cluster/streams.go
@@ -480,7 +480,9 @@ func (c *Cluster) compareStreams(curEventStreams, newEventStreams *zalandov1.Fab
 	reasons := make([]string, 0)
 	match = true
 
-	if changed, reason := c.compareAnnotations(curEventStreams.ObjectMeta.Annotations, newEventStreams.ObjectMeta.Annotations); changed {
+	// stream operator can add extra annotations so incl. current annotations in desired annotations
+	desiredAnnotations := c.annotationsSet(curEventStreams.Annotations)
+	if changed, reason := c.compareAnnotations(curEventStreams.ObjectMeta.Annotations, desiredAnnotations); changed {
 		match = false
 		reasons = append(reasons, fmt.Sprintf("new streams annotations do not match: %s", reason))
 	}

--- a/pkg/cluster/streams_test.go
+++ b/pkg/cluster/streams_test.go
@@ -18,28 +18,24 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
-func newFakeK8sStreamClient() (k8sutil.KubernetesClient, *fake.Clientset) {
-	zalandoClientSet := fakezalandov1.NewSimpleClientset()
-	clientSet := fake.NewSimpleClientset()
-
-	return k8sutil.KubernetesClient{
-		FabricEventStreamsGetter: zalandoClientSet.ZalandoV1(),
-		PostgresqlsGetter:        zalandoClientSet.AcidV1(),
-		PodsGetter:               clientSet.CoreV1(),
-		StatefulSetsGetter:       clientSet.AppsV1(),
-	}, clientSet
-}
-
 var (
-	clusterName string = "acid-test-cluster"
+	clusterName string = "acid-stream-cluster"
 	namespace   string = "default"
 	appId       string = "test-app"
 	dbName      string = "foo"
 	fesUser     string = fmt.Sprintf("%s%s", constants.EventStreamSourceSlotPrefix, constants.UserRoleNameSuffix)
 	slotName    string = fmt.Sprintf("%s_%s_%s", constants.EventStreamSourceSlotPrefix, dbName, strings.Replace(appId, "-", "_", -1))
+
+	zalandoClientSet = fakezalandov1.NewSimpleClientset()
+
+	client = k8sutil.KubernetesClient{
+		FabricEventStreamsGetter: zalandoClientSet.ZalandoV1(),
+		PostgresqlsGetter:        zalandoClientSet.AcidV1(),
+		PodsGetter:               clientSet.CoreV1(),
+		StatefulSetsGetter:       clientSet.AppsV1(),
+	}
 
 	pg = acidv1.Postgresql{
 		TypeMeta: metav1.TypeMeta{
@@ -181,20 +177,8 @@ var (
 			},
 		},
 	}
-)
 
-func TestGatherApplicationIds(t *testing.T) {
-	testAppIds := []string{appId}
-	appIds := getDistinctApplicationIds(pg.Spec.Streams)
-
-	if !util.IsEqualIgnoreOrder(testAppIds, appIds) {
-		t.Errorf("list of applicationIds does not match, expected %#v, got %#v", testAppIds, appIds)
-	}
-}
-
-func TestHasSlotsInSync(t *testing.T) {
-	client, _ := newFakeK8sStreamClient()
-	var cluster = New(
+	cluster = New(
 		Config{
 			OpConfig: config.Config{
 				Auth: config.Auth{
@@ -212,7 +196,18 @@ func TestHasSlotsInSync(t *testing.T) {
 				},
 			},
 		}, client, pg, logger, eventRecorder)
+)
 
+func TestGatherApplicationIds(t *testing.T) {
+	testAppIds := []string{appId}
+	appIds := getDistinctApplicationIds(pg.Spec.Streams)
+
+	if !util.IsEqualIgnoreOrder(testAppIds, appIds) {
+		t.Errorf("list of applicationIds does not match, expected %#v, got %#v", testAppIds, appIds)
+	}
+}
+
+func TestHasSlotsInSync(t *testing.T) {
 	cluster.Name = clusterName
 	cluster.Namespace = namespace
 
@@ -403,7 +398,7 @@ func TestHasSlotsInSync(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result := cluster.hasSlotsInSync(tt.applicationId, tt.expectedSlots, tt.actualSlots)
+		result := hasSlotsInSync(tt.applicationId, tt.expectedSlots, tt.actualSlots)
 		if result != tt.slotsInSync {
 			t.Errorf("%s: unexpected result for slot test of applicationId: %v, expected slots %#v, actual slots %#v", tt.subTest, tt.applicationId, tt.expectedSlots, tt.actualSlots)
 		}
@@ -411,27 +406,6 @@ func TestHasSlotsInSync(t *testing.T) {
 }
 
 func TestGenerateFabricEventStream(t *testing.T) {
-	client, _ := newFakeK8sStreamClient()
-
-	var cluster = New(
-		Config{
-			OpConfig: config.Config{
-				Auth: config.Auth{
-					SecretNameTemplate: "{username}.{cluster}.credentials.{tprkind}.{tprgroup}",
-				},
-				PodManagementPolicy: "ordered_ready",
-				Resources: config.Resources{
-					ClusterLabels:        map[string]string{"application": "spilo"},
-					ClusterNameLabel:     "cluster-name",
-					DefaultCPURequest:    "300m",
-					DefaultCPULimit:      "300m",
-					DefaultMemoryRequest: "300Mi",
-					DefaultMemoryLimit:   "300Mi",
-					PodRoleLabel:         "spilo-role",
-				},
-			},
-		}, client, pg, logger, eventRecorder)
-
 	cluster.Name = clusterName
 	cluster.Namespace = namespace
 
@@ -445,7 +419,7 @@ func TestGenerateFabricEventStream(t *testing.T) {
 
 	// compare generated stream with expected stream
 	result := cluster.generateFabricEventStream(appId)
-	if match, _ := sameStreams(result.Spec.EventStreams, fes.Spec.EventStreams); !match {
+	if match, _ := cluster.compareStreams(result, fes); !match {
 		t.Errorf("malformed FabricEventStream, expected %#v, got %#v", fes, result)
 	}
 
@@ -461,7 +435,7 @@ func TestGenerateFabricEventStream(t *testing.T) {
 	}
 
 	// compare stream returned from API with expected stream
-	if match, _ := sameStreams(streams.Items[0].Spec.EventStreams, fes.Spec.EventStreams); !match {
+	if match, _ := cluster.compareStreams(&streams.Items[0], fes); !match {
 		t.Errorf("malformed FabricEventStream returned from API, expected %#v, got %#v", fes, streams.Items[0])
 	}
 
@@ -478,13 +452,28 @@ func TestGenerateFabricEventStream(t *testing.T) {
 	}
 
 	// compare stream resturned from API with generated stream
-	if match, _ := sameStreams(streams.Items[0].Spec.EventStreams, result.Spec.EventStreams); !match {
+	if match, _ := cluster.compareStreams(&streams.Items[0], result); !match {
 		t.Errorf("returned FabricEventStream differs from generated one, expected %#v, got %#v", result, streams.Items[0])
+	}
+}
+
+func newFabricEventStream(streams []zalandov1.EventStream, annotations map[string]string) *zalandov1.FabricEventStream {
+	return &zalandov1.FabricEventStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        fmt.Sprintf("%s-12345", clusterName),
+			Annotations: annotations,
+		},
+		Spec: zalandov1.FabricEventStreamSpec{
+			ApplicationId: appId,
+			EventStreams:  streams,
+		},
 	}
 }
 
 func TestSameStreams(t *testing.T) {
 	testName := "TestSameStreams"
+	annotationsA := map[string]string{"owned-by": "acid"}
+	annotationsB := map[string]string{"owned-by": "foo"}
 
 	stream1 := zalandov1.EventStream{
 		EventStreamFlow:     zalandov1.EventStreamFlow{},
@@ -529,57 +518,64 @@ func TestSameStreams(t *testing.T) {
 
 	tests := []struct {
 		subTest  string
-		streamsA []zalandov1.EventStream
-		streamsB []zalandov1.EventStream
+		streamsA *zalandov1.FabricEventStream
+		streamsB *zalandov1.FabricEventStream
 		match    bool
 		reason   string
 	}{
 		{
 			subTest:  "identical streams",
-			streamsA: []zalandov1.EventStream{stream1, stream2},
-			streamsB: []zalandov1.EventStream{stream1, stream2},
+			streamsA: newFabricEventStream([]zalandov1.EventStream{stream1, stream2}, annotationsA),
+			streamsB: newFabricEventStream([]zalandov1.EventStream{stream1, stream2}, annotationsA),
 			match:    true,
 			reason:   "",
 		},
 		{
 			subTest:  "same streams different order",
-			streamsA: []zalandov1.EventStream{stream1, stream2},
-			streamsB: []zalandov1.EventStream{stream2, stream1},
+			streamsA: newFabricEventStream([]zalandov1.EventStream{stream1, stream2}, nil),
+			streamsB: newFabricEventStream([]zalandov1.EventStream{stream2, stream1}, nil),
 			match:    true,
 			reason:   "",
 		},
 		{
 			subTest:  "same streams different order",
-			streamsA: []zalandov1.EventStream{stream1},
-			streamsB: []zalandov1.EventStream{stream1, stream2},
+			streamsA: newFabricEventStream([]zalandov1.EventStream{stream1}, nil),
+			streamsB: newFabricEventStream([]zalandov1.EventStream{stream1, stream2}, nil),
 			match:    false,
 			reason:   "number of defined streams is different",
 		},
 		{
 			subTest:  "different number of streams",
-			streamsA: []zalandov1.EventStream{stream1},
-			streamsB: []zalandov1.EventStream{stream1, stream2},
+			streamsA: newFabricEventStream([]zalandov1.EventStream{stream1}, nil),
+			streamsB: newFabricEventStream([]zalandov1.EventStream{stream1, stream2}, nil),
 			match:    false,
 			reason:   "number of defined streams is different",
 		},
 		{
 			subTest:  "event stream specs differ",
-			streamsA: []zalandov1.EventStream{stream1, stream2},
-			streamsB: fes.Spec.EventStreams,
+			streamsA: newFabricEventStream([]zalandov1.EventStream{stream1, stream2}, nil),
+			streamsB: fes,
 			match:    false,
 			reason:   "number of defined streams is different",
 		},
 		{
 			subTest:  "event stream recovery specs differ",
-			streamsA: []zalandov1.EventStream{stream2},
-			streamsB: []zalandov1.EventStream{stream3},
+			streamsA: newFabricEventStream([]zalandov1.EventStream{stream2}, nil),
+			streamsB: newFabricEventStream([]zalandov1.EventStream{stream3}, nil),
+			match:    false,
+			reason:   "event stream specs differ",
+		},
+		{
+			subTest:  "event stream annotations differ",
+			streamsA: newFabricEventStream([]zalandov1.EventStream{stream2}, annotationsA),
+			streamsB: newFabricEventStream([]zalandov1.EventStream{stream3}, annotationsB),
 			match:    false,
 			reason:   "event stream specs differ",
 		},
 	}
 
 	for _, tt := range tests {
-		streamsMatch, matchReason := sameStreams(tt.streamsA, tt.streamsB)
+		streamsMatch, matchReason := cluster.compareStreams(tt.streamsA, tt.streamsB)
 		if streamsMatch != tt.match {
 			t.Errorf("%s %s: unexpected match result when comparing streams: got %s, epxected %s",
 				testName, tt.subTest, matchReason, tt.reason)
@@ -588,8 +584,7 @@ func TestSameStreams(t *testing.T) {
 }
 
 func TestUpdateFabricEventStream(t *testing.T) {
-	client, _ := newFakeK8sStreamClient()
-
+	pg.Name = fmt.Sprintf("%s-2", pg.Name)
 	var cluster = New(
 		Config{
 			OpConfig: config.Config{
@@ -635,7 +630,7 @@ func TestUpdateFabricEventStream(t *testing.T) {
 	}
 	streams := patchPostgresqlStreams(t, cluster, &pg.Spec, listOptions)
 	result := cluster.generateFabricEventStream(appId)
-	if match, _ := sameStreams(streams.Items[0].Spec.EventStreams, result.Spec.EventStreams); !match {
+	if match, _ := cluster.compareStreams(&streams.Items[0], result); !match {
 		t.Errorf("Malformed FabricEventStream after updating manifest, expected %#v, got %#v", streams.Items[0], result)
 	}
 
@@ -649,7 +644,7 @@ func TestUpdateFabricEventStream(t *testing.T) {
 
 	streams = patchPostgresqlStreams(t, cluster, &pg.Spec, listOptions)
 	result = cluster.generateFabricEventStream(appId)
-	if match, _ := sameStreams(streams.Items[0].Spec.EventStreams, result.Spec.EventStreams); !match {
+	if match, _ := cluster.compareStreams(&streams.Items[0], result); !match {
 		t.Errorf("Malformed FabricEventStream after disabling event recovery, expected %#v, got %#v", streams.Items[0], result)
 	}
 

--- a/pkg/cluster/streams_test.go
+++ b/pkg/cluster/streams_test.go
@@ -251,7 +251,7 @@ func TestHasSlotsInSync(t *testing.T) {
 			},
 			slotsInSync: true,
 		}, {
-			subTest:       fmt.Sprintf("slots empty for applicationId %s", appId),
+			subTest:       fmt.Sprintf("slots empty for applicationId %s after create or update of publication failed", appId),
 			applicationId: appId,
 			expectedSlots: map[string]map[string]zalandov1.Slot{
 				dbNotExists: {
@@ -272,7 +272,30 @@ func TestHasSlotsInSync(t *testing.T) {
 			actualSlots: map[string]map[string]string{},
 			slotsInSync: false,
 		}, {
-			subTest:       fmt.Sprintf("one slot not in sync for applicationId %s", appId),
+			subTest:       fmt.Sprintf("slot with empty definition for applicationId %s after publication git deleted", appId),
+			applicationId: appId,
+			expectedSlots: map[string]map[string]zalandov1.Slot{
+				dbNotExists: {
+					slotNotExists: zalandov1.Slot{
+						Slot: map[string]string{
+							"databases": dbName,
+							"plugin":    constants.EventStreamSourcePluginType,
+							"type":      "logical",
+						},
+						Publication: map[string]acidv1.StreamTable{
+							"test1": acidv1.StreamTable{
+								EventType: "stream-type-a",
+							},
+						},
+					},
+				},
+			},
+			actualSlots: map[string]map[string]string{
+				slotName: nil,
+			},
+			slotsInSync: false,
+		}, {
+			subTest:       fmt.Sprintf("one slot not in sync for applicationId %s because database does not exist", appId),
 			applicationId: appId,
 			expectedSlots: map[string]map[string]zalandov1.Slot{
 				dbName: {
@@ -313,7 +336,7 @@ func TestHasSlotsInSync(t *testing.T) {
 			},
 			slotsInSync: false,
 		}, {
-			subTest:       fmt.Sprintf("slots in sync for applicationId %s, but not for for %s - checking %s", appId, appId2, appId),
+			subTest:       fmt.Sprintf("slots in sync for applicationId %s, but not for %s - checking %s should return true", appId, appId2, appId),
 			applicationId: appId,
 			expectedSlots: map[string]map[string]zalandov1.Slot{
 				dbName: {
@@ -354,7 +377,7 @@ func TestHasSlotsInSync(t *testing.T) {
 			},
 			slotsInSync: true,
 		}, {
-			subTest:       fmt.Sprintf("slots in sync for applicationId %s, but not for for %s - checking %s", appId, appId2, appId2),
+			subTest:       fmt.Sprintf("slots in sync for applicationId %s, but not for %s - checking %s should return false", appId, appId2, appId2),
 			applicationId: appId2,
 			expectedSlots: map[string]map[string]zalandov1.Slot{
 				dbName: {

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -228,6 +228,7 @@ func (c *Cluster) syncPatroniConfigMap(suffix string) error {
 		}
 		annotations := make(map[string]string)
 		maps.Copy(annotations, cm.Annotations)
+		// Patroni can add extra annotations so incl. current annotations in desired annotations
 		desiredAnnotations := c.annotationsSet(cm.Annotations)
 		if changed, _ := c.compareAnnotations(annotations, desiredAnnotations); changed {
 			patchData, err := metaAnnotationsPatch(desiredAnnotations)
@@ -272,6 +273,7 @@ func (c *Cluster) syncPatroniEndpoint(suffix string) error {
 		}
 		annotations := make(map[string]string)
 		maps.Copy(annotations, ep.Annotations)
+		// Patroni can add extra annotations so incl. current annotations in desired annotations
 		desiredAnnotations := c.annotationsSet(ep.Annotations)
 		if changed, _ := c.compareAnnotations(annotations, desiredAnnotations); changed {
 			patchData, err := metaAnnotationsPatch(desiredAnnotations)
@@ -315,6 +317,7 @@ func (c *Cluster) syncPatroniService() error {
 		}
 		annotations := make(map[string]string)
 		maps.Copy(annotations, svc.Annotations)
+		// Patroni can add extra annotations so incl. current annotations in desired annotations
 		desiredAnnotations := c.annotationsSet(svc.Annotations)
 		if changed, _ := c.compareAnnotations(annotations, desiredAnnotations); changed {
 			patchData, err := metaAnnotationsPatch(desiredAnnotations)

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -667,15 +667,15 @@ func parseResourceRequirements(resourcesRequirement v1.ResourceRequirements) (ac
 	return resources, nil
 }
 
-func (c *Cluster) isInMainternanceWindow() bool {
-	if c.Spec.MaintenanceWindows == nil {
+func isInMainternanceWindow(specMaintenanceWindows []acidv1.MaintenanceWindow) bool {
+	if len(specMaintenanceWindows) == 0 {
 		return true
 	}
 	now := time.Now()
 	currentDay := now.Weekday()
 	currentTime := now.Format("15:04")
 
-	for _, window := range c.Spec.MaintenanceWindows {
+	for _, window := range specMaintenanceWindows {
 		startTime := window.StartTime.Format("15:04")
 		endTime := window.EndTime.Format("15:04")
 

--- a/pkg/cluster/util_test.go
+++ b/pkg/cluster/util_test.go
@@ -651,24 +651,6 @@ func Test_trimCronjobName(t *testing.T) {
 }
 
 func TestIsInMaintenanceWindow(t *testing.T) {
-	client, _ := newFakeK8sStreamClient()
-
-	var cluster = New(
-		Config{
-			OpConfig: config.Config{
-				PodManagementPolicy: "ordered_ready",
-				Resources: config.Resources{
-					ClusterLabels:        map[string]string{"application": "spilo"},
-					ClusterNameLabel:     "cluster-name",
-					DefaultCPURequest:    "300m",
-					DefaultCPULimit:      "300m",
-					DefaultMemoryRequest: "300Mi",
-					DefaultMemoryLimit:   "300Mi",
-					PodRoleLabel:         "spilo-role",
-				},
-			},
-		}, client, pg, logger, eventRecorder)
-
 	now := time.Now()
 	futureTimeStart := now.Add(1 * time.Hour)
 	futureTimeStartFormatted := futureTimeStart.Format("15:04")
@@ -723,7 +705,7 @@ func TestIsInMaintenanceWindow(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cluster.Spec.MaintenanceWindows = tt.windows
-			if cluster.isInMainternanceWindow() != tt.expected {
+			if isInMainternanceWindow(cluster.Spec.MaintenanceWindows) != tt.expected {
 				t.Errorf("Expected isInMainternanceWindow to return %t", tt.expected)
 			}
 		})


### PR DESCRIPTION
in our internal e2e tests I found the following logs:

```
level=warning msg="database replication slots for streams with applicationId test-app not in sync, skipping event stream sync" 
level=warning msg="database replication slots for streams with applicationId test-app-2 not in sync, skipping event stream sync"
```

The stream with test-app-2 uses a slot with not existing schema and table hence the expected second log line. But the stream of the first app should be fine. I have extended and improved the TestHasSlotsInSync unit test but found no bugs. After adding a logger, I found the issue:

In #2704 we [removed](https://github.com/zalando/postgres-operator/pull/2704/files#diff-6592d6884b6c11bdc6a11828daa2592c9c23b29865c49a30a55f6be5c7602ff7L137) always setting a slot to sync in order not block syncing broken streams. However, now they are only set on create, update or delete, but not on a normal sync. Therefore, hasSlotsInSync does not find the desired slots in slotsToSync and skips the stream sync. The proposed solution sets a slot if 
- create and alter operations succeed (behavior not changed)
- or if current publication is not new or tables changes (new, now with else, prior to #2704 it was done for every publication).

If we find out later that the publication can be removed it is set to nil. This code already exists, too.

I'm using this PR to also introduce diffs for annotations and owner references in streams. It required some rewriting of unit tests.

The changes on maintenanceWindows function were triggered because the fake stream client was used before which wasn't working anymore after my changes. First, I choose another client from the same go files (newFakeK8sAnnotationsClient) but then I realized, it's better to just pass the maintenance windows from the manifest to this function to simplify the code.