### PR TITLE
Hash slotname, if it exceeds 63 characters in streams

### DIFF
--- a/pkg/cluster/streams.go
+++ b/pkg/cluster/streams.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"crypto/sha1"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -288,7 +289,11 @@ func getOutboxTable(tableName string, idColumn *string) zalandov1.EventStreamTab
 }
 
 func getSlotName(dbName, appId string) string {
-	return fmt.Sprintf("%s_%s_%s", constants.EventStreamSourceSlotPrefix, dbName, strings.Replace(appId, "-", "_", -1))
+	name := fmt.Sprintf("%s_%s_%s", constants.EventStreamSourceSlotPrefix, dbName, strings.Replace(appId, "-", "_", -1))
+	if len(name) > 63 {
+		name = fmt.Sprintf("%s_%s", constants.EventStreamSourceSlotPrefix, sha1.Sum([]byte(name)))
+	}
+	return name
 }
 
 func (c *Cluster) getStreamConnection(database, user, appId string) zalandov1.Connection {

--- a/pkg/cluster/streams.go
+++ b/pkg/cluster/streams.go
@@ -291,7 +291,7 @@ func getOutboxTable(tableName string, idColumn *string) zalandov1.EventStreamTab
 func getSlotName(dbName, appId string) string {
 	name := fmt.Sprintf("%s_%s_%s", constants.EventStreamSourceSlotPrefix, dbName, strings.Replace(appId, "-", "_", -1))
 	if len(name) > 63 {
-		name = fmt.Sprintf("%s_%s", constants.EventStreamSourceSlotPrefix, sha1.Sum([]byte(name)))
+		name = fmt.Sprintf("%s_%x", constants.EventStreamSourceSlotPrefix, sha1.Sum([]byte(name)))
 	}
 	return name
 }

--- a/pkg/cluster/streams_test.go
+++ b/pkg/cluster/streams_test.go
@@ -752,3 +752,27 @@ func patchPostgresqlStreams(t *testing.T, cluster *Cluster, pgSpec *acidv1.Postg
 
 	return streams
 }
+
+func TestSlotNameWithinMaxLength(t *testing.T) {
+	dbName := "testdb"
+	appId := "test-app"
+	expected := constants.EventStreamSourceSlotPrefix + "_testdb_test_app"
+	result := getSlotName(dbName, appId)
+	assert.Equal(t, expected, result)
+}
+
+func TestSlotNameExceedsMaxLength(t *testing.T) {
+	dbName := "testdb"
+	appId := "this-is-a-very-long-application-id-that-will-exceed-the-maximum-length"
+	expected := constants.EventStreamSourceSlotPrefix + "_5a300d179c894b672b35bac212eab875d4c4145a"
+	result := getSlotName(dbName, appId)
+	assert.Equal(t, expected, result)
+}
+
+func TestSlotNameWithHyphens(t *testing.T) {
+	dbName := "testdb"
+	appId := "test-app-with-hyphens"
+	expected := constants.EventStreamSourceSlotPrefix + "_testdb_test_app_with_hyphens"
+	result := getSlotName(dbName, appId)
+	assert.Equal(t, expected, result)
+}


### PR DESCRIPTION
The replication slot in Postgres is of type name, which has a char limit of 63. At the moment the inputs of the stream section are used to generate the slot name, they are constructed by combining `fes_{dbname}_{app_id}`. This easily can exceed 63 characters, as application ids tend to be longer in a microservice environment, and also db names can contain things like team-name, environment, and the same long app-id. To address this when using streams in the Postgres manifest, I created a PR that checks if this is the case and then **hashes** the slot name to ensure its length is always shorter than 63. This should result in the configuration not failing when applied. 

I am also happy to discuss/implement other alternatives like:

- Truncating
- Shortening: long_application_id -> lai