### PR TITLE
2867: Configurable api group for postgres operator with default

### DIFF
--- a/pkg/apis/acid.zalan.do/register.go
+++ b/pkg/apis/acid.zalan.do/register.go
@@ -1,6 +1,18 @@
 package acidzalando
 
-const (
-	// GroupName is the group name for the operator CRDs
-	GroupName = "acid.zalan.do"
+import "os"
+
+var (
+    // GroupName is the group name for the operator CRDs
+    GroupName = getEnvWithDefault("POSTGRES_OPERATOR_API_GROUP", "ost.cloud.rakuten.com")
 )
+
+func getEnvWithDefault(key, defaultValue string) string {
+    if value := os.Getenv(key); value != "" {
+        return value
+    }
+    return defaultValue
+}
+
+
+

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -15,14 +15,17 @@ const (
 	PostgresCRDResourceKind   = "postgresql"
 	PostgresCRDResourcePlural = "postgresqls"
 	PostgresCRDResourceList   = PostgresCRDResourceKind + "List"
-	PostgresCRDResouceName    = PostgresCRDResourcePlural + "." + acidzalando.GroupName
 	PostgresCRDResourceShort  = "pg"
 
 	OperatorConfigCRDResouceKind    = "OperatorConfiguration"
 	OperatorConfigCRDResourcePlural = "operatorconfigurations"
 	OperatorConfigCRDResourceList   = OperatorConfigCRDResouceKind + "List"
-	OperatorConfigCRDResourceName   = OperatorConfigCRDResourcePlural + "." + acidzalando.GroupName
 	OperatorConfigCRDResourceShort  = "opconfig"
+)
+
+var (
+	PostgresCRDResouceName    = PostgresCRDResourcePlural + "." + acidzalando.GroupName
+	OperatorConfigCRDResourceName   = OperatorConfigCRDResourcePlural + "." + acidzalando.GroupName
 )
 
 // PostgresCRDResourceColumns definition of AdditionalPrinterColumns for postgresql CRD


### PR DESCRIPTION
In Kubernetes, there is tight coupling of API group, CRD and Custom Resources managed by operators. CRDs are cluster resource and unique per cluster. CRD operatorconfigurations.acid.zalan.do defines the operator configurations for postgres operator. CRD postgresqls.acid.zalan.do defines minimum and maximum supported postgresql versions.

This leads to issues in a multi-tenant k8s cluster, an example provided below.

In Namespace X, user X deploys web tier application which uses zalando postgres-operator with max version PG 15. In Namespace Y, user Y deploys web tier application which also uses zalando postgres-operator but needs PG 17 runs into an issue as CRD postgresqls.acid.zalan.do supports only PG 15. This happens because CRD is cluster scope and all namespace scoped applications should adhere to it.

With large k8s clusters, postgresql being a very popular database, zalando postgres operator being defacto way to manage databases, there is a need to keep this configurable so applications can manage the API group of CRDs.

Take API group for postgres operator as an env variable, assuming that the relevant CRDs with API groups are installed.