### PR TITLE
fix(postgres-operator/deployment): Set 'nindent' to 8 for 'extraEnvs'

### DIFF
--- a/charts/postgres-operator/Chart.yaml
+++ b/charts/postgres-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: postgres-operator
-version: 1.13.0
+version: 1.14.0
 appVersion: 1.13.0
 home: https://github.com/zalando/postgres-operator
 description: Postgres Operator creates and manages PostgreSQL clusters running in Kubernetes

--- a/charts/postgres-operator/templates/deployment.yaml
+++ b/charts/postgres-operator/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
           value: {{ template "postgres-operator.controllerID" . }}
       {{- end }}
       {{- if .Values.extraEnvs }}
-      {{- .Values.extraEnvs | toYaml | nindent 12 }}
+      {{- .Values.extraEnvs | toYaml | nindent 8 }}
       {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}


### PR DESCRIPTION
This PR fixes a template error in `postgres-operator/deployment`.
If you want to use `extraEnvs` in `values.yaml`, the current indentation for `extraEnvs` causes the resulting `deployment.yaml` to break due to incorrect indentation.

The nindent value has been updated from `12` to `8`.

**Result with the old values.yaml (nindent 12):**

![Old-template](https://github.com/user-attachments/assets/86caae76-9886-4c4c-978f-feb847c94626)


**Result with the new nindent set to 8:**
![New-template](https://github.com/user-attachments/assets/59483401-979e-471c-824f-30455c8aee80)


Bumped Chart.yaml version to 1.13.1 but I'm not sure if it's correct 