### PR TITLE
Fix resource constraints

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -376,28 +376,28 @@ spec:
                 properties:
                   default_cpu_limit:
                     type: string
-                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$|^$'
                   default_cpu_request:
                     type: string
-                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$|^$'
                   default_memory_limit:
                     type: string
-                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$|^$'
                   default_memory_request:
                     type: string
-                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$|^$'
                   max_cpu_request:
                     type: string
-                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$|^$'
                   max_memory_request:
                     type: string
-                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$|^$'
                   min_cpu_limit:
                     type: string
-                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$|^$'
                   min_memory_limit:
                     type: string
-                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$|^$'
               timeouts:
                 type: object
                 properties:


### PR DESCRIPTION
The documentation about `postgres_pod_resources` says that you can disable the defaults by setting them to zero **OR empty string**:

> Empty string or `0` disables the default.

Source: https://github.com/zalando/postgres-operator/blob/2582b934bfb5bfaba9e5d7116ef270e507c5d6a2/docs/reference/operator_parameters.md#L570-L604

But it's not currently possible to set them to empty string, due to the **regular expressions** in `charts/postgres-operator/crds/operatorconfigurations.yaml`.

Also, the `enforceMinResourceLimits` function currently supports only the empty string case, which is impossible to use due to the aforementioned regexes.

This PR aims to fix these two issues 🙂 