### PR TITLE
do not remove publications of slot defined in manifest

### DIFF
--- a/pkg/cluster/util_test.go
+++ b/pkg/cluster/util_test.go
@@ -650,7 +650,7 @@ func Test_trimCronjobName(t *testing.T) {
 	}
 }
 
-func TestisInMaintenanceWindow(t *testing.T) {
+func TestIsInMaintenanceWindow(t *testing.T) {
 	now := time.Now()
 	futureTimeStart := now.Add(1 * time.Hour)
 	futureTimeStartFormatted := futureTimeStart.Format("15:04")


### PR DESCRIPTION
With #2684 we introduced proper stream removal incl. database objects such as slots and publications which helped in cases when 
a. users decided to abandon/pause the stream idea after a testing phase
b. the removal of the slot became necessary due to problems with WAL consumption and growing disk space.

Another case might be that users want to migrate to self-deploy the stream resource because it offers more flexibility compared to what our operator will ever offer. Of course, they could turn streams off and on again which would mean a loss of decoded events. If they do not want to lose any event data, they have to 

a. define the slot with the exact same name `fes_<dbname>_<appId>` in the manifest
b. add parameter `wal_level: logical` to `postgresql` section
c. create a fes_user replication user.

However, the current implementation only persist the slots, not the publication, making the migration impossible. The problem lies in the initialization of publications to sync. For every database we create an [empty struct](https://github.com/zalando/postgres-operator/blob/2a4be1cb397e70d641a40ab20a05537b0e90d42c/pkg/cluster/streams.go#L378) to allow for later removal. When the following spec.Streams loop is skipped `syncPublication` is later called with an empty `databaseSlotList` which will then [remove the publications](https://github.com/zalando/postgres-operator/blob/master/pkg/cluster/streams.go#L141).

This PR suggests to set the slotName in the databaseSlotList when it is specified in the manifest. I could do an additional check if the plugin is also pgoutput, but maybe that's not really necessary (nobody should switch to wal2json). In the syncPublication code I am simply using the current publication tables when the new table list is empty. One cannot define publications in the manifest.