### PR TITLE
only trigger ghcr build on tag event

### DIFF
--- a/.github/workflows/publish_ghcr_image.yaml
+++ b/.github/workflows/publish_ghcr_image.yaml
@@ -7,8 +7,6 @@ env:
 
 on:
   push:
-    branches:
-    - master
     tags:
       - '*'
 


### PR DESCRIPTION
in #2991 I've updated the ghcr build pipeline to also get triggered on merge to master, but the pipeline itself is expecting to read tags (`...${{ env.IMAGE_NAME }}:${GITHUB_REF/refs\/tags\//}`).

Otherwise it fails with: `Error: buildx failed with: ERROR: failed to build: invalid tag "[ghcr.io/zalando/postgres-operator:refs/heads/master](http://ghcr.io/zalando/postgres-operator:refs/heads/master)": invalid reference format`

I revert my change and hope the pipeline works after the next tag.