### PR TITLE
add cluster field for PVCs

### DIFF
--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -366,7 +366,7 @@ configuration they are grouped under the `kubernetes` key.
   manifest. To keep secrets, set this option to `false`. The default is `true`.
 
 * **enable_persistent_volume_claim_deletion**
-  By default, the operator deletes PersistentVolumeClaims when removing the
+  By default, the operator deletes persistent volume claims when removing the
   Postgres cluster manifest, no matter if `persistent_volume_claim_retention_policy`
   on the statefulset is set to `retain`. To keep PVCs set this option to `false`.
   The default is `true`.

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -65,11 +65,11 @@ type kubeResources struct {
 	PatroniConfigMaps   map[string]*v1.ConfigMap
 	Secrets             map[types.UID]*v1.Secret
 	Statefulset         *appsv1.StatefulSet
+	VolumeClaims        map[types.UID]*v1.PersistentVolumeClaim
 	PodDisruptionBudget *policyv1.PodDisruptionBudget
 	LogicalBackupJob    *batchv1.CronJob
 	Streams             map[string]*zalandov1.FabricEventStream
 	//Pods are treated separately
-	//PVCs are treated separately
 }
 
 // Cluster describes postgresql cluster
@@ -140,6 +140,7 @@ func New(cfg Config, kubeClient k8sutil.KubernetesClient, pgSpec acidv1.Postgres
 			Endpoints:         make(map[PostgresRole]*v1.Endpoints),
 			PatroniEndpoints:  make(map[string]*v1.Endpoints),
 			PatroniConfigMaps: make(map[string]*v1.ConfigMap),
+			VolumeClaims:      make(map[types.UID]*v1.PersistentVolumeClaim),
 			Streams:           make(map[string]*zalandov1.FabricEventStream)},
 		userSyncStrategy: users.DefaultUserSyncStrategy{
 			PasswordEncryption:   passwordEncryption,

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -364,6 +364,11 @@ func (c *Cluster) Create() (err error) {
 	c.logger.Infof("pods are ready")
 	c.eventRecorder.Event(c.GetReference(), v1.EventTypeNormal, "StatefulSet", "Pods are ready")
 
+	// sync volume may already transition volumes to gp3, if iops/throughput or type is specified
+	if err = c.syncVolumes(); err != nil {
+		return err
+	}
+
 	// sync resources created by Patroni
 	if err = c.syncPatroniResources(); err != nil {
 		c.logger.Warnf("Patroni resources not yet synced: %v", err)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1390,18 +1390,18 @@ func (c *Cluster) initPreparedDatabaseRoles() error {
 			preparedSchemas = map[string]acidv1.PreparedSchema{"data": {DefaultRoles: util.True()}}
 		}
 
-		var searchPath strings.Builder
-		searchPath.WriteString(constants.DefaultSearchPath)
+		searchPathArr := []string{constants.DefaultSearchPath}
 		for preparedSchemaName := range preparedSchemas {
-			searchPath.WriteString(", " + preparedSchemaName)
+			searchPathArr = append(searchPathArr, fmt.Sprintf("%q", preparedSchemaName))
 		}
+		searchPath := strings.Join(searchPathArr, ", ")
 
 		// default roles per database
-		if err := c.initDefaultRoles(defaultRoles, "admin", preparedDbName, searchPath.String(), preparedDB.SecretNamespace); err != nil {
+		if err := c.initDefaultRoles(defaultRoles, "admin", preparedDbName, searchPath, preparedDB.SecretNamespace); err != nil {
 			return fmt.Errorf("could not initialize default roles for database %s: %v", preparedDbName, err)
 		}
 		if preparedDB.DefaultUsers {
-			if err := c.initDefaultRoles(defaultUsers, "admin", preparedDbName, searchPath.String(), preparedDB.SecretNamespace); err != nil {
+			if err := c.initDefaultRoles(defaultUsers, "admin", preparedDbName, searchPath, preparedDB.SecretNamespace); err != nil {
 				return fmt.Errorf("could not initialize default roles for database %s: %v", preparedDbName, err)
 			}
 		}
@@ -1412,14 +1412,16 @@ func (c *Cluster) initPreparedDatabaseRoles() error {
 				if err := c.initDefaultRoles(defaultRoles,
 					preparedDbName+constants.OwnerRoleNameSuffix,
 					preparedDbName+"_"+preparedSchemaName,
-					constants.DefaultSearchPath+", "+preparedSchemaName, preparedDB.SecretNamespace); err != nil {
+					fmt.Sprintf("%s, %q", constants.DefaultSearchPath, preparedSchemaName),
+					preparedDB.SecretNamespace); err != nil {
 					return fmt.Errorf("could not initialize default roles for database schema %s: %v", preparedSchemaName, err)
 				}
 				if preparedSchema.DefaultUsers {
 					if err := c.initDefaultRoles(defaultUsers,
 						preparedDbName+constants.OwnerRoleNameSuffix,
 						preparedDbName+"_"+preparedSchemaName,
-						constants.DefaultSearchPath+", "+preparedSchemaName, preparedDB.SecretNamespace); err != nil {
+						fmt.Sprintf("%s, %q", constants.DefaultSearchPath, preparedSchemaName),
+						preparedDB.SecretNamespace); err != nil {
 						return fmt.Errorf("could not initialize default users for database schema %s: %v", preparedSchemaName, err)
 					}
 				}

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -71,7 +71,7 @@ func (c *Cluster) listResources() error {
 	}
 
 	for uid, pvc := range c.VolumeClaims {
-		c.logger.Infof("found PersistentVolumeClaim: %q (uid: %q)", util.NameFromMeta(pvc.ObjectMeta), uid)
+		c.logger.Infof("found persistent volume claim: %q (uid: %q)", util.NameFromMeta(pvc.ObjectMeta), uid)
 	}
 
 	for role, poolerObjs := range c.ConnectionPooler {
@@ -283,10 +283,10 @@ func (c *Cluster) deleteStatefulSet() error {
 
 	if c.OpConfig.EnablePersistentVolumeClaimDeletion != nil && *c.OpConfig.EnablePersistentVolumeClaimDeletion {
 		if err := c.deletePersistentVolumeClaims(); err != nil {
-			return fmt.Errorf("could not delete PersistentVolumeClaims: %v", err)
+			return fmt.Errorf("could not delete persistent volume claims: %v", err)
 		}
 	} else {
-		c.logger.Info("not deleting PersistentVolumeClaims because disabled in configuration")
+		c.logger.Info("not deleting persistent volume claims because disabled in configuration")
 	}
 
 	return nil

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -39,8 +39,8 @@ func (c *Cluster) listResources() error {
 		c.logger.Infof("found logical backup job: %q (uid: %q)", util.NameFromMeta(c.LogicalBackupJob.ObjectMeta), c.LogicalBackupJob.UID)
 	}
 
-	for _, secret := range c.Secrets {
-		c.logger.Infof("found secret: %q (uid: %q) namespace: %s", util.NameFromMeta(secret.ObjectMeta), secret.UID, secret.ObjectMeta.Namespace)
+	for uid, secret := range c.Secrets {
+		c.logger.Infof("found secret: %q (uid: %q) namespace: %s", util.NameFromMeta(secret.ObjectMeta), uid, secret.ObjectMeta.Namespace)
 	}
 
 	for role, service := range c.Services {
@@ -70,13 +70,8 @@ func (c *Cluster) listResources() error {
 		c.logger.Infof("found pod: %q (uid: %q)", util.NameFromMeta(obj.ObjectMeta), obj.UID)
 	}
 
-	pvcs, err := c.listPersistentVolumeClaims()
-	if err != nil {
-		return fmt.Errorf("could not get the list of PVCs: %v", err)
-	}
-
-	for _, obj := range pvcs {
-		c.logger.Infof("found PVC: %q (uid: %q)", util.NameFromMeta(obj.ObjectMeta), obj.UID)
+	for uid, pvc := range c.VolumeClaims {
+		c.logger.Infof("found PersistentVolumeClaim: %q (uid: %q)", util.NameFromMeta(pvc.ObjectMeta), uid)
 	}
 
 	for role, poolerObjs := range c.ConnectionPooler {

--- a/pkg/cluster/volumes.go
+++ b/pkg/cluster/volumes.go
@@ -185,7 +185,7 @@ func (c *Cluster) syncVolumeClaims() error {
 
 	if c.OpConfig.StorageResizeMode == "off" || c.OpConfig.StorageResizeMode == "ebs" {
 		ignoreResize = true
-		c.logger.Debugf("Storage resize mode is set to %q. Skipping volume size sync of PersistentVolumeClaims.", c.OpConfig.StorageResizeMode)
+		c.logger.Debugf("Storage resize mode is set to %q. Skipping volume size sync of persistent volume claims.", c.OpConfig.StorageResizeMode)
 	}
 
 	newSize, err := resource.ParseQuantity(c.Spec.Volume.Size)
@@ -196,7 +196,7 @@ func (c *Cluster) syncVolumeClaims() error {
 
 	pvcs, err := c.listPersistentVolumeClaims()
 	if err != nil {
-		return fmt.Errorf("could not receive persistent volume claims: %v", err)
+		return fmt.Errorf("could not list persistent volume claims: %v", err)
 	}
 	for _, pvc := range pvcs {
 		c.VolumeClaims[pvc.UID] = &pvc
@@ -272,13 +272,13 @@ func (c *Cluster) listPersistentVolumeClaims() ([]v1.PersistentVolumeClaim, erro
 
 	pvcs, err := c.KubeClient.PersistentVolumeClaims(ns).List(context.TODO(), listOptions)
 	if err != nil {
-		return nil, fmt.Errorf("could not list of PersistentVolumeClaims: %v", err)
+		return nil, fmt.Errorf("could not list of persistent volume claims: %v", err)
 	}
 	return pvcs.Items, nil
 }
 
 func (c *Cluster) deletePersistentVolumeClaims() error {
-	c.setProcessName("deleting PersistentVolumeClaims")
+	c.setProcessName("deleting persistent volume claims")
 	errors := make([]string, 0)
 	for uid := range c.VolumeClaims {
 		err := c.deletePersistentVolumeClaim(uid)
@@ -295,16 +295,16 @@ func (c *Cluster) deletePersistentVolumeClaims() error {
 }
 
 func (c *Cluster) deletePersistentVolumeClaim(uid types.UID) error {
-	c.setProcessName("deleting PersistentVolumeClaim")
+	c.setProcessName("deleting persistent volume claim")
 	pvc := c.VolumeClaims[uid]
 	c.logger.Debugf("deleting secret %q", pvc.Name)
 	err := c.KubeClient.PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, c.deleteOptions)
 	if k8sutil.ResourceNotFound(err) {
-		c.logger.Debugf("PersistentVolumeClaim %q has already been deleted", pvc.Name)
+		c.logger.Debugf("persistent volume claim %q has already been deleted", pvc.Name)
 	} else if err != nil {
-		return fmt.Errorf("could not delete PersistentVolumeClaim %q: %v", pvc.Name, err)
+		return fmt.Errorf("could not delete persistent volume claim %q: %v", pvc.Name, err)
 	}
-	c.logger.Infof("PersistentVolumeClaim %q has been deleted", pvc.Name)
+	c.logger.Infof("persistent volume claim %q has been deleted", pvc.Name)
 	delete(c.VolumeClaims, uid)
 
 	return nil
@@ -315,7 +315,7 @@ func (c *Cluster) listPersistentVolumes() ([]*v1.PersistentVolume, error) {
 
 	pvcs, err := c.listPersistentVolumeClaims()
 	if err != nil {
-		return nil, fmt.Errorf("could not list cluster's PersistentVolumeClaims: %v", err)
+		return nil, fmt.Errorf("could not list cluster's persistent volume claims: %v", err)
 	}
 
 	pods, err := c.listPods()

--- a/pkg/cluster/volumes.go
+++ b/pkg/cluster/volumes.go
@@ -185,7 +185,7 @@ func (c *Cluster) syncVolumeClaims() error {
 
 	if c.OpConfig.StorageResizeMode == "off" || c.OpConfig.StorageResizeMode == "ebs" {
 		ignoreResize = true
-		c.logger.Debugf("Storage resize mode is set to %q. Skipping volume size sync of PVCs.", c.OpConfig.StorageResizeMode)
+		c.logger.Debugf("Storage resize mode is set to %q. Skipping volume size sync of PersistentVolumeClaims.", c.OpConfig.StorageResizeMode)
 	}
 
 	newSize, err := resource.ParseQuantity(c.Spec.Volume.Size)
@@ -278,7 +278,7 @@ func (c *Cluster) listPersistentVolumeClaims() ([]v1.PersistentVolumeClaim, erro
 }
 
 func (c *Cluster) deletePersistentVolumeClaims() error {
-	c.setProcessName("deleting PVCs")
+	c.setProcessName("deleting PersistentVolumeClaims")
 	errors := make([]string, 0)
 	for uid := range c.VolumeClaims {
 		err := c.deletePersistentVolumeClaim(uid)
@@ -295,16 +295,16 @@ func (c *Cluster) deletePersistentVolumeClaims() error {
 }
 
 func (c *Cluster) deletePersistentVolumeClaim(uid types.UID) error {
-	c.setProcessName("deleting PVC")
+	c.setProcessName("deleting PersistentVolumeClaim")
 	pvc := c.VolumeClaims[uid]
 	c.logger.Debugf("deleting secret %q", pvc.Name)
 	err := c.KubeClient.PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, c.deleteOptions)
 	if k8sutil.ResourceNotFound(err) {
-		c.logger.Debugf("PVC %q has already been deleted", pvc.Name)
+		c.logger.Debugf("PersistentVolumeClaim %q has already been deleted", pvc.Name)
 	} else if err != nil {
-		return fmt.Errorf("could not delete PVC %q: %v", pvc.Name, err)
+		return fmt.Errorf("could not delete PersistentVolumeClaim %q: %v", pvc.Name, err)
 	}
-	c.logger.Infof("PVC %q has been deleted", pvc.Name)
+	c.logger.Infof("PersistentVolumeClaim %q has been deleted", pvc.Name)
 	delete(c.VolumeClaims, uid)
 
 	return nil

--- a/pkg/cluster/volumes.go
+++ b/pkg/cluster/volumes.go
@@ -297,7 +297,7 @@ func (c *Cluster) deletePersistentVolumeClaims() error {
 func (c *Cluster) deletePersistentVolumeClaim(uid types.UID) error {
 	c.setProcessName("deleting persistent volume claim")
 	pvc := c.VolumeClaims[uid]
-	c.logger.Debugf("deleting secret %q", pvc.Name)
+	c.logger.Debugf("deleting persistent volume claim %q", pvc.Name)
 	err := c.KubeClient.PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, c.deleteOptions)
 	if k8sutil.ResourceNotFound(err) {
 		c.logger.Debugf("persistent volume claim %q has already been deleted", pvc.Name)

--- a/pkg/cluster/volumes_test.go
+++ b/pkg/cluster/volumes_test.go
@@ -93,7 +93,7 @@ func TestResizeVolumeClaim(t *testing.T) {
 
 	// check if listPersistentVolumeClaims returns only the PVCs matching the filter
 	if len(pvcs) != len(pvcList.Items)-1 {
-		t.Errorf("%s: could not find all PVCs, got %v, expected %v", testName, len(pvcs), len(pvcList.Items)-1)
+		t.Errorf("%s: could not find all PersistentVolumeClaims, got %v, expected %v", testName, len(pvcs), len(pvcList.Items)-1)
 	}
 
 	// check if PVCs were correctly resized

--- a/pkg/cluster/volumes_test.go
+++ b/pkg/cluster/volumes_test.go
@@ -93,7 +93,7 @@ func TestResizeVolumeClaim(t *testing.T) {
 
 	// check if listPersistentVolumeClaims returns only the PVCs matching the filter
 	if len(pvcs) != len(pvcList.Items)-1 {
-		t.Errorf("%s: could not find all PersistentVolumeClaims, got %v, expected %v", testName, len(pvcs), len(pvcList.Items)-1)
+		t.Errorf("%s: could not find all persistent volume claims, got %v, expected %v", testName, len(pvcs), len(pvcList.Items)-1)
 	}
 
 	// check if PVCs were correctly resized


### PR DESCRIPTION
PVCs are the only resource which is not covered by OwnerReferences. We have observed that on cluster deletion operator can report that all PVCs have already been deleted, although they still exist. We believe that there might be a race condition with cluster fields such as Name and Namespace getting unset after cascaded deletion via OwnerReferences resulting in an empty list when [fetching PVCs to delete](https://github.com/zalando/postgres-operator/blob/002d0f94a1463c15500dbfa77ea42c48e5790e6b/pkg/cluster/volumes.go#L266) (labelSet function [using c.Name](https://github.com/zalando/postgres-operator/blob/master/pkg/cluster/util.go#L479) for filtering). PVC management by StatefulSet is set to Retain in our case.

This PR present an idea which we use for other resources as well: Storing resource information in a cluster field and loop over this map on deletion. However, unlike resources like Secrets and Services, PVCs are created by K8s via StatefulSet template. So we rely on a [syncVolumeClaims](https://github.com/zalando/postgres-operator/blob/002d0f94a1463c15500dbfa77ea42c48e5790e6b/pkg/cluster/volumes.go#L47) call to have the PVCs info stored in the cluster struct. If this sync does not happen for some reason, the PVCs will not get deleted. I don't think an extra call of listPersisntentVolumeClaims is needed as c.Name would mostly likely be empty as well in this scenario.

I found that syncVolumes is not called in Create() event. Adding it there would greatly reduce the chance that PVCs are not synced before a potential deletion.