### PR TITLE
Skip major upgrade for standby clusters with warning

### DIFF
--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -161,6 +161,11 @@ func (c *Cluster) majorVersionUpgrade() error {
 		}
 	}
 
+	if masterPod == nil {
+		c.logger.Infof("no master in the cluster, skipping major version upgrade")
+		return nil
+	}
+
 	// Recheck version with newest data from Patroni
 	if c.currentMajorVersion >= desiredVersion {
 		if _, exists := c.ObjectMeta.Annotations[majorVersionUpgradeFailureAnnotation]; exists { // if failure annotation exists, remove it

--- a/pkg/cluster/majorversionupgrade.go
+++ b/pkg/cluster/majorversionupgrade.go
@@ -145,6 +145,11 @@ func (c *Cluster) majorVersionUpgrade() error {
 	for i, pod := range pods {
 		ps, _ := c.patroni.GetMemberData(&pod)
 
+		if ps.Role == "standby_leader" {
+			c.logger.Errorf("skipping major version upgrade for %s/%s standby cluster. Re-deploy standby cluster with the required Postgres version specified", c.Namespace, c.Name)
+			return nil
+		}
+
 		if ps.State != "running" {
 			allRunning = false
 			c.logger.Infof("identified non running pod, potentially skipping major version upgrade")


### PR DESCRIPTION
otherwise it fails non-gracefully 

```
time="2024-10-15T09:37:25Z" level=debug msg="making GET http request: x" cluster-name=default/x-standby pkg=cluster
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x3a8 pc=0x14ffba2]

goroutine 161 [running]:
github.com/zalando/postgres-operator/pkg/util/patroni.apiURL(0x0)
    /go/src/github.com/zalando/postgres-operator/pkg/util/patroni/patroni.go:67 +0x22
github.com/zalando/postgres-operator/pkg/util/patroni.(*Patroni).GetClusterMembers(0xc000010420, 0xc000b32720?)
    /go/src/github.com/zalando/postgres-operator/pkg/util/patroni/patroni.go:291 +0x1f
github.com/zalando/postgres-operator/pkg/cluster.(*Cluster).majorVersionUpgrade(0xc000983908)
    /go/src/github.com/zalando/postgres-operator/pkg/cluster/majorversionupgrade.go:174 +0x6c3
github.com/zalando/postgres-operator/pkg/cluster.(*Cluster).Sync(0xc000983908, 0xc000b38488)
    /go/src/github.com/zalando/postgres-operator/pkg/cluster/sync.go:160 +0xdf5
github.com/zalando/postgres-operator/pkg/controller.(*Controller).processEvent(0xc0007b5188, {{0xc1bbab6bc0334e6f, 0x4f53bbb, 0x3a8a6a0}, {0xc000ca74a0, 0x24}, {0x21bf2de, 0x4}, 0x0, 0xc000b38488, ...})
    /go/src/github.com/zalando/postgres-operator/pkg/controller/postgresql.go:343 +0x1007
github.com/zalando/postgres-operator/pkg/controller.(*Controller).processClusterEventsQueue(0xc0007b5188, 0x9, 0xc0006db380, 0x0?)
    /go/src/github.com/zalando/postgres-operator/pkg/controller/postgresql.go:377 +0x2c5
created by github.com/zalando/postgres-operator/pkg/controller.(*Controller).Run in goroutine 1
    /go/src/github.com/zalando/postgres-operator/pkg/controller/controller.go:446 +0x5c
```