### PR TITLE
extend RBAC in prepatation to switch to configmap-based cluster management

### DIFF
--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -107,8 +107,13 @@ Those are top-level keys, containing both leaf keys and groups.
 * **kubernetes_use_configmaps**
   Select if setup uses endpoints (default), or configmaps to manage leader when
   DCS is kubernetes (not etcd or similar). In OpenShift it is not possible to
-  use endpoints option, and configmaps is required. By default,
-  `kubernetes_use_configmaps: false`, meaning endpoints will be used.
+  use endpoints option, and configmaps is required. Starting with K8s 1.33,
+  endpoints are marked as deprecated. It's recommended to switch to config maps
+  instead. But, to do so make sure you scale the Postgres cluster down to just
+  one primary pod (e.g. using `max_instances` option). Otherwise, you risk
+  running into a split-brain scenario.
+  By default, `kubernetes_use_configmaps: false`, meaning endpoints will be used.
+  Starting from v1.16.0 the default will be changed to `true`.
 
 * **docker_image**
   Spilo Docker image for Postgres instances. For production, don't rely on the

--- a/manifests/operator-service-account-rbac.yaml
+++ b/manifests/operator-service-account-rbac.yaml
@@ -59,13 +59,20 @@ rules:
   - get
   - patch
   - update
-# to read configuration from ConfigMaps
+# to read configuration from ConfigMaps and help Patroni manage the cluster if endpoints are not used
 - apiGroups:
   - ""
   resources:
   - configmaps
   verbs:
+  - create
+  - delete
+  - deletecollection
   - get
+  - list
+  - patch
+  - update
+  - watch
 # to send events to the CRs
 - apiGroups:
   - ""
@@ -78,7 +85,7 @@ rules:
   - patch
   - update
   - watch
-# to manage endpoints which are also used by Patroni
+# to manage endpoints which are also used by Patroni (if it is using config maps)
 - apiGroups:
   - ""
   resources:
@@ -249,7 +256,21 @@ kind: ClusterRole
 metadata:
   name: postgres-pod
 rules:
-# Patroni needs to watch and manage endpoints
+# Patroni needs to watch and manage config maps (or endpoints)
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+# Patroni needs to watch and manage endpoints (or config maps)
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
In #2946 it was correctly pointed out that endpoint are marked for deprecation in K8s 1.33. However, it's successor EndpointSlices is not regarded an option for Patroni to manage the database clusters. Our only choice atm is to switch to configmap-based cluster management.

One has to follow these three steps:
1. Scale all clusters to 1 pod
2. Change `kubernetes_use_configmaps: true` in the config
3. Revert 1 and ideally remove endpoints manually.

The PR is only a preparation for future releases. For 1.15. we'd better not change the default behavior. But for 1.16 we should.