### PR TITLE
update clusterrole.yaml

### DIFF
--- a/charts/postgres-operator/templates/clusterrole.yaml
+++ b/charts/postgres-operator/templates/clusterrole.yaml
@@ -142,7 +142,6 @@ rules:
   - list
   - patch
 {{- if toString .Values.configKubernetes.storage_resize_mode | eq "pvc" }}
-  - patch
   - update
 {{- end }}
  # to read existing PVs. Creation should be done via dynamic provisioning

--- a/charts/postgres-operator/templates/clusterrole.yaml
+++ b/charts/postgres-operator/templates/clusterrole.yaml
@@ -140,6 +140,7 @@ rules:
   - delete
   - get
   - list
+  - patch
 {{- if toString .Values.configKubernetes.storage_resize_mode | eq "pvc" }}
   - patch
   - update


### PR DESCRIPTION
I upgraded our cluster from v1.11.0 to v1.13.0 today (running on self-hosted K8s cluster) and encountered an issue where the upgrade failed to sync the clusters, showing the following error messages. It worked fine after I added the patch permission to the PVCs in the cluster role. I'm submitting a PR to get this merged.

```
time="2024-09-16T05:42:46Z" level=warning msg="error while syncing cluster state: could not sync persistent volume claims: could not patch annotations of the persistent volume claim for volume \"pgdata-fake-hunting-db-0\": persistentvolumeclaims \"pgdata-fake-hunting-db-0\" is forbidden: User \"system:serviceaccount:postgres-operator:postgres-operator\" cannot patch resource \"persistentvolumeclaims\" in API group \"\" in the namespace \"fake-hunting\"" cluster-name=fake-hunting/fake-hunting-db pkg=cluster
time="2024-09-16T05:42:47Z" level=error msg="could not sync cluster: could not sync persistent volume claims: could not patch annotations of the persistent volume claim for volume \"pgdata-fake-hunting-db-0\": persistentvolumeclaims \"pgdata-fake-hunting-db-0\" is forbidden: User \"system:serviceaccount:postgres-operator:postgres-operator\" cannot patch resource \"persistentvolumeclaims\" in API group \"\" in the namespace \"fake-hunting\"" cluster-name=fake-hunting/fake-hunting-db pkg=controller worker=3
time="2024-09-16T05:42:47Z" level=info msg="received add event for already existing Postgres cluster" cluster-name=fake-hunting/fake-hunting-db pkg=controller worker=3```