### PR TITLE
Make bind address of apiserver configurable

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -616,6 +616,9 @@ spec:
               logging_rest_api:
                 type: object
                 properties:
+                  api_address:
+                    type: string
+                    default: ""
                   api_port:
                     type: integer
                     default: 8080

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -309,6 +309,8 @@ configDebug:
 
 # parameters affecting logging and REST API listener
 configLoggingRestApi:
+  # REST API listener binds to this address
+  # api_address: ""
   # REST API listener listens to this port
   api_port: 8080
   # number of entries in the cluster history ring buffer

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -978,6 +978,9 @@ key.
 Parameters affecting logging and REST API listener. In the CRD-based
 configuration they are grouped under the `logging_rest_api` key.
 
+* **api_address**
+  REST API listener binds to this address. The default is empty.
+
 * **api_port**
   REST API listener listens to this port. The default is `8080`.
 

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -7,6 +7,7 @@ data:
   # additional_pod_capabilities: "SYS_NICE"
   # additional_secret_mount: "some-secret-name"
   # additional_secret_mount_path: "/some/dir"
+  # api_address: ""
   api_port: "8080"
   aws_region: eu-central-1
   cluster_domain: cluster.local

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -614,6 +614,9 @@ spec:
               logging_rest_api:
                 type: object
                 properties:
+                  api_address:
+                    type: string
+                    default: ""
                   api_port:
                     type: integer
                     default: 8080

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -205,6 +205,7 @@ configuration:
       log_statement: all
     # teams_api_url: ""
   logging_rest_api:
+    # api_address: ""
     api_port: 8080
     cluster_history_entries: 1000
     ring_log_lines: 100

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -1878,6 +1878,9 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 					"logging_rest_api": {
 						Type: "object",
 						Properties: map[string]apiextv1.JSONSchemaProps{
+							"api_address": {
+								Type: "string",
+							},
 							"api_port": {
 								Type: "integer",
 							},

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -191,9 +191,10 @@ type TeamsAPIConfiguration struct {
 
 // LoggingRESTAPIConfiguration defines Logging API conf
 type LoggingRESTAPIConfiguration struct {
-	APIPort               int `json:"api_port,omitempty"`
-	RingLogLines          int `json:"ring_log_lines,omitempty"`
-	ClusterHistoryEntries int `json:"cluster_history_entries,omitempty"`
+	APIAddress            string `json:"api_address,omitempty"`
+	APIPort               int    `json:"api_port,omitempty"`
+	RingLogLines          int    `json:"ring_log_lines,omitempty"`
+	ClusterHistoryEntries int    `json:"cluster_history_entries,omitempty"`
 }
 
 // ScalyrConfiguration defines the configuration for ScalyrAPI

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/pprof"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -72,7 +74,7 @@ var (
 )
 
 // New creates new HTTP API server
-func New(controller controllerInformer, port int, logger *logrus.Logger) *Server {
+func New(controller controllerInformer, address string, port int, logger *logrus.Logger) *Server {
 	s := &Server{
 		logger:     logger.WithField("pkg", "apiserver"),
 		controller: controller,
@@ -94,7 +96,7 @@ func New(controller controllerInformer, port int, logger *logrus.Logger) *Server
 	mux.HandleFunc("/databases/", s.databases)
 
 	s.http = http.Server{
-		Addr:        fmt.Sprintf(":%d", port),
+		Addr:        net.JoinHostPort(strings.Trim(address, "[]"), strconv.Itoa(port)),
 		Handler:     http.TimeoutHandler(mux, httpAPITimeout, ""),
 		ReadTimeout: httpReadTimeout,
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -366,7 +366,7 @@ func (c *Controller) initController() {
 		})
 	}
 
-	c.apiserver = apiserver.New(c, c.opConfig.APIPort, c.logger.Logger)
+	c.apiserver = apiserver.New(c, c.opConfig.APIAddress, c.opConfig.APIPort, c.logger.Logger)
 }
 
 func (c *Controller) initSharedInformers() {

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -222,6 +222,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.RoleDeletionSuffix = util.Coalesce(fromCRD.TeamsAPI.RoleDeletionSuffix, "_deleted")
 
 	// logging REST API config
+	result.APIAddress = util.Coalesce(fromCRD.LoggingRESTAPI.APIAddress, "")
 	result.APIPort = util.CoalesceInt(fromCRD.LoggingRESTAPI.APIPort, 8080)
 	result.RingLogLines = util.CoalesceInt(fromCRD.LoggingRESTAPI.RingLogLines, 100)
 	result.ClusterHistoryEntries = util.CoalesceInt(fromCRD.LoggingRESTAPI.ClusterHistoryEntries, 1000)

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -228,6 +228,7 @@ type Config struct {
 	EnableSidecars                           *bool             `name:"enable_sidecars" default:"true"`
 	SharePgSocketWithSidecars                *bool             `name:"share_pgsocket_with_sidecars" default:"false"`
 	Workers                                  uint32            `name:"workers" default:"8"`
+	APIAddress                               string            `name:"api_address" default:""`
 	APIPort                                  int               `name:"api_port" default:"8080"`
 	RingLogLines                             int               `name:"ring_log_lines" default:"100"`
 	ClusterHistoryEntries                    int               `name:"cluster_history_entries" default:"1000"`


### PR DESCRIPTION
This is a proposed solution for #2883.

I tried to keep the compatibility to the current behavior. The address is not a mandatory parameter in the configuration, so the original setting will provide the same result as currently, that the bind address will be "0.0.0.0"
If the address is configured then the API server will try to bind to that instead of 0.0.0.0.

If `api_address: "localhost"` configured:
```
time="2025-03-22T11:11:14Z" level=info msg="listening on localhost:8080" pkg=apiserver
```