### PR TITLE
include external traffic policy comparison into service diffing

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -845,6 +845,10 @@ func (c *Cluster) compareServices(old, new *v1.Service) (bool, string) {
 		return false, "new service's selector does not match the current one"
 	}
 
+	if old.Spec.ExternalTrafficPolicy != new.Spec.ExternalTrafficPolicy {
+		return false, "new service's ExternalTrafficPolicy does not match the current one"
+	}
+
 	return true, ""
 }
 


### PR DESCRIPTION
When you are using external load balancers for many of your database clusters chances are you're running short on IPs at some point when using the default service external traffic policy `Cluster`. With `Cluster` the ELB can send traffic to any node and from there iptables forward rules decide on the "right" instance. With `Local` iptables forwards are not needed because the ELB only sees valid instances directly. We've been supporting configuring the external traffic policy for services for quite some time (#1136), but forgot to also diff on it.

The added unit tests also cover the recently added selector diff from #2955.