### PR TITLE
Ensure podAnnotations are removed from pods if reset in the config

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -853,7 +853,7 @@ func (c *Cluster) compareLogicalBackupJob(cur, new *batchv1.CronJob) (match bool
 	newPodAnnotation := new.Spec.JobTemplate.Spec.Template.Annotations
 	curPodAnnotation := cur.Spec.JobTemplate.Spec.Template.Annotations
 	if changed, reason := c.compareAnnotations(curPodAnnotation, newPodAnnotation); changed {
-		return false, fmt.Sprintf("new job's pod template metadata annotations does not match " + reason)
+		return false, fmt.Sprint("new job's pod template metadata annotations do not match " + reason)
 	}
 
 	newPgVersion := getPgVersion(new)

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1680,7 +1680,7 @@ func TestCompareLogicalBackupJob(t *testing.T) {
 				}
 			}
 
-			match, reason := cluster.compareLogicalBackupJob(currentCronJob, desiredCronJob)
+			match, reason := cluster.compareLogicalBackupJob(currentCronJob, desiredCronJob, nil)
 			if match != tt.match {
 				t.Errorf("%s - unexpected match result %t when comparing cronjobs %#v and %#v", t.Name(), match, currentCronJob, desiredCronJob)
 			} else {

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1680,12 +1680,20 @@ func TestCompareLogicalBackupJob(t *testing.T) {
 				}
 			}
 
-			match, reason := cluster.compareLogicalBackupJob(currentCronJob, desiredCronJob, nil)
-			if match != tt.match {
-				t.Errorf("%s - unexpected match result %t when comparing cronjobs %#v and %#v", t.Name(), match, currentCronJob, desiredCronJob)
-			} else {
-				if !strings.HasPrefix(reason, tt.reason) {
-					t.Errorf("%s - expected reason prefix %s, found %s", t.Name(), tt.reason, reason)
+			cmp := cluster.compareLogicalBackupJob(currentCronJob, desiredCronJob)
+			if cmp.match != tt.match {
+				t.Errorf("%s - unexpected match result %t when comparing cronjobs %#v and %#v", t.Name(), cmp.match, currentCronJob, desiredCronJob)
+			} else if !cmp.match {
+				found := false
+				for _, reason := range cmp.reasons {
+					if strings.HasPrefix(reason, tt.reason) {
+						found = true
+						break
+					}
+					found = false
+				}
+				if !found {
+					t.Errorf("%s - expected reason prefix %s, not found in %#v", t.Name(), tt.reason, cmp.reasons)
 				}
 			}
 		})

--- a/pkg/cluster/connection_pooler.go
+++ b/pkg/cluster/connection_pooler.go
@@ -978,7 +978,7 @@ func (c *Cluster) syncConnectionPoolerWorker(oldSpec, newSpec *acidv1.Postgresql
 		err           error
 	)
 
-	updatedAnnotations := map[string]*string{}
+	updatedPodAnnotations := map[string]*string{}
 	syncReason := make([]string, 0)
 	deployment, err = c.KubeClient.
 		Deployments(c.Namespace).
@@ -1040,35 +1040,27 @@ func (c *Cluster) syncConnectionPoolerWorker(oldSpec, newSpec *acidv1.Postgresql
 		}
 
 		newPodAnnotations := c.annotationsSet(c.generatePodAnnotations(&c.Spec))
-		if changed, reason := c.compareAnnotations(deployment.Spec.Template.Annotations, newPodAnnotations); changed {
+		deletedPodAnnotations := []string{}
+		if changed, reason := c.compareAnnotations(deployment.Spec.Template.Annotations, newPodAnnotations, &deletedPodAnnotations); changed {
 			specSync = true
 			syncReason = append(syncReason, []string{"new connection pooler's pod template annotations do not match the current ones: " + reason}...)
 
-			if strings.Contains(reason, "Removed") {
-				templateMetadataReq := map[string]map[string]map[string]map[string]map[string]*string{"spec": {"template": {"metadata": {"annotations": {}}}}}
-				for anno := range deployment.Spec.Template.Annotations {
-					if _, ok := newPodAnnotations[anno]; !ok {
-						// template annotation was removed
-						for _, ignore := range c.OpConfig.IgnoredAnnotations {
-							if anno == ignore {
-								continue
-							}
-						}
-						updatedAnnotations[anno] = nil
-					}
-				}
-				templateMetadataReq["spec"]["template"]["metadata"]["annotations"] = updatedAnnotations
-				patch, err := json.Marshal(templateMetadataReq)
-				if err != nil {
-					return nil, fmt.Errorf("could not marshal ObjectMeta for %s connection pooler's pod template: %v", role, err)
-				}
-				deployment, err = c.KubeClient.Deployments(c.Namespace).Patch(context.TODO(),
-					deployment.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "")
-				if err != nil {
-					c.logger.Errorf("failed to remove annotations from %s connection pooler's pod template: %v", role, err)
-					return nil, err
-				}
+			for _, anno := range deletedPodAnnotations {
+				updatedPodAnnotations[anno] = nil
 			}
+			templateMetadataReq := map[string]map[string]map[string]map[string]map[string]*string{
+				"spec": {"template": {"metadata": {"annotations": updatedPodAnnotations}}}}
+			patch, err := json.Marshal(templateMetadataReq)
+			if err != nil {
+				return nil, fmt.Errorf("could not marshal ObjectMeta for %s connection pooler's pod template: %v", role, err)
+			}
+			deployment, err = c.KubeClient.Deployments(c.Namespace).Patch(context.TODO(),
+				deployment.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "")
+			if err != nil {
+				c.logger.Errorf("failed to patch %s connection pooler's pod template: %v", role, err)
+				return nil, err
+			}
+
 			deployment.Spec.Template.Annotations = newPodAnnotations
 		}
 
@@ -1092,7 +1084,7 @@ func (c *Cluster) syncConnectionPoolerWorker(oldSpec, newSpec *acidv1.Postgresql
 		}
 
 		newAnnotations := c.AnnotationsToPropagate(c.annotationsSet(nil)) // including the downscaling annotations
-		if changed, _ := c.compareAnnotations(deployment.Annotations, newAnnotations); changed {
+		if changed, _ := c.compareAnnotations(deployment.Annotations, newAnnotations, nil); changed {
 			deployment, err = patchConnectionPoolerAnnotations(c.KubeClient, deployment, newAnnotations)
 			if err != nil {
 				return nil, err
@@ -1126,13 +1118,13 @@ func (c *Cluster) syncConnectionPoolerWorker(oldSpec, newSpec *acidv1.Postgresql
 			if err != nil {
 				return nil, fmt.Errorf("could not delete pooler pod: %v", err)
 			}
-		} else if changed, _ := c.compareAnnotations(pod.Annotations, deployment.Spec.Template.Annotations); changed {
+		} else if changed, _ := c.compareAnnotations(pod.Annotations, deployment.Spec.Template.Annotations, nil); changed {
 			metadataReq := map[string]map[string]map[string]*string{"metadata": {}}
 
 			for anno, val := range deployment.Spec.Template.Annotations {
-				updatedAnnotations[anno] = &val
+				updatedPodAnnotations[anno] = &val
 			}
-			metadataReq["metadata"]["annotations"] = updatedAnnotations
+			metadataReq["metadata"]["annotations"] = updatedPodAnnotations
 			patch, err := json.Marshal(metadataReq)
 			if err != nil {
 				return nil, fmt.Errorf("could not marshal ObjectMeta for %s connection pooler's pods: %v", role, err)

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -329,7 +329,7 @@ func (c *Cluster) updateService(role PostgresRole, oldService *v1.Service, newSe
 		}
 	}
 
-	if changed, _ := c.compareAnnotations(oldService.Annotations, newService.Annotations); changed {
+	if changed, _ := c.compareAnnotations(oldService.Annotations, newService.Annotations, nil); changed {
 		patchData, err := metaAnnotationsPatch(newService.Annotations)
 		if err != nil {
 			return nil, fmt.Errorf("could not form patch for service %q annotations: %v", oldService.Name, err)

--- a/pkg/cluster/streams.go
+++ b/pkg/cluster/streams.go
@@ -545,7 +545,7 @@ func (c *Cluster) compareStreams(curEventStreams, newEventStreams *zalandov1.Fab
 	for newKey, newValue := range newEventStreams.Annotations {
 		desiredAnnotations[newKey] = newValue
 	}
-	if changed, reason := c.compareAnnotations(curEventStreams.ObjectMeta.Annotations, desiredAnnotations); changed {
+	if changed, reason := c.compareAnnotations(curEventStreams.ObjectMeta.Annotations, desiredAnnotations, nil); changed {
 		match = false
 		reasons = append(reasons, fmt.Sprintf("new streams annotations do not match: %s", reason))
 	}

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -559,11 +559,10 @@ func (c *Cluster) syncStatefulSet() error {
 		// statefulset is already there, make sure we use its definition in order to compare with the spec.
 		c.Statefulset = sset
 
-		deletedPodAnnotations := []string{}
-		cmp := c.compareStatefulSetWith(desiredSts, &deletedPodAnnotations)
+		cmp := c.compareStatefulSetWith(desiredSts)
 		if !cmp.rollingUpdate {
 			updatedPodAnnotations := map[string]*string{}
-			for _, anno := range deletedPodAnnotations {
+			for _, anno := range cmp.deletedPodAnnotations {
 				updatedPodAnnotations[anno] = nil
 			}
 			for anno, val := range desiredSts.Spec.Template.Annotations {

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -146,7 +146,7 @@ func TestPodAnnotationsSync(t *testing.T) {
 	clusterName := "acid-test-cluster-2"
 	namespace := "default"
 	podAnnotation := "no-scale-down"
-	podAnnotations := map[string]string{"no-scale-down": "true"}
+	podAnnotations := map[string]string{podAnnotation: "true"}
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -271,7 +271,7 @@ func TestPodAnnotationsSync(t *testing.T) {
 	stsList, err = cluster.KubeClient.StatefulSets(namespace).List(context.TODO(), clusterOptions)
 	assert.NoError(t, err)
 	for _, sts := range stsList.Items {
-		assert.NotContains(t, sts.Spec.Template.Annotations, "no-scale-down")
+		assert.NotContains(t, sts.Spec.Template.Annotations, podAnnotation)
 	}
 
 	for _, role := range []PostgresRole{Master, Replica} {
@@ -286,7 +286,7 @@ func TestPodAnnotationsSync(t *testing.T) {
 	podList, err = cluster.KubeClient.Pods(namespace).List(context.TODO(), clusterOptions)
 	assert.NoError(t, err)
 	for _, pod := range podList.Items {
-		assert.NotContains(t, pod.Annotations, "no-scale-down",
+		assert.NotContains(t, pod.Annotations, podAnnotation,
 			fmt.Sprintf("pod %s should not contain annotation %s, found %#v", pod.Name, podAnnotation, pod.Annotations))
 	}
 

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -193,6 +193,7 @@ func TestPodAnnotationsSync(t *testing.T) {
 					DefaultCPULimit:       "300m",
 					DefaultMemoryRequest:  "300Mi",
 					DefaultMemoryLimit:    "300Mi",
+					MaxInstances:          -1,
 					PodRoleLabel:          "spilo-role",
 					ResourceCheckInterval: time.Duration(3),
 					ResourceCheckTimeout:  time.Duration(10),
@@ -309,7 +310,7 @@ func TestPodAnnotationsSync(t *testing.T) {
 	assert.NoError(t, err)
 	for _, cronJob := range cronJobList.Items {
 		for _, annotation := range []string{podAnnotation, customPodAnnotation} {
-			assert.NotContains(t, cronJob.Annotations, annotation,
+			assert.NotContains(t, cronJob.Spec.JobTemplate.Spec.Template.Annotations, annotation,
 				fmt.Sprintf("logical backup cron job's pod template should not contain annotation %s, found %#v",
 					annotation, cronJob.Spec.JobTemplate.Spec.Template.Annotations))
 		}

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -122,7 +122,7 @@ func TestSyncStatefulSetsAnnotations(t *testing.T) {
 	desiredSts, err := cluster.generateStatefulSet(&cluster.Postgresql.Spec)
 	assert.NoError(t, err)
 
-	cmp := cluster.compareStatefulSetWith(desiredSts, nil)
+	cmp := cluster.compareStatefulSetWith(desiredSts)
 	if cmp.match {
 		t.Errorf("%s: match between current and desired statefulsets albeit differences: %#v", testName, cmp)
 	}
@@ -131,7 +131,7 @@ func TestSyncStatefulSetsAnnotations(t *testing.T) {
 	cluster.syncStatefulSet()
 
 	// compare again after the SYNC - must be identical to the desired state
-	cmp = cluster.compareStatefulSetWith(desiredSts, nil)
+	cmp = cluster.compareStatefulSetWith(desiredSts)
 	if !cmp.match {
 		t.Errorf("%s: current and desired statefulsets are not matching %#v", testName, cmp)
 	}

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -122,7 +122,7 @@ func TestSyncStatefulSetsAnnotations(t *testing.T) {
 	desiredSts, err := cluster.generateStatefulSet(&cluster.Postgresql.Spec)
 	assert.NoError(t, err)
 
-	cmp := cluster.compareStatefulSetWith(desiredSts)
+	cmp := cluster.compareStatefulSetWith(desiredSts, nil)
 	if cmp.match {
 		t.Errorf("%s: match between current and desired statefulsets albeit differences: %#v", testName, cmp)
 	}
@@ -131,7 +131,7 @@ func TestSyncStatefulSetsAnnotations(t *testing.T) {
 	cluster.syncStatefulSet()
 
 	// compare again after the SYNC - must be identical to the desired state
-	cmp = cluster.compareStatefulSetWith(desiredSts)
+	cmp = cluster.compareStatefulSetWith(desiredSts, nil)
 	if !cmp.match {
 		t.Errorf("%s: current and desired statefulsets are not matching %#v", testName, cmp)
 	}

--- a/pkg/cluster/util_test.go
+++ b/pkg/cluster/util_test.go
@@ -247,18 +247,18 @@ func createPods(cluster *Cluster) []v1.Pod {
 	for i, role := range []PostgresRole{Master, Replica} {
 		podsList = append(podsList, v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-%d", clusterName, i),
+				Name:      fmt.Sprintf("%s-%d", cluster.Name, i),
 				Namespace: namespace,
 				Labels: map[string]string{
 					"application":  "spilo",
-					"cluster-name": clusterName,
+					"cluster-name": cluster.Name,
 					"spilo-role":   string(role),
 				},
 			},
 		})
 		podsList = append(podsList, v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-pooler-%s", clusterName, role),
+				Name:      fmt.Sprintf("%s-pooler-%s", cluster.Name, role),
 				Namespace: namespace,
 				Labels:    cluster.connectionPoolerLabels(role, true).MatchLabels,
 			},

--- a/pkg/cluster/volumes.go
+++ b/pkg/cluster/volumes.go
@@ -225,7 +225,7 @@ func (c *Cluster) syncVolumeClaims() error {
 		}
 
 		newAnnotations := c.annotationsSet(nil)
-		if changed, _ := c.compareAnnotations(pvc.Annotations, newAnnotations); changed {
+		if changed, _ := c.compareAnnotations(pvc.Annotations, newAnnotations, nil); changed {
 			patchData, err := metaAnnotationsPatch(newAnnotations)
 			if err != nil {
 				return fmt.Errorf("could not form patch for the persistent volume claim for volume %q: %v", pvc.Name, err)


### PR DESCRIPTION
fix use case when an annotation is removed from the `podAnnotations` setting  (should be reflected for the running Pods and Pod templates)