### PR TITLE
do not reset secrets of standby clusters

### DIFF
--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -1211,6 +1211,8 @@ class EndToEndTestCase(unittest.TestCase):
 
         k8s.create_with_kubectl("manifests/minimal-postgres-lowest-version-manifest.yaml")
         self.eventuallyEqual(lambda: k8s.count_running_pods(labels=cluster_label), 2, "No 2 pods running")
+        time.sleep(30)
+        print('Operator log: {}'.format(k8s.get_operator_log()))
         self.eventuallyEqual(lambda: k8s.get_operator_state(), {"0": "idle"}, "Operator does not get in sync")
         self.eventuallyEqual(check_version, 14, "Version is not correct")
 

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -1211,8 +1211,6 @@ class EndToEndTestCase(unittest.TestCase):
 
         k8s.create_with_kubectl("manifests/minimal-postgres-lowest-version-manifest.yaml")
         self.eventuallyEqual(lambda: k8s.count_running_pods(labels=cluster_label), 2, "No 2 pods running")
-        time.sleep(30)
-        print('Operator log: {}'.format(k8s.get_operator_log()))
         self.eventuallyEqual(lambda: k8s.get_operator_state(), {"0": "idle"}, "Operator does not get in sync")
         self.eventuallyEqual(check_version, 14, "Version is not correct")
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -385,7 +385,7 @@ func (c *Cluster) Create() (err error) {
 
 	// create database objects unless we are running without pods or disabled
 	// that feature explicitly
-	if !(c.databaseAccessDisabled() || c.getNumberOfInstances(&c.Spec) <= 0 || c.Spec.StandbyCluster != nil) {
+	if !(c.databaseAccessDisabled() || c.getNumberOfInstances(&c.Spec) <= 0 || isStandbyCluster(&c.Spec)) {
 		c.logger.Infof("Create roles")
 		if err = c.createRoles(); err != nil {
 			return fmt.Errorf("could not create users: %v", err)

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1691,7 +1691,7 @@ func (c *Cluster) getNumberOfInstances(spec *acidv1.PostgresSpec) int32 {
 		}
 	}
 
-	if spec.StandbyCluster != nil {
+	if isStandbyCluster(spec) {
 		if newcur == 1 {
 			min = newcur
 			max = newcur

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -1050,6 +1050,6 @@ func TestUpdateSecretNameConflict(t *testing.T) {
 	assert.Error(t, err)
 
 	// the order of secrets to sync is not deterministic, check only first part of the error message
-	expectedError := fmt.Sprintf("syncing secret %s failed: could not update secret because of user name mismatch", "default/prepared-owner-user.acid-test-cluster.credentials")
+	expectedError := fmt.Sprintf("syncing secret %s failed: error while checking for password rotation: could not update secret because of user name mismatch", "default/prepared-owner-user.acid-test-cluster.credentials")
 	assert.Contains(t, err.Error(), expectedError)
 }

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -665,7 +666,8 @@ func parseResourceRequirements(resourcesRequirement v1.ResourceRequirements) (ac
 
 func isStandbyCluster(spec *acidv1.PostgresSpec) bool {
 	for _, env := range spec.Env {
-		if env.Name == "STANDBY_WALE_S3_PREFIX" && env.Value != "" {
+		hasStandbyEnv, _ := regexp.MatchString(`^STANDBY_WALE_(S3|GS|GSC|SWIFT)_PREFIX$`, env.Name)
+		if hasStandbyEnv && env.Value != "" {
 			return true
 		}
 	}

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -663,6 +663,15 @@ func parseResourceRequirements(resourcesRequirement v1.ResourceRequirements) (ac
 	return resources, nil
 }
 
+func isStandbyCluster(spec *acidv1.PostgresSpec) bool {
+	for _, env := range spec.Env {
+		if env.Name == "STANDBY_WALE_S3_PREFIX" && env.Value != "" {
+			return true
+		}
+	}
+	return spec.StandbyCluster != nil
+}
+
 func (c *Cluster) isInMaintenanceWindow(specMaintenanceWindows []acidv1.MaintenanceWindow) bool {
 	if len(specMaintenanceWindows) == 0 && len(c.OpConfig.MaintenanceWindows) == 0 {
 		return true


### PR DESCRIPTION
This PR changes two things:

Standby clusters are not only determined by the existence of the `standby` manifest section, but also searching for the `STANDBY_WALE_S3_PREFIX` env var.

The second change deals with password rotation. The current implementation resets secrets if rotation is not allowed. But, when using standby clusters we typically copy the secrets first, before creating the standby via the operator. We require credentials to remain stable. After all, it's a read only cluster, and the operator could not alter password in the database anyway after resetting the username and password in the secret.

I did some refactoring and moved all password rotation bits into a new function so I can easily bypass it when dealing with a standby cluster.