### PR TITLE
Update spilo image for e2e test

### DIFF
--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -12,7 +12,7 @@ from kubernetes import client
 from tests.k8s_api import K8s
 from kubernetes.client.rest import ApiException
 
-SPILO_CURRENT = "ghcr.io/zalando/spilo-17:4.0-p3"
+SPILO_CURRENT = "ghcr.io/zalando/spilo-18-dev:6a722f01"
 SPILO_LAZY = "ghcr.io/zalando/spilo-17:4.0-p2"
 SPILO_FULL_IMAGE = "ghcr.io/zalando/spilo-17:4.0-p3"
 


### PR DESCRIPTION
[DO NOT MERGE]

Current e2e test still use the outdated spilo image, which might be the reason why e2e keep failing when we change to spilo-18 image as there is change on AWS_EC2_METADATA