### PR TITLE
allow hyphens in database name

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -42,7 +42,7 @@ import (
 
 var (
 	alphaNumericRegexp    = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9]*$")
-	databaseNameRegexp    = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
+	databaseNameRegexp    = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_-]*$")
 	userRegexp            = regexp.MustCompile(`^[a-z0-9]([-_a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-_a-z0-9]*[a-z0-9])?)*$`)
 	patroniObjectSuffixes = []string{"leader", "config", "sync", "failover"}
 	finalizerName         = "postgres-operator.acid.zalan.do"


### PR DESCRIPTION
Allow for hyphens in the database name, they are currently supported by Postgres, but not this operator

Current behavior:
```
time="2024-12-10T22:58:31Z" level=info msg="database \"my-database\" has invalid name" cluster-name=postgres/pg-cluster pkg=cluster
```