### PR TITLE
try to set infra roles also if one fails

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -347,9 +347,11 @@ func (c *Controller) initController() {
 	logMultiLineConfig(c.logger, c.opConfig.MustMarshal())
 
 	roleDefs := c.getInfrastructureRoleDefinitions()
-	if infraRoles, err := c.getInfrastructureRoles(roleDefs); err != nil {
-		c.logger.Warningf("could not get infrastructure roles: %v", err)
-	} else {
+	infraRoles, err := c.getInfrastructureRoles(roleDefs)
+	if err != nil {
+		c.logger.Warningf("could not get all infrastructure roles: %v", err)
+	}
+	if len(infraRoles) > 0 {
 		c.config.InfrastructureRoles = infraRoles
 	}
 


### PR DESCRIPTION
atm one could use the old and new way to define two infrastructure roles. However if fetching one fails, no roles will be set. This PR will add an extra check to set infraRoles when at least one was found