### PR TITLE
remove streams delete and extend unit tests

### DIFF
--- a/pkg/cluster/streams.go
+++ b/pkg/cluster/streams.go
@@ -451,15 +451,6 @@ func (c *Cluster) syncStream(appId string) error {
 		if stream.Spec.ApplicationId != appId {
 			continue
 		}
-		if streamExists {
-			c.logger.Warningf("more than one event stream with applicationId %s found, delete it", appId)
-			if err = c.KubeClient.FabricEventStreams(stream.ObjectMeta.Namespace).Delete(context.TODO(), stream.ObjectMeta.Name, metav1.DeleteOptions{}); err != nil {
-				c.logger.Errorf("could not delete event stream %q with applicationId %s: %v", stream.ObjectMeta.Name, appId, err)
-			} else {
-				c.logger.Infof("redundant event stream %q with applicationId %s has been successfully deleted", stream.ObjectMeta.Name, appId)
-			}
-			continue
-		}
 		streamExists = true
 		desiredStreams := c.generateFabricEventStream(appId)
 		if !reflect.DeepEqual(stream.ObjectMeta.OwnerReferences, desiredStreams.ObjectMeta.OwnerReferences) {
@@ -482,6 +473,7 @@ func (c *Cluster) syncStream(appId string) error {
 			c.Streams[appId] = updatedStream
 			c.logger.Infof("event streams %q with applicationId %s have been successfully updated", updatedStream.Name, appId)
 		}
+		break
 	}
 
 	if !streamExists {


### PR DESCRIPTION
#2733 fixed a bug with stream duplicates created on every operator restart. To facilitate the cleanup the operator was deleting every extra stream it found based on the filter labels.

In general, the operator should be careful with what it deletes. Therefore this PR removes the delete call again assuming that duplicates should not exist only if somebody adds them manually with the same labels which is unlikely to happen. Sorting is not supported in go client so we would not be able to tell which stream gets synced in the cluster struct (same for deletions).

I have split the update streams unit test to have a dedicated test only for removal.