### PR TITLE
Critical operation PDB

### DIFF
--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -620,22 +620,34 @@ By default the topology key for the pod anti affinity is set to
 `kubernetes.io/hostname`, you can set another topology key e.g.
 `failure-domain.beta.kubernetes.io/zone`. See [built-in node labels](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#interlude-built-in-node-labels) for available topology keys.
 
-## Pod Disruption Budget
+## Pod Disruption Budgets
 
-By default the operator uses a PodDisruptionBudget (PDB) to protect the cluster
-from voluntarily disruptions and hence unwanted DB downtime. The `MinAvailable`
-parameter of the PDB is set to `1` which prevents killing masters in single-node
-clusters and/or the last remaining running instance in a multi-node cluster.
+By default the operator creates two PodDisruptionBudgets (PDB) to protect the cluster
+from voluntarily disruptions and hence unwanted DB downtime: so-called primary PDB and
+and PDB for critical operations.
+
+### Primary PDB
+The `MinAvailable` parameter of this PDB is set to `1` and, if `pdb_master_label_selector`
+is enabled, label selector includes `spilo-role=master` condition, which prevents killing
+masters in single-node clusters and/or the last remaining running instance in a multi-node
+cluster.
+
+## PDB for critical operations
+The `MinAvailable` parameter of this PDB is equal to the `numberOfInstances` set in the
+cluster manifest, while label selector includes `critical-operation=true` condition. This
+allows to protect all pods of a cluster, given they are labeled accordingly.
+For example, Operator labels all Spilo pods with `critical-operation=true` during the major
+version upgrade run. You may want to protect cluster pods during other critical operations
+by assigning the label to pods yourself or using other means of automation.
 
 The PDB is only relaxed in two scenarios:
 
 * If a cluster is scaled down to `0` instances (e.g. for draining nodes)
 * If the PDB is disabled in the configuration (`enable_pod_disruption_budget`)
 
-The PDB is still in place having `MinAvailable` set to `0`. If enabled it will
-be automatically set to `1` on scale up. Disabling PDBs helps avoiding blocking
-Kubernetes upgrades in managed K8s environments at the cost of prolonged DB
-downtime. See PR [#384](https://github.com/zalando/postgres-operator/pull/384)
+The PDBs are still in place having `MinAvailable` set to `0`. Disabling PDBs
+helps avoiding blocking Kubernetes upgrades in managed K8s environments at the
+cost of prolonged DB downtime. See PR [#384](https://github.com/zalando/postgres-operator/pull/384)
 for the use case.
 
 ## Add cluster-specific labels

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -230,7 +230,7 @@ kubectl delete postgresql acid-minimal-cluster
 ```
 
 This should remove the associated StatefulSet, database Pods, Services and
-Endpoints. The PersistentVolumes are released and the PodDisruptionBudget is
+Endpoints. The PersistentVolumes are released and the PodDisruptionBudgets are
 deleted. Secrets however are not deleted and backups will remain in place.
 
 When deleting a cluster while it is still starting up or got stuck during that

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -334,13 +334,13 @@ configuration they are grouped under the `kubernetes` key.
   pod namespace).
 
 * **pdb_name_format**
-  defines the template for PDB (Pod Disruption Budget) names created by the
+  defines the template for primary PDB (Pod Disruption Budget) name created by the
   operator. The default is `postgres-{cluster}-pdb`, where `{cluster}` is
   replaced by the cluster name. Only the `{cluster}` placeholders is allowed in
   the template.
 
 * **pdb_master_label_selector**
-  By default the PDB will match the master role hence preventing nodes to be
+  By default the primary PDB will match the master role hence preventing nodes to be
   drained if the node_readiness_label is not used. If this option if set to
   `false` the `spilo-role=master` selector will not be added to the PDB.
 

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -2547,10 +2547,10 @@ class EndToEndTestCase(unittest.TestCase):
         self.assertTrue(self.has_postgresql_owner_reference(config_ep.metadata.owner_references, inverse), "config endpoint owner reference check failed")
 
         pdb = k8s.api.policy_v1.read_namespaced_pod_disruption_budget("postgres-{}-pdb".format(cluster_name), cluster_namespace)
-        self.assertTrue(self.has_postgresql_owner_reference(pdb.metadata.owner_references, inverse), "pod disruption owner reference check failed")
+        self.assertTrue(self.has_postgresql_owner_reference(pdb.metadata.owner_references, inverse), "pod disruption budget owner reference check failed")
 
         pdb = k8s.api.policy_v1.read_namespaced_pod_disruption_budget("postgres-{}-critical-operation-pdb".format(cluster_name), cluster_namespace)
-        self.assertTrue(self.has_postgresql_owner_reference(pdb.metadata.owner_references, inverse), "pod disruption owner reference check failed")
+        self.assertTrue(self.has_postgresql_owner_reference(pdb.metadata.owner_references, inverse), "pod disruption budget for critical operations owner reference check failed")
 
         pg_secret = k8s.api.core_v1.read_namespaced_secret("postgres.{}.credentials.postgresql.acid.zalan.do".format(cluster_name), cluster_namespace)
         self.assertTrue(self.has_postgresql_owner_reference(pg_secret.metadata.owner_references, inverse), "postgres secret owner reference check failed")

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -2547,9 +2547,9 @@ class EndToEndTestCase(unittest.TestCase):
         self.assertTrue(self.has_postgresql_owner_reference(config_ep.metadata.owner_references, inverse), "config endpoint owner reference check failed")
 
         pdb = k8s.api.policy_v1.read_namespaced_pod_disruption_budget("postgres-{}-pdb".format(cluster_name), cluster_namespace)
-        self.assertTrue(self.has_postgresql_owner_reference(pdb.metadata.owner_references, inverse), "pod disruption budget owner reference check failed")
+        self.assertTrue(self.has_postgresql_owner_reference(pdb.metadata.owner_references, inverse), "primary pod disruption budget owner reference check failed")
 
-        pdb = k8s.api.policy_v1.read_namespaced_pod_disruption_budget("postgres-{}-critical-operation-pdb".format(cluster_name), cluster_namespace)
+        pdb = k8s.api.policy_v1.read_namespaced_pod_disruption_budget("postgres-{}-critical-op-pdb".format(cluster_name), cluster_namespace)
         self.assertTrue(self.has_postgresql_owner_reference(pdb.metadata.owner_references, inverse), "pod disruption budget for critical operations owner reference check failed")
 
         pg_secret = k8s.api.core_v1.read_namespaced_secret("postgres.{}.credentials.postgresql.acid.zalan.do".format(cluster_name), cluster_namespace)

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -2549,6 +2549,9 @@ class EndToEndTestCase(unittest.TestCase):
         pdb = k8s.api.policy_v1.read_namespaced_pod_disruption_budget("postgres-{}-pdb".format(cluster_name), cluster_namespace)
         self.assertTrue(self.has_postgresql_owner_reference(pdb.metadata.owner_references, inverse), "pod disruption owner reference check failed")
 
+        pdb = k8s.api.policy_v1.read_namespaced_pod_disruption_budget("postgres-{}-critical-operation-pdb".format(cluster_name), cluster_namespace)
+        self.assertTrue(self.has_postgresql_owner_reference(pdb.metadata.owner_references, inverse), "pod disruption owner reference check failed")
+
         pg_secret = k8s.api.core_v1.read_namespaced_secret("postgres.{}.credentials.postgresql.acid.zalan.do".format(cluster_name), cluster_namespace)
         self.assertTrue(self.has_postgresql_owner_reference(pg_secret.metadata.owner_references, inverse), "postgres secret owner reference check failed")
         standby_secret = k8s.api.core_v1.read_namespaced_secret("standby.{}.credentials.postgresql.acid.zalan.do".format(cluster_name), cluster_namespace)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -59,16 +59,17 @@ type Config struct {
 }
 
 type kubeResources struct {
-	Services                   map[PostgresRole]*v1.Service
-	Endpoints                  map[PostgresRole]*v1.Endpoints
-	PatroniEndpoints           map[string]*v1.Endpoints
-	PatroniConfigMaps          map[string]*v1.ConfigMap
-	Secrets                    map[types.UID]*v1.Secret
-	Statefulset                *appsv1.StatefulSet
-	VolumeClaims               map[types.UID]*v1.PersistentVolumeClaim
-	GeneralPodDisruptionBudget *policyv1.PodDisruptionBudget
-	LogicalBackupJob           *batchv1.CronJob
-	Streams                    map[string]*zalandov1.FabricEventStream
+	Services                      map[PostgresRole]*v1.Service
+	Endpoints                     map[PostgresRole]*v1.Endpoints
+	PatroniEndpoints              map[string]*v1.Endpoints
+	PatroniConfigMaps             map[string]*v1.ConfigMap
+	Secrets                       map[types.UID]*v1.Secret
+	Statefulset                   *appsv1.StatefulSet
+	VolumeClaims                  map[types.UID]*v1.PersistentVolumeClaim
+	GeneralPodDisruptionBudget    *policyv1.PodDisruptionBudget
+	CriticalOpPodDisruptionBudget *policyv1.PodDisruptionBudget
+	LogicalBackupJob              *batchv1.CronJob
+	Streams                       map[string]*zalandov1.FabricEventStream
 	//Pods are treated separately
 }
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -66,7 +66,7 @@ type kubeResources struct {
 	Secrets                       map[types.UID]*v1.Secret
 	Statefulset                   *appsv1.StatefulSet
 	VolumeClaims                  map[types.UID]*v1.PersistentVolumeClaim
-	GeneralPodDisruptionBudget    *policyv1.PodDisruptionBudget
+	PrimaryPodDisruptionBudget    *policyv1.PodDisruptionBudget
 	CriticalOpPodDisruptionBudget *policyv1.PodDisruptionBudget
 	LogicalBackupJob              *batchv1.CronJob
 	Streams                       map[string]*zalandov1.FabricEventStream
@@ -1735,7 +1735,7 @@ func (c *Cluster) GetStatus() *ClusterStatus {
 		MasterService:                 c.GetServiceMaster(),
 		ReplicaService:                c.GetServiceReplica(),
 		StatefulSet:                   c.GetStatefulSet(),
-		GeneralPodDisruptionBudget:    c.GetGeneralPodDisruptionBudget(),
+		PrimaryPodDisruptionBudget:    c.GetPrimaryPodDisruptionBudget(),
 		CriticalOpPodDisruptionBudget: c.GetCriticalOpPodDisruptionBudget(),
 		CurrentProcess:                c.GetCurrentProcess(),
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1727,16 +1727,17 @@ func (c *Cluster) GetCurrentProcess() Process {
 // GetStatus provides status of the cluster
 func (c *Cluster) GetStatus() *ClusterStatus {
 	status := &ClusterStatus{
-		Cluster:                    c.Name,
-		Namespace:                  c.Namespace,
-		Team:                       c.Spec.TeamID,
-		Status:                     c.Status,
-		Spec:                       c.Spec,
-		MasterService:              c.GetServiceMaster(),
-		ReplicaService:             c.GetServiceReplica(),
-		StatefulSet:                c.GetStatefulSet(),
-		GeneralPodDisruptionBudget: c.GetGeneralPodDisruptionBudget(),
-		CurrentProcess:             c.GetCurrentProcess(),
+		Cluster:                       c.Name,
+		Namespace:                     c.Namespace,
+		Team:                          c.Spec.TeamID,
+		Status:                        c.Status,
+		Spec:                          c.Spec,
+		MasterService:                 c.GetServiceMaster(),
+		ReplicaService:                c.GetServiceReplica(),
+		StatefulSet:                   c.GetStatefulSet(),
+		GeneralPodDisruptionBudget:    c.GetGeneralPodDisruptionBudget(),
+		CriticalOpPodDisruptionBudget: c.GetCriticalOpPodDisruptionBudget(),
+		CurrentProcess:                c.GetCurrentProcess(),
 
 		Error: fmt.Errorf("error: %s", c.Error),
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -59,16 +59,16 @@ type Config struct {
 }
 
 type kubeResources struct {
-	Services                  map[PostgresRole]*v1.Service
-	Endpoints                 map[PostgresRole]*v1.Endpoints
-	PatroniEndpoints          map[string]*v1.Endpoints
-	PatroniConfigMaps         map[string]*v1.ConfigMap
-	Secrets                   map[types.UID]*v1.Secret
-	Statefulset               *appsv1.StatefulSet
-	VolumeClaims              map[types.UID]*v1.PersistentVolumeClaim
-	MasterPodDisruptionBudget *policyv1.PodDisruptionBudget
-	LogicalBackupJob          *batchv1.CronJob
-	Streams                   map[string]*zalandov1.FabricEventStream
+	Services                   map[PostgresRole]*v1.Service
+	Endpoints                  map[PostgresRole]*v1.Endpoints
+	PatroniEndpoints           map[string]*v1.Endpoints
+	PatroniConfigMaps          map[string]*v1.ConfigMap
+	Secrets                    map[types.UID]*v1.Secret
+	Statefulset                *appsv1.StatefulSet
+	VolumeClaims               map[types.UID]*v1.PersistentVolumeClaim
+	GeneralPodDisruptionBudget *policyv1.PodDisruptionBudget
+	LogicalBackupJob           *batchv1.CronJob
+	Streams                    map[string]*zalandov1.FabricEventStream
 	//Pods are treated separately
 }
 
@@ -1726,16 +1726,16 @@ func (c *Cluster) GetCurrentProcess() Process {
 // GetStatus provides status of the cluster
 func (c *Cluster) GetStatus() *ClusterStatus {
 	status := &ClusterStatus{
-		Cluster:                   c.Name,
-		Namespace:                 c.Namespace,
-		Team:                      c.Spec.TeamID,
-		Status:                    c.Status,
-		Spec:                      c.Spec,
-		MasterService:             c.GetServiceMaster(),
-		ReplicaService:            c.GetServiceReplica(),
-		StatefulSet:               c.GetStatefulSet(),
-		MasterPodDisruptionBudget: c.GetMasterPodDisruptionBudget(),
-		CurrentProcess:            c.GetCurrentProcess(),
+		Cluster:                    c.Name,
+		Namespace:                  c.Namespace,
+		Team:                       c.Spec.TeamID,
+		Status:                     c.Status,
+		Spec:                       c.Spec,
+		MasterService:              c.GetServiceMaster(),
+		ReplicaService:             c.GetServiceReplica(),
+		StatefulSet:                c.GetStatefulSet(),
+		GeneralPodDisruptionBudget: c.GetGeneralPodDisruptionBudget(),
+		CurrentProcess:             c.GetCurrentProcess(),
 
 		Error: fmt.Errorf("error: %s", c.Error),
 	}

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -109,7 +109,7 @@ func (c *Cluster) servicePort(role PostgresRole) int32 {
 	return pgPort
 }
 
-func (c *Cluster) podDisruptionBudgetName() string {
+func (c *Cluster) masterPodDisruptionBudgetName() string {
 	return c.OpConfig.PDBNameFormat.Format("cluster", c.Name)
 }
 
@@ -2207,7 +2207,7 @@ func (c *Cluster) generateStandbyEnvironment(description *acidv1.StandbyDescript
 	return result
 }
 
-func (c *Cluster) generatePodDisruptionBudget() *policyv1.PodDisruptionBudget {
+func (c *Cluster) generateMasterPodDisruptionBudget() *policyv1.PodDisruptionBudget {
 	minAvailable := intstr.FromInt(1)
 	pdbEnabled := c.OpConfig.EnablePodDisruptionBudget
 	pdbMasterLabelSelector := c.OpConfig.PDBMasterLabelSelector
@@ -2225,7 +2225,7 @@ func (c *Cluster) generatePodDisruptionBudget() *policyv1.PodDisruptionBudget {
 
 	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            c.podDisruptionBudgetName(),
+			Name:            c.masterPodDisruptionBudgetName(),
 			Namespace:       c.Namespace,
 			Labels:          c.labelsSet(true),
 			Annotations:     c.annotationsSet(nil),

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -109,7 +109,7 @@ func (c *Cluster) servicePort(role PostgresRole) int32 {
 	return pgPort
 }
 
-func (c *Cluster) masterPodDisruptionBudgetName() string {
+func (c *Cluster) generalPodDisruptionBudgetName() string {
 	return c.OpConfig.PDBNameFormat.Format("cluster", c.Name)
 }
 
@@ -2207,7 +2207,7 @@ func (c *Cluster) generateStandbyEnvironment(description *acidv1.StandbyDescript
 	return result
 }
 
-func (c *Cluster) generateMasterPodDisruptionBudget() *policyv1.PodDisruptionBudget {
+func (c *Cluster) generateGeneralPodDisruptionBudget() *policyv1.PodDisruptionBudget {
 	minAvailable := intstr.FromInt(1)
 	pdbEnabled := c.OpConfig.EnablePodDisruptionBudget
 	pdbMasterLabelSelector := c.OpConfig.PDBMasterLabelSelector
@@ -2225,7 +2225,7 @@ func (c *Cluster) generateMasterPodDisruptionBudget() *policyv1.PodDisruptionBud
 
 	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            c.masterPodDisruptionBudgetName(),
+			Name:            c.generalPodDisruptionBudgetName(),
 			Namespace:       c.Namespace,
 			Labels:          c.labelsSet(true),
 			Annotations:     c.annotationsSet(nil),

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -109,12 +109,12 @@ func (c *Cluster) servicePort(role PostgresRole) int32 {
 	return pgPort
 }
 
-func (c *Cluster) generalPodDisruptionBudgetName() string {
+func (c *Cluster) PrimaryPodDisruptionBudgetName() string {
 	return c.OpConfig.PDBNameFormat.Format("cluster", c.Name)
 }
 
 func (c *Cluster) criticalOpPodDisruptionBudgetName() string {
-	pdbTemplate := config.StringTemplate("postgres-{cluster}-critical-operation-pdb")
+	pdbTemplate := config.StringTemplate("postgres-{cluster}-critical-op-pdb")
 	return pdbTemplate.Format("cluster", c.Name)
 }
 
@@ -2212,7 +2212,7 @@ func (c *Cluster) generateStandbyEnvironment(description *acidv1.StandbyDescript
 	return result
 }
 
-func (c *Cluster) generateGeneralPodDisruptionBudget() *policyv1.PodDisruptionBudget {
+func (c *Cluster) generatePrimaryPodDisruptionBudget() *policyv1.PodDisruptionBudget {
 	minAvailable := intstr.FromInt(1)
 	pdbEnabled := c.OpConfig.EnablePodDisruptionBudget
 	pdbMasterLabelSelector := c.OpConfig.PDBMasterLabelSelector
@@ -2230,7 +2230,7 @@ func (c *Cluster) generateGeneralPodDisruptionBudget() *policyv1.PodDisruptionBu
 
 	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            c.generalPodDisruptionBudgetName(),
+			Name:            c.PrimaryPodDisruptionBudgetName(),
 			Namespace:       c.Namespace,
 			Labels:          c.labelsSet(true),
 			Annotations:     c.annotationsSet(nil),
@@ -2255,7 +2255,7 @@ func (c *Cluster) generateCriticalOpPodDisruptionBudget() *policyv1.PodDisruptio
 	}
 
 	labels := c.labelsSet(false)
-	labels["critical-operaton"] = "true"
+	labels["critical-operation"] = "true"
 
 	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2248,7 +2248,6 @@ func (c *Cluster) generateGeneralPodDisruptionBudget() *policyv1.PodDisruptionBu
 func (c *Cluster) generateCriticalOpPodDisruptionBudget() *policyv1.PodDisruptionBudget {
 	minAvailable := intstr.FromInt32(c.Spec.NumberOfInstances)
 	pdbEnabled := c.OpConfig.EnablePodDisruptionBudget
-	pdbMasterLabelSelector := c.OpConfig.PDBMasterLabelSelector
 
 	// if PodDisruptionBudget is disabled or if there are no DB pods, set the budget to 0.
 	if (pdbEnabled != nil && !(*pdbEnabled)) || c.Spec.NumberOfInstances <= 0 {
@@ -2256,9 +2255,7 @@ func (c *Cluster) generateCriticalOpPodDisruptionBudget() *policyv1.PodDisruptio
 	}
 
 	labels := c.labelsSet(false)
-	if pdbMasterLabelSelector == nil || *c.OpConfig.PDBMasterLabelSelector {
-		labels["critical-operaton"] = "true"
-	}
+	labels["critical-operaton"] = "true"
 
 	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -2349,7 +2349,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 		}
 	}
 
-	testLabelsAndSelectors := func(isGeneral bool) func(cluster *Cluster, podDisruptionBudget *policyv1.PodDisruptionBudget) error {
+	testLabelsAndSelectors := func(isPrimary bool) func(cluster *Cluster, podDisruptionBudget *policyv1.PodDisruptionBudget) error {
 		return func(cluster *Cluster, podDisruptionBudget *policyv1.PodDisruptionBudget) error {
 			masterLabelSelectorDisabled := cluster.OpConfig.PDBMasterLabelSelector != nil && !*cluster.OpConfig.PDBMasterLabelSelector
 			if podDisruptionBudget.ObjectMeta.Namespace != "myapp" {
@@ -2360,7 +2360,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 				return fmt.Errorf("Labels incorrect, got %#v, expected %#v", podDisruptionBudget.Labels, expectedLabels)
 			}
 			if !masterLabelSelectorDisabled {
-				if isGeneral {
+				if isPrimary {
 					expectedLabels := &metav1.LabelSelector{
 						MatchLabels: map[string]string{"spilo-role": "master", "cluster-name": "myapp-database"}}
 					if !reflect.DeepEqual(podDisruptionBudget.Spec.Selector, expectedLabels) {
@@ -2368,7 +2368,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 					}
 				} else {
 					expectedLabels := &metav1.LabelSelector{
-						MatchLabels: map[string]string{"cluster-name": "myapp-database", "critical-operaton": "true"}}
+						MatchLabels: map[string]string{"cluster-name": "myapp-database", "critical-operation": "true"}}
 					if !reflect.DeepEqual(podDisruptionBudget.Spec.Selector, expectedLabels) {
 						return fmt.Errorf("MatchLabels incorrect, got %#v, expected %#v", podDisruptionBudget.Spec.Selector, expectedLabels)
 					}
@@ -2503,7 +2503,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result := tt.spec.generateGeneralPodDisruptionBudget()
+		result := tt.spec.generatePrimaryPodDisruptionBudget()
 		for _, check := range tt.check {
 			err := check(tt.spec, result)
 			if err != nil {
@@ -2530,7 +2530,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 				eventRecorder),
 			check: []func(cluster *Cluster, podDisruptionBudget *policyv1.PodDisruptionBudget) error{
 				testPodDisruptionBudgetOwnerReference,
-				hasName("postgres-myapp-database-critical-operation-pdb"),
+				hasName("postgres-myapp-database-critical-op-pdb"),
 				hasMinAvailable(3),
 				testLabelsAndSelectors(false),
 			},
@@ -2547,7 +2547,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 				eventRecorder),
 			check: []func(cluster *Cluster, podDisruptionBudget *policyv1.PodDisruptionBudget) error{
 				testPodDisruptionBudgetOwnerReference,
-				hasName("postgres-myapp-database-critical-operation-pdb"),
+				hasName("postgres-myapp-database-critical-op-pdb"),
 				hasMinAvailable(0),
 				testLabelsAndSelectors(false),
 			},
@@ -2564,7 +2564,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 				eventRecorder),
 			check: []func(cluster *Cluster, podDisruptionBudget *policyv1.PodDisruptionBudget) error{
 				testPodDisruptionBudgetOwnerReference,
-				hasName("postgres-myapp-database-critical-operation-pdb"),
+				hasName("postgres-myapp-database-critical-op-pdb"),
 				hasMinAvailable(0),
 				testLabelsAndSelectors(false),
 			},
@@ -2581,7 +2581,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 				eventRecorder),
 			check: []func(cluster *Cluster, podDisruptionBudget *policyv1.PodDisruptionBudget) error{
 				testPodDisruptionBudgetOwnerReference,
-				hasName("postgres-myapp-database-critical-operation-pdb"),
+				hasName("postgres-myapp-database-critical-op-pdb"),
 				hasMinAvailable(3),
 				testLabelsAndSelectors(false),
 			},

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -2491,7 +2491,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result := tt.spec.generateMasterPodDisruptionBudget()
+		result := tt.spec.generateGeneralPodDisruptionBudget()
 		for _, check := range tt.check {
 			err := check(tt.spec, result)
 			if err != nil {

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -2491,7 +2491,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result := tt.spec.generatePodDisruptionBudget()
+		result := tt.spec.generateMasterPodDisruptionBudget()
 		for _, check := range tt.check {
 			err := check(tt.spec, result)
 			if err != nil {

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -425,7 +425,8 @@ func (c *Cluster) generateEndpointSubsets(role PostgresRole) []v1.EndpointSubset
 func (c *Cluster) createPrimaryPodDisruptionBudget() error {
 	c.logger.Debug("creating primary pod disruption budget")
 	if c.PrimaryPodDisruptionBudget != nil {
-		return fmt.Errorf("primary pod disruption budget already exists in the cluster")
+		c.logger.Warning("primary pod disruption budget already exists in the cluster")
+		return nil
 	}
 
 	podDisruptionBudgetSpec := c.generatePrimaryPodDisruptionBudget()
@@ -445,7 +446,8 @@ func (c *Cluster) createPrimaryPodDisruptionBudget() error {
 func (c *Cluster) createCriticalOpPodDisruptionBudget() error {
 	c.logger.Debug("creating pod disruption budget for critical operations")
 	if c.CriticalOpPodDisruptionBudget != nil {
-		return fmt.Errorf("pod disruption budget for critical operations already exists in the cluster")
+		c.logger.Warning("pod disruption budget for critical operations already exists in the cluster")
+		return nil
 	}
 
 	podDisruptionBudgetSpec := c.generateCriticalOpPodDisruptionBudget()

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -831,3 +831,8 @@ func (c *Cluster) GetStatefulSet() *appsv1.StatefulSet {
 func (c *Cluster) GetGeneralPodDisruptionBudget() *policyv1.PodDisruptionBudget {
 	return c.GeneralPodDisruptionBudget
 }
+
+// GetPodDisruptionBudget returns cluster's kubernetes PodDisruptionBudget for critical operations
+func (c *Cluster) GetCriticalOpPodDisruptionBudget() *policyv1.PodDisruptionBudget {
+	return c.CriticalOpPodDisruptionBudget
+}

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -117,8 +117,8 @@ func (c *Cluster) Sync(newSpec *acidv1.Postgresql) error {
 	}
 
 	c.logger.Debug("syncing pod disruption budgets")
-	if err = c.syncPodDisruptionBudget(false); err != nil {
-		err = fmt.Errorf("could not sync pod disruption budget: %v", err)
+	if err = c.syncPodDisruptionBudgets(false); err != nil {
+		err = fmt.Errorf("could not sync pod disruption budgets: %v", err)
 		return err
 	}
 
@@ -452,22 +452,22 @@ func (c *Cluster) syncEndpoint(role PostgresRole) error {
 	return nil
 }
 
-func (c *Cluster) syncPodDisruptionBudget(isUpdate bool) error {
+func (c *Cluster) syncMasterPodDisruptionBudget(isUpdate bool) error {
 	var (
 		pdb *policyv1.PodDisruptionBudget
 		err error
 	)
-	if pdb, err = c.KubeClient.PodDisruptionBudgets(c.Namespace).Get(context.TODO(), c.podDisruptionBudgetName(), metav1.GetOptions{}); err == nil {
-		c.PodDisruptionBudget = pdb
-		newPDB := c.generatePodDisruptionBudget()
+	if pdb, err = c.KubeClient.PodDisruptionBudgets(c.Namespace).Get(context.TODO(), c.masterPodDisruptionBudgetName(), metav1.GetOptions{}); err == nil {
+		c.MasterPodDisruptionBudget = pdb
+		newPDB := c.generateMasterPodDisruptionBudget()
 		match, reason := c.comparePodDisruptionBudget(pdb, newPDB)
 		if !match {
 			c.logPDBChanges(pdb, newPDB, isUpdate, reason)
-			if err = c.updatePodDisruptionBudget(newPDB); err != nil {
+			if err = c.updateMasterPodDisruptionBudget(newPDB); err != nil {
 				return err
 			}
 		} else {
-			c.PodDisruptionBudget = pdb
+			c.MasterPodDisruptionBudget = pdb
 		}
 		return nil
 
@@ -476,21 +476,34 @@ func (c *Cluster) syncPodDisruptionBudget(isUpdate bool) error {
 		return fmt.Errorf("could not get pod disruption budget: %v", err)
 	}
 	// no existing pod disruption budget, create new one
-	c.logger.Infof("could not find the cluster's pod disruption budget")
+	c.logger.Infof("could not find the master pod disruption budget")
 
-	if pdb, err = c.createPodDisruptionBudget(); err != nil {
+	if err = c.createMasterPodDisruptionBudget(); err != nil {
 		if !k8sutil.ResourceAlreadyExists(err) {
-			return fmt.Errorf("could not create pod disruption budget: %v", err)
+			return fmt.Errorf("could not create master pod disruption budget: %v", err)
 		}
 		c.logger.Infof("pod disruption budget %q already exists", util.NameFromMeta(pdb.ObjectMeta))
-		if pdb, err = c.KubeClient.PodDisruptionBudgets(c.Namespace).Get(context.TODO(), c.podDisruptionBudgetName(), metav1.GetOptions{}); err != nil {
+		if pdb, err = c.KubeClient.PodDisruptionBudgets(c.Namespace).Get(context.TODO(), c.masterPodDisruptionBudgetName(), metav1.GetOptions{}); err != nil {
 			return fmt.Errorf("could not fetch existing %q pod disruption budget", util.NameFromMeta(pdb.ObjectMeta))
 		}
 	}
 
 	c.logger.Infof("created missing pod disruption budget %q", util.NameFromMeta(pdb.ObjectMeta))
-	c.PodDisruptionBudget = pdb
+	c.MasterPodDisruptionBudget = pdb
 
+	return nil
+}
+
+func (c *Cluster) syncPodDisruptionBudgets(isUpdate bool) error {
+	errors := make([]string, 0)
+
+	if err := c.syncMasterPodDisruptionBudget(isUpdate); err != nil {
+		errors = append(errors, fmt.Sprintf("%v", err))
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("%v", strings.Join(errors, `', '`))
+	}
 	return nil
 }
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -488,9 +488,6 @@ func (c *Cluster) syncPrimaryPodDisruptionBudget(isUpdate bool) error {
 		}
 	}
 
-	c.logger.Infof("created missing pod disruption budget %q", util.NameFromMeta(pdb.ObjectMeta))
-	c.PrimaryPodDisruptionBudget = pdb
-
 	return nil
 }
 
@@ -529,9 +526,6 @@ func (c *Cluster) syncCriticalOpPodDisruptionBudget(isUpdate bool) error {
 			return fmt.Errorf("could not fetch existing %q pod disruption budget", util.NameFromMeta(pdb.ObjectMeta))
 		}
 	}
-
-	c.logger.Infof("created missing pod disruption budget %q", util.NameFromMeta(pdb.ObjectMeta))
-	c.CriticalOpPodDisruptionBudget = pdb
 
 	return nil
 }

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -66,7 +66,7 @@ type ClusterStatus struct {
 	MasterEndpoint                *v1.Endpoints
 	ReplicaEndpoint               *v1.Endpoints
 	StatefulSet                   *appsv1.StatefulSet
-	GeneralPodDisruptionBudget    *policyv1.PodDisruptionBudget
+	PrimaryPodDisruptionBudget    *policyv1.PodDisruptionBudget
 	CriticalOpPodDisruptionBudget *policyv1.PodDisruptionBudget
 
 	CurrentProcess Process

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -58,15 +58,15 @@ type WorkerStatus struct {
 
 // ClusterStatus describes status of the cluster
 type ClusterStatus struct {
-	Team                string
-	Cluster             string
-	Namespace           string
-	MasterService       *v1.Service
-	ReplicaService      *v1.Service
-	MasterEndpoint      *v1.Endpoints
-	ReplicaEndpoint     *v1.Endpoints
-	StatefulSet         *appsv1.StatefulSet
-	PodDisruptionBudget *policyv1.PodDisruptionBudget
+	Team                      string
+	Cluster                   string
+	Namespace                 string
+	MasterService             *v1.Service
+	ReplicaService            *v1.Service
+	MasterEndpoint            *v1.Endpoints
+	ReplicaEndpoint           *v1.Endpoints
+	StatefulSet               *appsv1.StatefulSet
+	MasterPodDisruptionBudget *policyv1.PodDisruptionBudget
 
 	CurrentProcess Process
 	Worker         uint32

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -58,15 +58,16 @@ type WorkerStatus struct {
 
 // ClusterStatus describes status of the cluster
 type ClusterStatus struct {
-	Team                       string
-	Cluster                    string
-	Namespace                  string
-	MasterService              *v1.Service
-	ReplicaService             *v1.Service
-	MasterEndpoint             *v1.Endpoints
-	ReplicaEndpoint            *v1.Endpoints
-	StatefulSet                *appsv1.StatefulSet
-	GeneralPodDisruptionBudget *policyv1.PodDisruptionBudget
+	Team                          string
+	Cluster                       string
+	Namespace                     string
+	MasterService                 *v1.Service
+	ReplicaService                *v1.Service
+	MasterEndpoint                *v1.Endpoints
+	ReplicaEndpoint               *v1.Endpoints
+	StatefulSet                   *appsv1.StatefulSet
+	GeneralPodDisruptionBudget    *policyv1.PodDisruptionBudget
+	CriticalOpPodDisruptionBudget *policyv1.PodDisruptionBudget
 
 	CurrentProcess Process
 	Worker         uint32

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -58,15 +58,15 @@ type WorkerStatus struct {
 
 // ClusterStatus describes status of the cluster
 type ClusterStatus struct {
-	Team                      string
-	Cluster                   string
-	Namespace                 string
-	MasterService             *v1.Service
-	ReplicaService            *v1.Service
-	MasterEndpoint            *v1.Endpoints
-	ReplicaEndpoint           *v1.Endpoints
-	StatefulSet               *appsv1.StatefulSet
-	MasterPodDisruptionBudget *policyv1.PodDisruptionBudget
+	Team                       string
+	Cluster                    string
+	Namespace                  string
+	MasterService              *v1.Service
+	ReplicaService             *v1.Service
+	MasterEndpoint             *v1.Endpoints
+	ReplicaEndpoint            *v1.Endpoints
+	StatefulSet                *appsv1.StatefulSet
+	GeneralPodDisruptionBudget *policyv1.PodDisruptionBudget
 
 	CurrentProcess Process
 	Worker         uint32

--- a/pkg/cluster/util_test.go
+++ b/pkg/cluster/util_test.go
@@ -329,7 +329,7 @@ func newInheritedAnnotationsCluster(client k8sutil.KubernetesClient) (*Cluster, 
 	if err != nil {
 		return nil, err
 	}
-	_, err = cluster.createPodDisruptionBudget()
+	err = cluster.createPodDisruptionBudgets()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Create the second PDB to cover Pods with a special "critical operation" label set.

This label is going to be assigned to all pg cluster's Pods by the Operator during a PG major version upgrade, by Patroni during a cluster/replica bootstrap. It can also be set manually or by any other automation tool.