### PR TITLE
Add support for extra objects

### DIFF
--- a/charts/postgres-operator/templates/extra-objects.yaml
+++ b/charts/postgres-operator/templates/extra-objects.yaml
@@ -1,0 +1,8 @@
+{{ range .Values.extraObjects }}
+---
+{{ if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
+{{ end }}

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -544,3 +544,17 @@ controllerID:
   # The name of the controller ID to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+
+# -- Array of extra K8s manifests to deploy
+## Note: Supports use of custom Helm templates
+extraObjects: []
+  # - apiVersion: acid.zalan.do/v1
+  #   kind: postgresql
+  #   metadata:
+  #     name: my-db-cluster
+  #     namespace: default
+  #   spec:
+  #     teamId: my-team
+  #     numberOfInstances: 3
+  #     preparedDatabases:
+  #       myfirstdb: {}


### PR DESCRIPTION
Often times you want to be able to deploy objects with the helm chart in one go and make the helm chart own said objects.

This PR addresses the current limitation of the helm template.

Project that use a similar paradigm:
- cert-manager
- argo
- traefik
- jaeger
- More that I don't know of