### PR TITLE
fix creating secrets for rotation users

### DIFF
--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -1814,6 +1814,7 @@ class EndToEndTestCase(unittest.TestCase):
         enable_password_rotation = {
             "data": {
                 "enable_password_rotation": "true",
+                "inherited_annotations": "environment",
                 "password_rotation_interval": "30",
                 "password_rotation_user_retention": "30",  # should be set to 60 
             },
@@ -1864,7 +1865,7 @@ class EndToEndTestCase(unittest.TestCase):
         pg_annotation_patch = {
             "metadata": {
                 "annotations": {
-                    "deployment-time": "2020-04-01 12:00:00",
+                    "environment": "test",
                 }
             }
         }
@@ -1881,7 +1882,7 @@ class EndToEndTestCase(unittest.TestCase):
                         "Unexpected username in secret of test.db_user: expected {}, got {}".format("test.db_user", secret_username))
 
         # check if annotation for secret has been updated
-        self.assertTrue("deployment-time" in db_user_secret.metadata.annotations, "Added annotation was not propagated to secret")
+        self.assertTrue("environment" in db_user_secret.metadata.annotations, "Added annotation was not propagated to secret")
 
         # disable password rotation for all other users (foo_user)
         # and pick smaller intervals to see if the third fake rotation user is dropped 
@@ -2120,7 +2121,7 @@ class EndToEndTestCase(unittest.TestCase):
         patch_sset_propagate_annotations = {
             "data": {
                 "downscaler_annotations": "deployment-time,downscaler/*",
-                "inherited_annotations": "owned-by",
+                "inherited_annotations": "environment,owned-by",
             }
         }
         k8s.update_config(patch_sset_propagate_annotations)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1037,7 +1037,7 @@ func (c *Cluster) Update(oldSpec, newSpec *acidv1.Postgresql) error {
 		annotationsChanged, _ := c.compareAnnotations(oldSpec.Annotations, newSpec.Annotations, nil)
 
 		initUsers := !sameUsers || !sameRotatedUsers || needPoolerUser || needStreamUser
-		if initUsers {
+		if initUsers || annotationsChanged {
 			c.logger.Debug("initialize users")
 			if err := c.initUsers(); err != nil {
 				c.logger.Errorf("could not init users - skipping sync of secrets and databases: %v", err)
@@ -1045,8 +1045,7 @@ func (c *Cluster) Update(oldSpec, newSpec *acidv1.Postgresql) error {
 				updateFailed = true
 				return
 			}
-		}
-		if initUsers || annotationsChanged {
+
 			c.logger.Debug("syncing secrets")
 			//TODO: mind the secrets of the deleted/new users
 			if err := c.syncSecrets(); err != nil {

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1900,7 +1900,12 @@ func (c *Cluster) generateUserSecrets() map[string]*v1.Secret {
 }
 
 func (c *Cluster) generateSingleUserSecret(pgUser spec.PgUser) *v1.Secret {
-	//Skip users with no password i.e. human users (they'll be authenticated using pam)
+	// skip rotation users (not now to check if e2e test fails)
+	//if pgUser.Rotated {
+	//	return nil
+	//}
+
+	// skip users with no password i.e. human users (they'll be authenticated using pam)
 	if pgUser.Password == "" {
 		if pgUser.Origin != spec.RoleOriginTeamsAPI {
 			c.logger.Warningf("could not generate secret for a non-teamsAPI role %q: role has no password",
@@ -1909,7 +1914,7 @@ func (c *Cluster) generateSingleUserSecret(pgUser spec.PgUser) *v1.Secret {
 		return nil
 	}
 
-	//skip NOLOGIN users
+	// skip NOLOGIN users
 	for _, flag := range pgUser.Flags {
 		if flag == constants.RoleFlagNoLogin {
 			return nil

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1900,12 +1900,7 @@ func (c *Cluster) generateUserSecrets() map[string]*v1.Secret {
 }
 
 func (c *Cluster) generateSingleUserSecret(pgUser spec.PgUser) *v1.Secret {
-	// skip rotation users (not now to check if e2e test fails)
-	//if pgUser.Rotated {
-	//	return nil
-	//}
-
-	// skip users with no password i.e. human users (they'll be authenticated using pam)
+	//Skip users with no password i.e. human users (they'll be authenticated using pam)
 	if pgUser.Password == "" {
 		if pgUser.Origin != spec.RoleOriginTeamsAPI {
 			c.logger.Warningf("could not generate secret for a non-teamsAPI role %q: role has no password",
@@ -1914,7 +1909,7 @@ func (c *Cluster) generateSingleUserSecret(pgUser spec.PgUser) *v1.Secret {
 		return nil
 	}
 
-	// skip NOLOGIN users
+	//skip NOLOGIN users
 	for _, flag := range pgUser.Flags {
 		if flag == constants.RoleFlagNoLogin {
 			return nil


### PR DESCRIPTION
In #2657 a [bug](https://github.com/zalando/postgres-operator/commit/47efca33c9857b5ada5cade4051468170f8ff17a#diff-f4933755bd63c9e160a2068e8ccb4048e8df1b43f7f4544dcbc7ae2650a07478R975) was introduced which produces additional secrets for rotation users which are redundant to the original secret. Before syncing secrets we usually initialize the user list to get the desired state.

On UPDATE events we only needed to sync secrets in case the user setup changed. `initUsers` and `syncSecrets` were called in one if block. The behavior was changed to have to if blocks where secrets can be synced on annotations diff while skipping user initializing. Therefore, the current pgUser list is used which contains the rotation users instead of the original ones.

We better return to the previous behavior incl. the annotation diff check, even though we would probably always init users then because UPDATEs are usually tiggered from deployments changing the deployment-time annotation.

Another quick hack would be to not generate a secret for rotation users (when `Rotated` flag is true), but since rotation users replace their original counterparts in the pgUsers list, we would then not sync the corresponding secrets.

In a first step I extended the e2e test without changing any other code (quick hack only as a comment) to reproduce the bug.