### PR TITLE
Register Capitalized Kind name for PostgresqlList

### DIFF
--- a/pkg/apis/acid.zalan.do/v1/register.go
+++ b/pkg/apis/acid.zalan.do/v1/register.go
@@ -43,6 +43,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	// TODO: User uppercase CRDResourceKind of our types in the next major API version
 	scheme.AddKnownTypeWithName(SchemeGroupVersion.WithKind("postgresql"), &Postgresql{})
 	scheme.AddKnownTypeWithName(SchemeGroupVersion.WithKind("postgresqlList"), &PostgresqlList{})
+	scheme.AddKnownTypeWithName(SchemeGroupVersion.WithKind("PostgresqlList"), &PostgresqlList{})
 	scheme.AddKnownTypeWithName(SchemeGroupVersion.WithKind("PostgresTeam"), &PostgresTeam{})
 	scheme.AddKnownTypeWithName(SchemeGroupVersion.WithKind("PostgresTeamList"), &PostgresTeamList{})
 	scheme.AddKnownTypeWithName(SchemeGroupVersion.WithKind("OperatorConfiguration"),


### PR DESCRIPTION
Register capitalized version of the `postgresqlList` Kind.

This is needed because Kubernetes makes assumptions about the capitalization of kind names and when I tried to use a fake informer in a test case I got the following errors:

```
Failed to watch" err="failed to list *v1.Postgresql: no kind \"PostgresqlList\" is registered for version \"acid.zalan.do/v1\" in scheme \"pkg/runtime/scheme.go:110\"" logger="UnhandledError"
``` 