### PR TITLE
#3062 fix invalid JSON in default UI deployment

### DIFF
--- a/ui/manifests/deployment.yaml
+++ b/ui/manifests/deployment.yaml
@@ -77,7 +77,7 @@ spec:
                     "17",
                     "16",
                     "15",
-                    "14",
+                    "14"
                   ]
                 }
             # Exemple of settings to make snapshot view working in the ui when using AWS


### PR DESCRIPTION
This PR fixes the invalid JSON of the default UI deployment manifest, which was causing the pod to enter a crash loop when the settings were otherwise unchanged.

Fixes #3062 