### PR TITLE
fix: invalid switchover scheduling with default maintenance windows

### DIFF
--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -14,6 +14,13 @@ readonly e2e_test_runner_image="ghcr.io/zalando/postgres-operator-e2e-tests-runn
 export GOPATH=${GOPATH-~/go}
 export PATH=${GOPATH}/bin:$PATH
 
+# detect system architecture for pulling the correct Spilo image
+case "$(uname -m)" in
+    x86_64)  readonly PLATFORM="linux/amd64" ;;
+    aarch64|arm64) readonly PLATFORM="linux/arm64" ;;
+    *) echo "Unsupported architecture: $(uname -m)"; exit 1 ;;
+esac
+
 echo "Clustername: ${cluster_name}"
 echo "Kubeconfig path: ${kubeconfig_path}"
 
@@ -43,9 +50,8 @@ function start_kind(){
   export KUBECONFIG="${kubeconfig_path}"
   kind create cluster --name ${cluster_name} --config kind-cluster-postgres-operator-e2e-tests.yaml  
   
-  # Pull all platforms to satisfy Kind's --all-platforms requirement
-  docker pull --platform linux/amd64 "${spilo_image}"
-  docker pull --platform linux/arm64 "${spilo_image}"
+  echo "Pulling Spilo image for platform ${PLATFORM}"
+  docker pull --platform ${PLATFORM} "${spilo_image}"
   kind load docker-image "${spilo_image}" --name ${cluster_name}
 }
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1784,7 +1784,20 @@ func (c *Cluster) GetSwitchoverSchedule() string {
 func (c *Cluster) getSwitchoverScheduleAtTime(now time.Time) string {
 	var possibleSwitchover, schedule time.Time
 
-	for _, window := range c.Spec.MaintenanceWindows {
+	maintenanceWindows := c.Spec.MaintenanceWindows
+	if len(maintenanceWindows) == 0 {
+		maintenanceWindows = make([]acidv1.MaintenanceWindow, 0, len(c.OpConfig.MaintenanceWindows))
+		for _, windowStr := range c.OpConfig.MaintenanceWindows {
+			var window acidv1.MaintenanceWindow
+			if err := window.UnmarshalJSON([]byte(windowStr)); err != nil {
+				c.logger.Errorf("could not parse default maintenance window %q: %v", windowStr, err)
+				continue
+			}
+			maintenanceWindows = append(maintenanceWindows, window)
+		}
+	}
+
+	for _, window := range maintenanceWindows {
 		// in the best case it is possible today
 		possibleSwitchover = time.Date(now.Year(), now.Month(), now.Day(), window.StartTime.Hour(), window.StartTime.Minute(), 0, 0, time.UTC)
 		if window.Everyday {
@@ -1806,6 +1819,11 @@ func (c *Cluster) getSwitchoverScheduleAtTime(now time.Time) string {
 			schedule = possibleSwitchover
 		}
 	}
+
+	if schedule.IsZero() {
+		return ""
+	}
+
 	return schedule.Format("2006-01-02T15:04+00")
 }
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -2125,10 +2125,13 @@ func TestGetSwitchoverSchedule(t *testing.T) {
 	pastWindowTimeStart := pastTimeStart.Format("15:04")
 	pastWindowTimeEnd := now.Add(-1 * time.Hour).Format("15:04")
 
+	defaultWindowStr := fmt.Sprintf("%s-%s", futureWindowTimeStart, futureWindowTimeEnd)
+
 	tests := []struct {
-		name     string
-		windows  []acidv1.MaintenanceWindow
-		expected string
+		name           string
+		windows        []acidv1.MaintenanceWindow
+		defaultWindows []string
+		expected       string
 	}{
 		{
 			name: "everyday maintenance windows is later today",
@@ -2190,11 +2193,40 @@ func TestGetSwitchoverSchedule(t *testing.T) {
 			},
 			expected: pastTimeStart.AddDate(0, 0, 1).Format("2006-01-02T15:04+00"),
 		},
+		{
+			name:           "fallback to operator default window when spec is empty",
+			windows:        []acidv1.MaintenanceWindow{},
+			defaultWindows: []string{defaultWindowStr},
+			expected:       futureTimeStart.Format("2006-01-02T15:04+00"),
+		},
+		{
+			name:           "no windows defined returns empty string",
+			windows:        []acidv1.MaintenanceWindow{},
+			defaultWindows: nil,
+			expected:       "",
+		},
+		{
+			name: "choose the earliest window from multiple in spec",
+			windows: []acidv1.MaintenanceWindow{
+				{
+					Weekday:   now.AddDate(0, 0, 2).Weekday(),
+					StartTime: mustParseTime(futureWindowTimeStart),
+					EndTime:   mustParseTime(futureWindowTimeEnd),
+				},
+				{
+					Weekday:   now.AddDate(0, 0, 1).Weekday(),
+					StartTime: mustParseTime(pastWindowTimeStart),
+					EndTime:   mustParseTime(pastWindowTimeEnd),
+				},
+			},
+			expected: pastTimeStart.AddDate(0, 0, 1).Format("2006-01-02T15:04+00"),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cluster.Spec.MaintenanceWindows = tt.windows
+			cluster.OpConfig.MaintenanceWindows = tt.defaultWindows
 			schedule := cluster.getSwitchoverScheduleAtTime(now)
 			if schedule != tt.expected {
 				t.Errorf("Expected GetSwitchoverSchedule to return %s, returned: %s", tt.expected, schedule)


### PR DESCRIPTION
Fixes an issue where the operator schedules a switchover with an invalid (zero) timestamp when default maintenance window is applied, causing Patroni to reject the request. 

Ensures a valid scheduled_at value is always set, allowing switchovers to proceed correctly during node decommissioning.

Additional fix: major upgrade e2e test was failing because of wrong architecture being loaded to kind. 