### PR TITLE
fix stream duplication on operator restart

### DIFF
--- a/pkg/cluster/streams.go
+++ b/pkg/cluster/streams.go
@@ -433,33 +433,54 @@ func hasSlotsInSync(appId string, databaseSlots map[string]map[string]zalandov1.
 }
 
 func (c *Cluster) syncStream(appId string) error {
+	var (
+		streams *zalandov1.FabricEventStreamList
+		err     error
+	)
+	c.setProcessName("syncing stream with applicationId %s", appId)
+	c.logger.Debugf("syncing stream with applicationId %s", appId)
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: c.labelsSet(true).String(),
+		FieldSelector: fmt.Sprintf("spec.applicationId=%s", appId),
+	}
+	streams, err = c.KubeClient.FabricEventStreams(c.Namespace).List(context.TODO(), listOptions)
+	if err != nil {
+		return fmt.Errorf("could not list of FabricEventStreams for applicationId %s: %v", appId, err)
+	}
+
 	streamExists := false
-	// update stream when it exists and EventStreams array differs
-	for _, stream := range c.Streams {
-		if appId == stream.Spec.ApplicationId {
-			streamExists = true
-			desiredStreams := c.generateFabricEventStream(appId)
-			if !reflect.DeepEqual(stream.ObjectMeta.OwnerReferences, desiredStreams.ObjectMeta.OwnerReferences) {
-				c.logger.Infof("owner references of event streams with applicationId %s do not match the current ones", appId)
-				stream.ObjectMeta.OwnerReferences = desiredStreams.ObjectMeta.OwnerReferences
-				c.setProcessName("updating event streams with applicationId %s", appId)
-				stream, err := c.KubeClient.FabricEventStreams(stream.Namespace).Update(context.TODO(), stream, metav1.UpdateOptions{})
-				if err != nil {
-					return fmt.Errorf("could not update event streams with applicationId %s: %v", appId, err)
-				}
-				c.Streams[appId] = stream
-			}
-			if match, reason := c.compareStreams(stream, desiredStreams); !match {
-				c.logger.Debugf("updating event streams with applicationId %s: %s", appId, reason)
-				desiredStreams.ObjectMeta = stream.ObjectMeta
-				updatedStream, err := c.updateStreams(desiredStreams)
-				if err != nil {
-					return fmt.Errorf("failed updating event streams %s with applicationId %s: %v", stream.Name, appId, err)
-				}
-				c.Streams[appId] = updatedStream
-				c.logger.Infof("event streams %q with applicationId %s have been successfully updated", updatedStream.Name, appId)
+	for _, stream := range streams.Items {
+		if streamExists {
+			c.logger.Warningf("more than one event stream with applicationId %s found, delete it", appId)
+			if err = c.KubeClient.FabricEventStreams(stream.ObjectMeta.Namespace).Delete(context.TODO(), stream.ObjectMeta.Name, metav1.DeleteOptions{}); err != nil {
+				c.logger.Errorf("could not delete event stream %q with applicationId %s: %v", stream.ObjectMeta.Name, appId, err)
+			} else {
+				c.logger.Infof("redundant event stream %q with applicationId %s has been successfully deleted", stream.ObjectMeta.Name, appId)
 			}
 			continue
+		}
+		streamExists = true
+		desiredStreams := c.generateFabricEventStream(appId)
+		if !reflect.DeepEqual(stream.ObjectMeta.OwnerReferences, desiredStreams.ObjectMeta.OwnerReferences) {
+			c.logger.Infof("owner references of event streams with applicationId %s do not match the current ones", appId)
+			stream.ObjectMeta.OwnerReferences = desiredStreams.ObjectMeta.OwnerReferences
+			c.setProcessName("updating event streams with applicationId %s", appId)
+			stream, err := c.KubeClient.FabricEventStreams(stream.Namespace).Update(context.TODO(), &stream, metav1.UpdateOptions{})
+			if err != nil {
+				return fmt.Errorf("could not update event streams with applicationId %s: %v", appId, err)
+			}
+			c.Streams[appId] = stream
+		}
+		if match, reason := c.compareStreams(&stream, desiredStreams); !match {
+			c.logger.Debugf("updating event streams with applicationId %s: %s", appId, reason)
+			desiredStreams.ObjectMeta = stream.ObjectMeta
+			updatedStream, err := c.updateStreams(desiredStreams)
+			if err != nil {
+				return fmt.Errorf("failed updating event streams %s with applicationId %s: %v", stream.Name, appId, err)
+			}
+			c.Streams[appId] = updatedStream
+			c.logger.Infof("event streams %q with applicationId %s have been successfully updated", updatedStream.Name, appId)
 		}
 	}
 


### PR DESCRIPTION
With the refactoring in #2713 I removed one important part of syncing the streams: Fetching the current state from K8s API. Instead I looped over the new cluster struct field Streams which is always empty on start up. This will produce a new stream resource on ever operator pod start. Therefore, I added a delete logic to cleanup the ill-created duplicates.

The unit tests were extended to test syncing and removal as well as owner references update. 