### PR TITLE
reflect linter feedback, remove unused argumnents and redundant type from arrays

### DIFF
--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -71,11 +71,11 @@ var cl = New(
 		Spec: acidv1.PostgresSpec{
 			EnableConnectionPooler: util.True(),
 			Streams: []acidv1.Stream{
-				acidv1.Stream{
+				{
 					ApplicationId: "test-app",
 					Database:      "test_db",
 					Tables: map[string]acidv1.StreamTable{
-						"test_table": acidv1.StreamTable{
+						"test_table": {
 							EventType: "test-app.test",
 						},
 					},
@@ -1504,7 +1504,7 @@ func newCronJob(image, schedule string, vars []v1.EnvVar, mounts []v1.VolumeMoun
 					Template: v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{
-								v1.Container{
+								{
 									Name:  "logical-backup",
 									Image: image,
 									Env:   vars,

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -95,6 +95,7 @@ func TestCreate(t *testing.T) {
 
 	client := k8sutil.KubernetesClient{
 		DeploymentsGetter:            clientSet.AppsV1(),
+		CronJobsGetter:               clientSet.BatchV1(),
 		EndpointsGetter:              clientSet.CoreV1(),
 		PersistentVolumeClaimsGetter: clientSet.CoreV1(),
 		PodDisruptionBudgetsGetter:   clientSet.PolicyV1(),
@@ -111,6 +112,7 @@ func TestCreate(t *testing.T) {
 			Namespace: clusterNamespace,
 		},
 		Spec: acidv1.PostgresSpec{
+			EnableLogicalBackup: true,
 			Volume: acidv1.Volume{
 				Size: "1Gi",
 			},

--- a/pkg/cluster/connection_pooler_test.go
+++ b/pkg/cluster/connection_pooler_test.go
@@ -969,7 +969,7 @@ func TestPoolerTLS(t *testing.T) {
 			TLS: &acidv1.TLSDescription{
 				SecretName: tlsSecretName, CAFile: "ca.crt"},
 			AdditionalVolumes: []acidv1.AdditionalVolume{
-				acidv1.AdditionalVolume{
+				{
 					Name:      tlsSecretName,
 					MountPath: mountPath,
 					VolumeSource: v1.VolumeSource{

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -739,7 +739,7 @@ func (c *Cluster) generateSidecarContainers(sidecars []acidv1.Sidecar,
 }
 
 // adds common fields to sidecars
-func patchSidecarContainers(in []v1.Container, volumeMounts []v1.VolumeMount, superUserName string, credentialsSecretName string, logger *logrus.Entry) []v1.Container {
+func patchSidecarContainers(in []v1.Container, volumeMounts []v1.VolumeMount, superUserName string, credentialsSecretName string) []v1.Container {
 	result := []v1.Container{}
 
 	for _, container := range in {
@@ -1444,7 +1444,7 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 			containerName, containerName)
 	}
 
-	sidecarContainers = patchSidecarContainers(sidecarContainers, volumeMounts, c.OpConfig.SuperUsername, c.credentialSecretName(c.OpConfig.SuperUsername), c.logger)
+	sidecarContainers = patchSidecarContainers(sidecarContainers, volumeMounts, c.OpConfig.SuperUsername, c.credentialSecretName(c.OpConfig.SuperUsername))
 
 	tolerationSpec := tolerations(&spec.Tolerations, c.OpConfig.PodToleration)
 	effectivePodPriorityClassName := util.Coalesce(spec.PodPriorityClassName, c.OpConfig.PodPriorityClassName)
@@ -1598,7 +1598,7 @@ func (c *Cluster) generatePodAnnotations(spec *acidv1.PostgresSpec) map[string]s
 	for k, v := range c.OpConfig.CustomPodAnnotations {
 		annotations[k] = v
 	}
-	if spec != nil || spec.PodAnnotations != nil {
+	if spec.PodAnnotations != nil {
 		for k, v := range spec.PodAnnotations {
 			annotations[k] = v
 		}
@@ -1875,18 +1875,16 @@ func (c *Cluster) generatePersistentVolumeClaimTemplate(volumeSize, volumeStorag
 
 func (c *Cluster) generateUserSecrets() map[string]*v1.Secret {
 	secrets := make(map[string]*v1.Secret, len(c.pgUsers)+len(c.systemUsers))
-	namespace := c.Namespace
 	for username, pgUser := range c.pgUsers {
 		//Skip users with no password i.e. human users (they'll be authenticated using pam)
-		secret := c.generateSingleUserSecret(pgUser.Namespace, pgUser)
+		secret := c.generateSingleUserSecret(pgUser)
 		if secret != nil {
 			secrets[username] = secret
 		}
-		namespace = pgUser.Namespace
 	}
 	/* special case for the system user */
 	for _, systemUser := range c.systemUsers {
-		secret := c.generateSingleUserSecret(namespace, systemUser)
+		secret := c.generateSingleUserSecret(systemUser)
 		if secret != nil {
 			secrets[systemUser.Name] = secret
 		}
@@ -1895,7 +1893,7 @@ func (c *Cluster) generateUserSecrets() map[string]*v1.Secret {
 	return secrets
 }
 
-func (c *Cluster) generateSingleUserSecret(namespace string, pgUser spec.PgUser) *v1.Secret {
+func (c *Cluster) generateSingleUserSecret(pgUser spec.PgUser) *v1.Secret {
 	//Skip users with no password i.e. human users (they'll be authenticated using pam)
 	if pgUser.Password == "" {
 		if pgUser.Origin != spec.RoleOriginTeamsAPI {

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -1451,9 +1451,9 @@ func TestNodeAffinity(t *testing.T) {
 	nodeAff := &v1.NodeAffinity{
 		RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
 			NodeSelectorTerms: []v1.NodeSelectorTerm{
-				v1.NodeSelectorTerm{
+				{
 					MatchExpressions: []v1.NodeSelectorRequirement{
-						v1.NodeSelectorRequirement{
+						{
 							Key:      "test-label",
 							Operator: v1.NodeSelectorOpIn,
 							Values: []string{
@@ -1673,7 +1673,7 @@ func TestTLS(t *testing.T) {
 			TLS: &acidv1.TLSDescription{
 				SecretName: tlsSecretName, CAFile: "ca.crt"},
 			AdditionalVolumes: []acidv1.AdditionalVolume{
-				acidv1.AdditionalVolume{
+				{
 					Name:      tlsSecretName,
 					MountPath: mountPath,
 					VolumeSource: v1.VolumeSource{
@@ -2162,17 +2162,17 @@ func TestSidecars(t *testing.T) {
 			Size: "1G",
 		},
 		Sidecars: []acidv1.Sidecar{
-			acidv1.Sidecar{
+			{
 				Name: "cluster-specific-sidecar",
 			},
-			acidv1.Sidecar{
+			{
 				Name: "cluster-specific-sidecar-with-resources",
 				Resources: &acidv1.Resources{
 					ResourceRequests: acidv1.ResourceDescription{CPU: k8sutil.StringToPointer("210m"), Memory: k8sutil.StringToPointer("0.8Gi")},
 					ResourceLimits:   acidv1.ResourceDescription{CPU: k8sutil.StringToPointer("510m"), Memory: k8sutil.StringToPointer("1.4Gi")},
 				},
 			},
-			acidv1.Sidecar{
+			{
 				Name:        "replace-sidecar",
 				DockerImage: "override-image",
 			},
@@ -2200,11 +2200,11 @@ func TestSidecars(t *testing.T) {
 					"deprecated-global-sidecar": "image:123",
 				},
 				SidecarContainers: []v1.Container{
-					v1.Container{
+					{
 						Name: "global-sidecar",
 					},
 					// will be replaced by a cluster specific sidecar with the same name
-					v1.Container{
+					{
 						Name:  "replace-sidecar",
 						Image: "replaced-image",
 					},
@@ -2259,7 +2259,7 @@ func TestSidecars(t *testing.T) {
 		},
 	}
 	mounts := []v1.VolumeMount{
-		v1.VolumeMount{
+		{
 			Name:      "pgdata",
 			MountPath: "/home/postgres/pgdata",
 		},
@@ -2516,17 +2516,17 @@ func TestGenerateService(t *testing.T) {
 			Size: "1G",
 		},
 		Sidecars: []acidv1.Sidecar{
-			acidv1.Sidecar{
+			{
 				Name: "cluster-specific-sidecar",
 			},
-			acidv1.Sidecar{
+			{
 				Name: "cluster-specific-sidecar-with-resources",
 				Resources: &acidv1.Resources{
 					ResourceRequests: acidv1.ResourceDescription{CPU: k8sutil.StringToPointer("210m"), Memory: k8sutil.StringToPointer("0.8Gi")},
 					ResourceLimits:   acidv1.ResourceDescription{CPU: k8sutil.StringToPointer("510m"), Memory: k8sutil.StringToPointer("1.4Gi")},
 				},
 			},
-			acidv1.Sidecar{
+			{
 				Name:        "replace-sidecar",
 				DockerImage: "override-image",
 			},
@@ -2555,11 +2555,11 @@ func TestGenerateService(t *testing.T) {
 					"deprecated-global-sidecar": "image:123",
 				},
 				SidecarContainers: []v1.Container{
-					v1.Container{
+					{
 						Name: "global-sidecar",
 					},
 					// will be replaced by a cluster specific sidecar with the same name
-					v1.Container{
+					{
 						Name:  "replace-sidecar",
 						Image: "replaced-image",
 					},
@@ -2654,27 +2654,27 @@ func newLBFakeClient() (k8sutil.KubernetesClient, *fake.Clientset) {
 
 func getServices(serviceType v1.ServiceType, sourceRanges []string, extTrafficPolicy, clusterName string) []v1.ServiceSpec {
 	return []v1.ServiceSpec{
-		v1.ServiceSpec{
+		{
 			ExternalTrafficPolicy:    v1.ServiceExternalTrafficPolicyType(extTrafficPolicy),
 			LoadBalancerSourceRanges: sourceRanges,
 			Ports:                    []v1.ServicePort{{Name: "postgresql", Port: 5432, TargetPort: intstr.IntOrString{IntVal: 5432}}},
 			Type:                     serviceType,
 		},
-		v1.ServiceSpec{
+		{
 			ExternalTrafficPolicy:    v1.ServiceExternalTrafficPolicyType(extTrafficPolicy),
 			LoadBalancerSourceRanges: sourceRanges,
 			Ports:                    []v1.ServicePort{{Name: clusterName + "-pooler", Port: 5432, TargetPort: intstr.IntOrString{IntVal: 5432}}},
 			Selector:                 map[string]string{"connection-pooler": clusterName + "-pooler"},
 			Type:                     serviceType,
 		},
-		v1.ServiceSpec{
+		{
 			ExternalTrafficPolicy:    v1.ServiceExternalTrafficPolicyType(extTrafficPolicy),
 			LoadBalancerSourceRanges: sourceRanges,
 			Ports:                    []v1.ServicePort{{Name: "postgresql", Port: 5432, TargetPort: intstr.IntOrString{IntVal: 5432}}},
 			Selector:                 map[string]string{"spilo-role": "replica", "application": "spilo", "cluster-name": clusterName},
 			Type:                     serviceType,
 		},
-		v1.ServiceSpec{
+		{
 			ExternalTrafficPolicy:    v1.ServiceExternalTrafficPolicyType(extTrafficPolicy),
 			LoadBalancerSourceRanges: sourceRanges,
 			Ports:                    []v1.ServicePort{{Name: clusterName + "-pooler-repl", Port: 5432, TargetPort: intstr.IntOrString{IntVal: 5432}}},
@@ -2894,7 +2894,7 @@ func TestGenerateResourceRequirements(t *testing.T) {
 				},
 				Spec: acidv1.PostgresSpec{
 					Sidecars: []acidv1.Sidecar{
-						acidv1.Sidecar{
+						{
 							Name: sidecarName,
 						},
 					},
@@ -3095,7 +3095,7 @@ func TestGenerateResourceRequirements(t *testing.T) {
 				},
 				Spec: acidv1.PostgresSpec{
 					Sidecars: []acidv1.Sidecar{
-						acidv1.Sidecar{
+						{
 							Name: sidecarName,
 							Resources: &acidv1.Resources{
 								ResourceRequests: acidv1.ResourceDescription{CPU: k8sutil.StringToPointer("10m"), Memory: k8sutil.StringToPointer("10Mi")},
@@ -3184,7 +3184,7 @@ func TestGenerateResourceRequirements(t *testing.T) {
 				},
 				Spec: acidv1.PostgresSpec{
 					Sidecars: []acidv1.Sidecar{
-						acidv1.Sidecar{
+						{
 							Name: sidecarName,
 							Resources: &acidv1.Resources{
 								ResourceRequests: acidv1.ResourceDescription{CPU: k8sutil.StringToPointer("10m"), Memory: k8sutil.StringToPointer("10Mi")},

--- a/pkg/cluster/streams.go
+++ b/pkg/cluster/streams.go
@@ -183,7 +183,7 @@ func (c *Cluster) generateFabricEventStream(appId string) *zalandov1.FabricEvent
 		}
 		for tableName, table := range stream.Tables {
 			streamSource := c.getEventStreamSource(stream, tableName, table.IdColumn)
-			streamFlow := getEventStreamFlow(stream, table.PayloadColumn)
+			streamFlow := getEventStreamFlow(table.PayloadColumn)
 			streamSink := getEventStreamSink(stream, table.EventType)
 			streamRecovery := getEventStreamRecovery(stream, table.RecoveryEventType, table.EventType)
 
@@ -230,7 +230,7 @@ func (c *Cluster) getEventStreamSource(stream acidv1.Stream, tableName string, i
 	}
 }
 
-func getEventStreamFlow(stream acidv1.Stream, payloadColumn *string) zalandov1.EventStreamFlow {
+func getEventStreamFlow(payloadColumn *string) zalandov1.EventStreamFlow {
 	return zalandov1.EventStreamFlow{
 		Type:          constants.EventStreamFlowPgGenericType,
 		PayloadColumn: payloadColumn,

--- a/pkg/cluster/streams_test.go
+++ b/pkg/cluster/streams_test.go
@@ -56,12 +56,12 @@ var (
 					ApplicationId: appId,
 					Database:      "foo",
 					Tables: map[string]acidv1.StreamTable{
-						"data.bar": acidv1.StreamTable{
+						"data.bar": {
 							EventType:     "stream-type-a",
 							IdColumn:      k8sutil.StringToPointer("b_id"),
 							PayloadColumn: k8sutil.StringToPointer("b_payload"),
 						},
-						"data.foobar": acidv1.StreamTable{
+						"data.foobar": {
 							EventType:         "stream-type-b",
 							RecoveryEventType: "stream-type-b-dlq",
 						},
@@ -94,7 +94,7 @@ var (
 				"team":         "acid",
 			},
 			OwnerReferences: []metav1.OwnerReference{
-				metav1.OwnerReference{
+				{
 					APIVersion: "apps/v1",
 					Kind:       "StatefulSet",
 					Name:       "acid-test-cluster",
@@ -105,7 +105,7 @@ var (
 		Spec: zalandov1.FabricEventStreamSpec{
 			ApplicationId: appId,
 			EventStreams: []zalandov1.EventStream{
-				zalandov1.EventStream{
+				{
 					EventStreamFlow: zalandov1.EventStreamFlow{
 						PayloadColumn: k8sutil.StringToPointer("b_payload"),
 						Type:          constants.EventStreamFlowPgGenericType,
@@ -144,7 +144,7 @@ var (
 						Type: constants.EventStreamSourcePGType,
 					},
 				},
-				zalandov1.EventStream{
+				{
 					EventStreamFlow: zalandov1.EventStreamFlow{
 						Type: constants.EventStreamFlowPgGenericType,
 					},
@@ -241,7 +241,7 @@ func TestHasSlotsInSync(t *testing.T) {
 							"type":      "logical",
 						},
 						Publication: map[string]acidv1.StreamTable{
-							"test1": acidv1.StreamTable{
+							"test1": {
 								EventType: "stream-type-a",
 							},
 						},
@@ -249,7 +249,7 @@ func TestHasSlotsInSync(t *testing.T) {
 				},
 			},
 			actualSlots: map[string]map[string]string{
-				slotName: map[string]string{
+				slotName: {
 					"databases": dbName,
 					"plugin":    constants.EventStreamSourcePluginType,
 					"type":      "logical",
@@ -268,7 +268,7 @@ func TestHasSlotsInSync(t *testing.T) {
 							"type":      "logical",
 						},
 						Publication: map[string]acidv1.StreamTable{
-							"test1": acidv1.StreamTable{
+							"test1": {
 								EventType: "stream-type-a",
 							},
 						},
@@ -289,7 +289,7 @@ func TestHasSlotsInSync(t *testing.T) {
 							"type":      "logical",
 						},
 						Publication: map[string]acidv1.StreamTable{
-							"test1": acidv1.StreamTable{
+							"test1": {
 								EventType: "stream-type-a",
 							},
 						},
@@ -312,7 +312,7 @@ func TestHasSlotsInSync(t *testing.T) {
 							"type":      "logical",
 						},
 						Publication: map[string]acidv1.StreamTable{
-							"test1": acidv1.StreamTable{
+							"test1": {
 								EventType: "stream-type-a",
 							},
 						},
@@ -326,7 +326,7 @@ func TestHasSlotsInSync(t *testing.T) {
 							"type":      "logical",
 						},
 						Publication: map[string]acidv1.StreamTable{
-							"test2": acidv1.StreamTable{
+							"test2": {
 								EventType: "stream-type-b",
 							},
 						},
@@ -334,7 +334,7 @@ func TestHasSlotsInSync(t *testing.T) {
 				},
 			},
 			actualSlots: map[string]map[string]string{
-				slotName: map[string]string{
+				slotName: {
 					"databases": dbName,
 					"plugin":    constants.EventStreamSourcePluginType,
 					"type":      "logical",
@@ -353,7 +353,7 @@ func TestHasSlotsInSync(t *testing.T) {
 							"type":      "logical",
 						},
 						Publication: map[string]acidv1.StreamTable{
-							"test1": acidv1.StreamTable{
+							"test1": {
 								EventType: "stream-type-a",
 							},
 						},
@@ -367,7 +367,7 @@ func TestHasSlotsInSync(t *testing.T) {
 							"type":      "logical",
 						},
 						Publication: map[string]acidv1.StreamTable{
-							"test2": acidv1.StreamTable{
+							"test2": {
 								EventType: "stream-type-b",
 							},
 						},
@@ -375,7 +375,7 @@ func TestHasSlotsInSync(t *testing.T) {
 				},
 			},
 			actualSlots: map[string]map[string]string{
-				slotName: map[string]string{
+				slotName: {
 					"databases": dbName,
 					"plugin":    constants.EventStreamSourcePluginType,
 					"type":      "logical",
@@ -394,7 +394,7 @@ func TestHasSlotsInSync(t *testing.T) {
 							"type":      "logical",
 						},
 						Publication: map[string]acidv1.StreamTable{
-							"test1": acidv1.StreamTable{
+							"test1": {
 								EventType: "stream-type-a",
 							},
 						},
@@ -408,7 +408,7 @@ func TestHasSlotsInSync(t *testing.T) {
 							"type":      "logical",
 						},
 						Publication: map[string]acidv1.StreamTable{
-							"test2": acidv1.StreamTable{
+							"test2": {
 								EventType: "stream-type-b",
 							},
 						},
@@ -416,7 +416,7 @@ func TestHasSlotsInSync(t *testing.T) {
 				},
 			},
 			actualSlots: map[string]map[string]string{
-				slotName: map[string]string{
+				slotName: {
 					"databases": dbName,
 					"plugin":    constants.EventStreamSourcePluginType,
 					"type":      "logical",

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -644,7 +644,7 @@ func TestUpdateSecret(t *testing.T) {
 					ApplicationId: appId,
 					Database:      dbname,
 					Tables: map[string]acidv1.StreamTable{
-						"data.foo": acidv1.StreamTable{
+						"data.foo": {
 							EventType: "stream-type-b",
 						},
 					},

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -76,9 +76,8 @@ func (c *Controller) createOperatorCRD(desiredCrd *apiextv1.CustomResourceDefini
 			context.TODO(), crd.Name, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
 			return fmt.Errorf("could not update customResourceDefinition %q: %v", crd.Name, err)
 		}
-	} else {
-		c.logger.Infof("customResourceDefinition %q has been registered", crd.Name)
 	}
+	c.logger.Infof("customResourceDefinition %q is registered", crd.Name)
 
 	return wait.PollUntilContextTimeout(context.TODO(), c.config.CRDReadyWaitInterval, c.config.CRDReadyWaitTimeout, false, func(ctx context.Context) (bool, error) {
 		c, err := c.KubeClient.CustomResourceDefinitions().Get(context.TODO(), desiredCrd.Name, metav1.GetOptions{})

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -132,7 +132,7 @@ func TestOldInfrastructureRoleFormat(t *testing.T) {
 	for _, test := range testTable {
 		roles, err := utilTestController.getInfrastructureRoles(
 			[]*config.InfrastructureRole{
-				&config.InfrastructureRole{
+				{
 					SecretName:  test.secretName,
 					UserKey:     "user",
 					PasswordKey: "password",
@@ -163,7 +163,7 @@ func TestNewInfrastructureRoleFormat(t *testing.T) {
 		// one secret with one configmap
 		{
 			[]spec.NamespacedName{
-				spec.NamespacedName{
+				{
 					Namespace: v1.NamespaceDefault,
 					Name:      testInfrastructureRolesNewSecretName,
 				},
@@ -187,11 +187,11 @@ func TestNewInfrastructureRoleFormat(t *testing.T) {
 		// multiple standalone secrets
 		{
 			[]spec.NamespacedName{
-				spec.NamespacedName{
+				{
 					Namespace: v1.NamespaceDefault,
 					Name:      "infrastructureroles-new-test1",
 				},
-				spec.NamespacedName{
+				{
 					Namespace: v1.NamespaceDefault,
 					Name:      "infrastructureroles-new-test2",
 				},
@@ -248,7 +248,7 @@ func TestInfrastructureRoleDefinitions(t *testing.T) {
 		// only new CRD format
 		{
 			[]*config.InfrastructureRole{
-				&config.InfrastructureRole{
+				{
 					SecretName: spec.NamespacedName{
 						Namespace: v1.NamespaceDefault,
 						Name:      testInfrastructureRolesNewSecretName,
@@ -262,7 +262,7 @@ func TestInfrastructureRoleDefinitions(t *testing.T) {
 			spec.NamespacedName{},
 			"",
 			[]*config.InfrastructureRole{
-				&config.InfrastructureRole{
+				{
 					SecretName: spec.NamespacedName{
 						Namespace: v1.NamespaceDefault,
 						Name:      testInfrastructureRolesNewSecretName,
@@ -280,7 +280,7 @@ func TestInfrastructureRoleDefinitions(t *testing.T) {
 			spec.NamespacedName{},
 			"secretname: infrastructureroles-new-test, userkey: test-user, passwordkey: test-password, rolekey: test-role",
 			[]*config.InfrastructureRole{
-				&config.InfrastructureRole{
+				{
 					SecretName: spec.NamespacedName{
 						Namespace: v1.NamespaceDefault,
 						Name:      testInfrastructureRolesNewSecretName,
@@ -298,7 +298,7 @@ func TestInfrastructureRoleDefinitions(t *testing.T) {
 			spec.NamespacedName{},
 			"secretname: infrastructureroles-new-test, userkey: test-user, passwordkey: test-password, defaultrolevalue: test-role",
 			[]*config.InfrastructureRole{
-				&config.InfrastructureRole{
+				{
 					SecretName: spec.NamespacedName{
 						Namespace: v1.NamespaceDefault,
 						Name:      testInfrastructureRolesNewSecretName,
@@ -319,7 +319,7 @@ func TestInfrastructureRoleDefinitions(t *testing.T) {
 			},
 			"",
 			[]*config.InfrastructureRole{
-				&config.InfrastructureRole{
+				{
 					SecretName: spec.NamespacedName{
 						Namespace: v1.NamespaceDefault,
 						Name:      testInfrastructureRolesOldSecretName,
@@ -334,7 +334,7 @@ func TestInfrastructureRoleDefinitions(t *testing.T) {
 		// both formats for CRD
 		{
 			[]*config.InfrastructureRole{
-				&config.InfrastructureRole{
+				{
 					SecretName: spec.NamespacedName{
 						Namespace: v1.NamespaceDefault,
 						Name:      testInfrastructureRolesNewSecretName,
@@ -351,7 +351,7 @@ func TestInfrastructureRoleDefinitions(t *testing.T) {
 			},
 			"",
 			[]*config.InfrastructureRole{
-				&config.InfrastructureRole{
+				{
 					SecretName: spec.NamespacedName{
 						Namespace: v1.NamespaceDefault,
 						Name:      testInfrastructureRolesNewSecretName,
@@ -361,7 +361,7 @@ func TestInfrastructureRoleDefinitions(t *testing.T) {
 					RoleKey:     "test-role",
 					Template:    false,
 				},
-				&config.InfrastructureRole{
+				{
 					SecretName: spec.NamespacedName{
 						Namespace: v1.NamespaceDefault,
 						Name:      testInfrastructureRolesOldSecretName,
@@ -382,7 +382,7 @@ func TestInfrastructureRoleDefinitions(t *testing.T) {
 			},
 			"secretname: infrastructureroles-new-test, userkey: test-user, passwordkey: test-password, rolekey: test-role",
 			[]*config.InfrastructureRole{
-				&config.InfrastructureRole{
+				{
 					SecretName: spec.NamespacedName{
 						Namespace: v1.NamespaceDefault,
 						Name:      testInfrastructureRolesNewSecretName,
@@ -392,7 +392,7 @@ func TestInfrastructureRoleDefinitions(t *testing.T) {
 					RoleKey:     "test-role",
 					Template:    false,
 				},
-				&config.InfrastructureRole{
+				{
 					SecretName: spec.NamespacedName{
 						Namespace: v1.NamespaceDefault,
 						Name:      testInfrastructureRolesOldSecretName,

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -373,7 +373,7 @@ func (mock *mockDeployment) Get(ctx context.Context, name string, opts metav1.Ge
 			Template: v1.PodTemplateSpec{
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
-						v1.Container{
+						{
 							Image: "pooler:1.0",
 						},
 					},

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -7,8 +7,6 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 
-	clientbatchv1 "k8s.io/client-go/kubernetes/typed/batch/v1"
-
 	apiacidv1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
 	zalandoclient "github.com/zalando/postgres-operator/pkg/generated/clientset/versioned"
 	acidv1 "github.com/zalando/postgres-operator/pkg/generated/clientset/versioned/typed/acid.zalan.do/v1"
@@ -24,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	batchv1 "k8s.io/client-go/kubernetes/typed/batch/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	policyv1 "k8s.io/client-go/kubernetes/typed/policy/v1"
 	rbacv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
@@ -59,9 +58,9 @@ type KubernetesClient struct {
 	appsv1.StatefulSetsGetter
 	appsv1.DeploymentsGetter
 	rbacv1.RoleBindingsGetter
+	batchv1.CronJobsGetter
 	policyv1.PodDisruptionBudgetsGetter
 	apiextv1client.CustomResourceDefinitionsGetter
-	clientbatchv1.CronJobsGetter
 	acidv1.OperatorConfigurationsGetter
 	acidv1.PostgresTeamsGetter
 	acidv1.PostgresqlsGetter


### PR DESCRIPTION
The amount of problems reported by the linter - mainly redundant type declarations - made it hard to see problems such as nil references and unused variables. With this PR merged no more problems should be reported - at least in VSCode