### PR TITLE
Allow chained references of custom environment variables to all generated envs

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -784,7 +784,7 @@ func patchSidecarContainers(in []v1.Container, volumeMounts []v1.VolumeMount, su
 				},
 			},
 		}
-		container.Env = appendEnvVars(env, container.Env...)
+		container.Env = appendIfNotPresent(env, container.Env...)
 		result = append(result, container)
 	}
 
@@ -1023,7 +1023,7 @@ func (c *Cluster) generateSpiloPodEnvVars(
 
 	// fetch cluster-specific variables that will override all subsequent global variables
 	if len(spec.Env) > 0 {
-		envVars = appendEnvVars(envVars, spec.Env...)
+		envVars = appendIfNotPresent(envVars, spec.Env...)
 	}
 
 	if spec.Clone != nil && spec.Clone.ClusterName != "" {
@@ -1040,7 +1040,7 @@ func (c *Cluster) generateSpiloPodEnvVars(
 	if err != nil {
 		return nil, err
 	}
-	envVars = appendEnvVars(envVars, secretEnvVarsList...)
+	envVars = appendIfNotPresent(envVars, secretEnvVarsList...)
 
 	// fetch variables from custom environment ConfigMap
 	// that will override all subsequent global variables
@@ -1048,7 +1048,7 @@ func (c *Cluster) generateSpiloPodEnvVars(
 	if err != nil {
 		return nil, err
 	}
-	envVars = appendEnvVars(envVars, configMapEnvVarsList...)
+	envVars = appendIfNotPresent(envVars, configMapEnvVarsList...)
 
 	// global variables derived from operator configuration
 	opConfigEnvVars := make([]v1.EnvVar, 0)
@@ -1080,12 +1080,12 @@ func (c *Cluster) generateSpiloPodEnvVars(
 		opConfigEnvVars = append(opConfigEnvVars, v1.EnvVar{Name: "LOG_BUCKET_SCOPE_PREFIX", Value: ""})
 	}
 
-	envVars = appendEnvVars(envVars, opConfigEnvVars...)
+	envVars = appendIfNotPresent(envVars, opConfigEnvVars...)
 
 	return envVars, nil
 }
 
-func appendEnvVars(envs []v1.EnvVar, appEnv ...v1.EnvVar) []v1.EnvVar {
+func appendIfNotPresent(envs []v1.EnvVar, appEnv ...v1.EnvVar) []v1.EnvVar {
 	collectedEnvs := envs
 	for _, env := range appEnv {
 		if !isEnvVarPresent(collectedEnvs, env.Name) {
@@ -1378,7 +1378,7 @@ func (c *Cluster) generateStatefulSet(spec *acidv1.PostgresSpec) (*appsv1.Statef
 		}
 		tlsEnv, tlsVolumes := generateTlsMounts(spec, getSpiloTLSEnv)
 		for _, env := range tlsEnv {
-			spiloEnvVars = appendEnvVars(spiloEnvVars, env)
+			spiloEnvVars = appendIfNotPresent(spiloEnvVars, env)
 		}
 		additionalVolumes = append(additionalVolumes, tlsVolumes...)
 	}
@@ -2490,7 +2490,7 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 
 	switch backupProvider {
 	case "s3":
-		envVars = appendEnvVars(envVars, []v1.EnvVar{
+		envVars = appendIfNotPresent(envVars, []v1.EnvVar{
 			{
 				Name:  "LOGICAL_BACKUP_S3_REGION",
 				Value: c.OpConfig.LogicalBackup.LogicalBackupS3Region,
@@ -2522,7 +2522,7 @@ func (c *Cluster) generateLogicalBackupPodEnvVars() []v1.EnvVar {
 		}
 
 	case "az":
-		envVars = appendEnvVars(envVars, []v1.EnvVar{
+		envVars = appendIfNotPresent(envVars, []v1.EnvVar{
 			{
 				Name:  "LOGICAL_BACKUP_AZURE_STORAGE_ACCOUNT_NAME",
 				Value: c.OpConfig.LogicalBackup.LogicalBackupAzureStorageAccountName,

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -623,7 +623,7 @@ func TestGenerateSpiloPodEnvVars(t *testing.T) {
 	}
 	expectedS3BucketConfigMap := []ExpectedValue{
 		{
-			envIndex:       17,
+			envIndex:       19,
 			envVarConstant: "wal_s3_bucket",
 			envVarValue:    "global-s3-bucket-configmap",
 		},
@@ -709,14 +709,14 @@ func TestGenerateSpiloPodEnvVars(t *testing.T) {
 			envVarValue:    fmt.Sprintf("/%s", dummyUUID),
 		},
 		{
-			envIndex:       21,
+			envIndex:       23,
 			envVarConstant: "clone_aws_endpoint",
 			envVarValue:    "s3.eu-west-1.amazonaws.com",
 		},
 	}
 	expectedCloneEnvSecret := []ExpectedValue{
 		{
-			envIndex:       21,
+			envIndex:       24,
 			envVarConstant: "clone_aws_access_key_id",
 			envVarValueRef: &v1.EnvVarSource{
 				SecretKeyRef: &v1.SecretKeySelector{
@@ -735,7 +735,7 @@ func TestGenerateSpiloPodEnvVars(t *testing.T) {
 			envVarValue:    "gs://some/path/",
 		},
 		{
-			envIndex:       20,
+			envIndex:       23,
 			envVarConstant: "standby_google_application_credentials",
 			envVarValueRef: &v1.EnvVarSource{
 				SecretKeyRef: &v1.SecretKeySelector{


### PR DESCRIPTION
Fixes #2227

Currently custom environment variables are added after _most_ generated envs but notably before `WAL_BUCKET_SCOPE_SUFFIX` and `_PREFIX`. This means that referencing one of these values from a custom env is impossible (k8s has an implied ordering of env vars). 

I have changed this to always have custom envs being at the end of the list while still respecting the overrideability of only certain envs. It is now possible to use WAL-E with Azure Storage Accounts while including the UID of the cluster in the backup path.

**tldr: Works now, didn't before**
```

apiVersion: v1
kind: ConfigMap
metadata:
  name: pod-env-overrides
  namespace: postgres-operator-system
data:
  WALG_AZ_PREFIX: "azure://container-name/$(SCOPE)$(WAL_BUCKET_SCOPE_SUFFIX)/$(PGVERSION)"
```