### PR TITLE
fix(2582): added cluster level delete secrets config

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -229,6 +229,8 @@ spec:
                   enable_secrets_deletion:
                     type: boolean
                     default: true
+                  enable_secrets_deletion_key:
+                    type: string
                   enable_sidecars:
                     type: boolean
                     default: true

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -141,6 +141,9 @@ configKubernetes:
   enable_readiness_probe: false
   # toggles if operator should delete secrets on cluster deletion
   enable_secrets_deletion: true
+  # key name for annotation that overrides enable_secrets_deletion on cluster level
+  # enable_secrets_deletion_key: "enable-secrets-deletion"
+
   # enables sidecar containers to run alongside Spilo in the same pod
   enable_sidecars: true
 

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -365,6 +365,9 @@ configuration they are grouped under the `kubernetes` key.
   By default, the operator deletes secrets when removing the Postgres cluster
   manifest. To keep secrets, set this option to `false`. The default is `true`.
 
+* **enable_secrets_deletion_key**
+  By default, the `enable_secrets_deletion` decides on the deletion of secrets for the entire operator. To overwrite `enable_secrets_deletion` this property can be set and an annotation on cluster level can be added with the values: delete secrets `true` or `false`.
+
 * **enable_persistent_volume_claim_deletion**
   By default, the operator deletes PersistentVolumeClaims when removing the
   Postgres cluster manifest, no matter if `persistent_volume_claim_retention_policy`

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -61,6 +61,7 @@ data:
   enable_replica_load_balancer: "false"
   enable_replica_pooler_load_balancer: "false"
   enable_secrets_deletion: "true"
+  # enable_secrets_deletion_key: enable-secrets-deletion
   enable_shm_volume: "true"
   enable_sidecars: "true"
   enable_spilo_wal_path_compat: "true"

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -227,6 +227,8 @@ spec:
                   enable_secrets_deletion:
                     type: boolean
                     default: true
+                  enable_secrets_deletion_key:
+                    type: string
                   enable_sidecars:
                     type: boolean
                     default: true

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -65,6 +65,7 @@ configuration:
     enable_pod_disruption_budget: true
     enable_readiness_probe: false
     enable_secrets_deletion: true
+    # enable_secrets_deletion_key: enable-secrets-deletion
     enable_sidecars: true
     # ignored_annotations:
     # - k8s.v1.cni.cncf.io/network-status

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1344,6 +1344,9 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 							"enable_secrets_deletion": {
 								Type: "boolean",
 							},
+							"enable_secrets_deletion_key": {
+								Type: "string",
+							},
 							"enable_sidecars": {
 								Type: "boolean",
 							},

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -104,6 +104,7 @@ type KubernetesMetaConfiguration struct {
 	PodManagementPolicy                      string              `json:"pod_management_policy,omitempty"`
 	PersistentVolumeClaimRetentionPolicy     map[string]string   `json:"persistent_volume_claim_retention_policy,omitempty"`
 	EnableSecretsDeletion                    *bool               `json:"enable_secrets_deletion,omitempty"`
+	EnableSecretsDeletionKey                 string              `json:"enable_secrets_deletion_key,omitempty"`
 	EnablePersistentVolumeClaimDeletion      *bool               `json:"enable_persistent_volume_claim_deletion,omitempty"`
 	EnableReadinessProbe                     bool                `json:"enable_readiness_probe,omitempty"`
 	EnableCrossNamespaceSecret               bool                `json:"enable_cross_namespace_secret,omitempty"`

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -124,6 +124,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.PodManagementPolicy = util.Coalesce(fromCRD.Kubernetes.PodManagementPolicy, "ordered_ready")
 	result.PersistentVolumeClaimRetentionPolicy = fromCRD.Kubernetes.PersistentVolumeClaimRetentionPolicy
 	result.EnableSecretsDeletion = util.CoalesceBool(fromCRD.Kubernetes.EnableSecretsDeletion, util.True())
+	result.EnableSecretsDeletionKey = fromCRD.Kubernetes.EnableSecretsDeletionKey
 	result.EnablePersistentVolumeClaimDeletion = util.CoalesceBool(fromCRD.Kubernetes.EnablePersistentVolumeClaimDeletion, util.True())
 	result.EnableReadinessProbe = fromCRD.Kubernetes.EnableReadinessProbe
 	result.MasterPodMoveTimeout = util.CoalesceDuration(time.Duration(fromCRD.Kubernetes.MasterPodMoveTimeout), "10m")

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -66,6 +66,7 @@ type Resources struct {
 	MaxInstances                      int32  `name:"max_instances" default:"-1"`
 	MinInstances                      int32  `name:"min_instances" default:"-1"`
 	IgnoreInstanceLimitsAnnotationKey string `name:"ignore_instance_limits_annotation_key"`
+	EnableSecretsDeletionKey          string `name:"enable_secrets_deletion_key"`
 }
 
 type InfrastructureRole struct {


### PR DESCRIPTION
Here [#2582 ](https://github.com/zalando/postgres-operator/pull/2582) it has been discussed to add a config for deleting secrets globally on operator level. This is very nice and helps greatly.

In my case I have a setup where my operator contains the config `delete_annotation_name_key: delete-clustername` and as a safety config `enable_secrets_deletion: false` which is needed if I want to clear a postgres cluster completely but still need the secrets. This works like a charm but I have temporary walg cluster clones which can be applied to get some backups. This temporary walg clones should still delete their secrets post deletion therefore a config is needed on cluster level.
I implemented the config `enable_secrets_deletion_key` in a similar way as `delete_annotation_name_key` works. This allows me to override the operator wide `enable_secrets_deletion` configuratin per postgresql cluster. If it is not set, the operator decides whether the secrets should be deleted, if it is set to `true` the secrets are deleted nevertheless and if it is set to `false` the secrets will not be deleted, allowing for a more fine granular configuration.

I have checked several possible scenarios with the following results:
| `enable_secrets_deletion` | `delete_annotation_name_key` | `delete-clustername` | `enable-secrets-deletion` |  Keep Secrets? |
| -------- | ------- | ------- | ------- | ------- | 
| - | - | - | - | NO |
| true | - | - | - | NO | 
| false | - | - | - | YES | 
| - | delete-clustername | acid-minimal-cluster | - | NO | 
| - | delete-clustername | - | - | YES | 
| true | delete-clustername | - | - | YES | 
| false | delete-clustername | - | - | YES |
| true | delete-clustername | - | true | YES | 
| false | delete-clustername | - | false | YES |
| true | delete-clustername | acid-minimal-cluster | - | NO | 
| false | delete-clustername | acid-minimal-cluster | - | YES |
| true | delete-clustername | acid-minimal-cluster | true | NO | 
| false | delete-clustername | acid-minimal-cluster | false | YES |

@dmotte can you review this please?