### PR TITLE
Do not promote operator image when merge to master

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -39,10 +39,6 @@ pipeline:
                     -f docker/Dockerfile \
                     --push .
 
-          if [ -z ${CDP_SOURCE_BRANCH} ]; then
-            cdp-promote-image ${IMAGE}:${CDP_BUILD_VERSION}
-          fi
-
   - id: build-operator-ui
     env:
       <<: *BUILD_ENV


### PR DESCRIPTION
Current internal build will always promote operator image when merge to master. But this image won't be used until we successfully test it. So image promotion should only happen when smoke test is running successfully.