### PR TITLE
Avoid rotating pods for PGVERSION change outside of maintenance window

### DIFF
--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -65,7 +65,10 @@ the `PGVERSION` environment variable is set for the database pods. Since
 In-place major version upgrades can be configured to be executed by the
 operator with the `major_version_upgrade_mode` option. By default, it is
 enabled (mode: `manual`). In any case, altering the version in the manifest
-will trigger a rolling update of pods to update the `PGVERSION` env variable.
+will update the desired `PGVERSION`. If `maintenanceWindows` are configured,
+major-version-related pod rotation is deferred until the next maintenance
+window. Without maintenance windows, the operator will trigger a rolling
+update of pods to apply the new `PGVERSION`.
 Spilo's [`configure_spilo`](https://github.com/zalando/spilo/blob/master/postgres-appliance/scripts/configure_spilo.py)
 script will notice the version mismatch but start the current version again.
 
@@ -93,8 +96,9 @@ Thus, the `full` mode can create drift between desired and actual state.
 ### Upgrade during maintenance windows
 
 When `maintenanceWindows` are defined in the Postgres manifest the operator
-will trigger a major version upgrade only during these periods. Make sure they
-are at least twice as long as your configured `resync_period` to guarantee
+will trigger major-version-related pod rotation and the major version upgrade
+only during these periods. Make sure they are at least twice as long as your
+configured `resync_period` to guarantee
 that operator actions can be triggered.
 
 ### Upgrade annotations

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -41,6 +41,12 @@ func (c *Cluster) Sync(newSpec *acidv1.Postgresql) error {
 	defer c.mu.Unlock()
 
 	oldSpec := c.Postgresql
+
+	if !c.isInMaintenanceWindow(newSpec.Spec.MaintenanceWindows) {
+		// do not apply any major version related changes yet
+		newSpec.Spec.PostgresqlParam.PgVersion = oldSpec.Spec.PostgresqlParam.PgVersion
+	}
+
 	c.setSpec(newSpec)
 
 	defer func() {
@@ -95,11 +101,6 @@ func (c *Cluster) Sync(newSpec *acidv1.Postgresql) error {
 		if nil != err {
 			return err
 		}
-	}
-
-	if !c.isInMaintenanceWindow(newSpec.Spec.MaintenanceWindows) {
-		// do not apply any major version related changes yet
-		newSpec.Spec.PostgresqlParam.PgVersion = oldSpec.Spec.PostgresqlParam.PgVersion
 	}
 
 	if err = c.syncStatefulSet(); err != nil {


### PR DESCRIPTION
Do reset of `PGVERSION` during Sync() before the setSpec() call, like in Update() to avoid disruptions caused by `PGVERSION` environment variable mismatch outside of the maintenance windows