### PR TITLE
implement sidecars for pooler 

### DIFF
--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -173,6 +173,12 @@ spec:
                             pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
                   schema:
                     type: string
+                  sidecars:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
                   user:
                     type: string
               databases:

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -603,7 +603,7 @@ for both master and replica pooler services (if `enableReplicaConnectionPooler`
   Resource configuration for connection pooler deployment.
 
 * **sidecars**
-  Extra containers to run alongside with PGBouncer container. 
+  Extra containers to run alongside with PGBouncer container in the same pod. 
 
 ## Custom TLS certificates
 

--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -511,7 +511,8 @@ properties of the persistent storage that stores Postgres data.
 
 Those parameters are defined under the `sidecars` key. They consist of a list
 of dictionaries, each defining one sidecar (an extra container running
-along the main Postgres container on the same pod). The following keys can be
+along the main Postgres container on the same pod). Same way sidecars can be
+defined for the pooler, using `connectionPooler.sidecars` key. The following keys can be
 defined in the sidecar dictionary:
 
 * **name**
@@ -600,6 +601,9 @@ for both master and replica pooler services (if `enableReplicaConnectionPooler`
 
 * **resources**
   Resource configuration for connection pooler deployment.
+
+* **sidecars**
+  Extra containers to run alongside with PGBouncer container. 
 
 ## Custom TLS certificates
 

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -171,6 +171,12 @@ spec:
                             pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
                   schema:
                     type: string
+                  sidecars:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
                   user:
                     type: string
               databases:

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -275,6 +275,16 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 							"schema": {
 								Type: "string",
 							},
+							"sidecars": {
+								Type:     "array",
+								Nullable: true,
+								Items: &apiextv1.JSONSchemaPropsOrArray{
+									Schema: &apiextv1.JSONSchemaProps{
+										Type:                   "object",
+										XPreserveUnknownFields: util.True(),
+									},
+								},
+							},
 							"user": {
 								Type: "string",
 							},

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -241,12 +241,13 @@ type PostgresStatus struct {
 // makes sense to expose. E.g. pool size (min/max boundaries), max client
 // connections etc.
 type ConnectionPooler struct {
-	NumberOfInstances *int32 `json:"numberOfInstances,omitempty"`
-	Schema            string `json:"schema,omitempty"`
-	User              string `json:"user,omitempty"`
-	Mode              string `json:"mode,omitempty"`
-	DockerImage       string `json:"dockerImage,omitempty"`
-	MaxDBConnections  *int32 `json:"maxDBConnections,omitempty"`
+	NumberOfInstances *int32    `json:"numberOfInstances,omitempty"`
+	Schema            string    `json:"schema,omitempty"`
+	User              string    `json:"user,omitempty"`
+	Mode              string    `json:"mode,omitempty"`
+	DockerImage       string    `json:"dockerImage,omitempty"`
+	MaxDBConnections  *int32    `json:"maxDBConnections,omitempty"`
+	Sidecars          []Sidecar `json:"sidecars,omitempty"`
 
 	*Resources `json:"resources,omitempty"`
 }

--- a/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
@@ -111,6 +111,13 @@ func (in *ConnectionPooler) DeepCopyInto(out *ConnectionPooler) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Sidecars != nil {
+		in, out := &in.Sidecars, &out.Sidecars
+		*out = make([]Sidecar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
 		*out = new(Resources)


### PR DESCRIPTION
fixes #1153 & #2547

Many people need this feature for running pgbouncer-exporter to monitor pgbouncer state. Can be used for any other purposes.