### PR TITLE
fix(logical-backup): wait for PG connectivity before running backup

### DIFF
--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -897,6 +897,19 @@ grouped under the `logical_backup` key.
 * **logical_backup_cronjob_environment_secret**
   Reference to a Kubernetes secret, which keys will be added as environment variables to the cronjob. Default: ""
 
+The following environment variables can be passed to the logical backup
+cronjob via `logical_backup_cronjob_environment_secret` to control
+connectivity checks before the backup starts:
+
+* **LOGICAL_BACKUP_CONNECT_RETRIES**
+  Number of times to retry connecting to the target PostgreSQL pod before
+  giving up. This is useful when NetworkPolicy enforcement introduces a
+  short delay before a newly-created pod's IP is allowed through ingress
+  rules on the destination node. Default: "10"
+
+* **LOGICAL_BACKUP_CONNECT_RETRY_DELAY**
+  Delay in seconds between connectivity retries. Default: "2"
+
 ## Debugging the operator
 
 Options to aid debugging of the operator itself. Grouped under the `debug` key.

--- a/logical-backup/dump.sh
+++ b/logical-backup/dump.sh
@@ -183,6 +183,25 @@ function get_master_pod {
     get_pods "labelSelector=${CLUSTER_NAME_LABEL}%3D${SCOPE},spilo-role%3Dmaster" | tee | head -n 1
 }
 
+# Wait for TCP connectivity to the target PostgreSQL pod.
+# When NetworkPolicy is enforced via iptables, a newly-created pod's IP may not
+# yet be present in the destination node's ingress allow lists, causing
+# cross-node connections to be rejected until the next policy sync.
+function wait_for_pg {
+    local retries=${LOGICAL_BACKUP_CONNECT_RETRIES:-10}
+    local delay=${LOGICAL_BACKUP_CONNECT_RETRY_DELAY:-2}
+    local i
+    for (( i=1; i<=retries; i++ )); do
+        if "$PG_BIN"/pg_isready -h "$PGHOST" -p "${PGPORT:-5432}" -q 2>/dev/null; then
+            return 0
+        fi
+        echo "waiting for $PGHOST:${PGPORT:-5432} to become reachable (attempt $i/$retries)..."
+        sleep "$delay"
+    done
+    echo "ERROR: $PGHOST:${PGPORT:-5432} not reachable after $((retries * delay))s"
+    return 1
+}
+
 CURRENT_NODENAME=$(get_current_pod | jq .items[].spec.nodeName --raw-output)
 export CURRENT_NODENAME
 
@@ -196,6 +215,8 @@ for search in "${search_strategy[@]}"; do
     fi
 
 done
+
+wait_for_pg
 
 set -x
 if [ "$LOGICAL_BACKUP_PROVIDER" == "az" ]; then


### PR DESCRIPTION
## Problem description

The logical-backup script (`dump.sh`) connects to the target PostgreSQL pod immediately after resolving its IP via the Kubernetes API. When NetworkPolicy is enforced via iptables, a newly-created pod's IP may not yet be present in the destination node's ingress allow lists, causing cross-node connections to be rejected until the next policy sync.

This manifests as intermittent `Connection refused` errors even though the target PostgreSQL pod is healthy and listening:

```
psql: error: connection to server at "x.x.x.x", port 5432 failed: Connection refused
    Is the server running on that host and accepting TCP/IP connections?
```

The rejection happens at the network layer on the destination node, not at PostgreSQL. The race window is typically under 1 second but is enough to cause consistent failures because `dump.sh` connects with zero delay after pod startup.

This PR adds a `pg_isready` retry loop before the dump starts. It returns as soon as the connection succeeds, adding near-zero overhead when connectivity is immediate. Retry count and delay are configurable via `LOGICAL_BACKUP_CONNECT_RETRIES` (default: 10) and `LOGICAL_BACKUP_CONNECT_RETRY_DELAY` (default: 2s), compatible with `logical_backup_cronjob_environment_secret`.

## Linked issues

- cloudnativelabs/kube-router#1372 - kube-router's `iptables-restore` without `--noflush` causes full chain rebuilds on every pod event, creating a race window where new pod IPs are not yet in the destination node's ingress ipsets. Milestoned for kube-router v2.2.0 but any iptables-based CNI that does full restores on pod events can trigger the same issue.

## Checklist

- [x] Your go code is [formatted](https://blog.golang.org/gofmt). Your IDE should do it automatically for you.
  - N/A: shell script change only
- [x] You have updated [generated code](https://github.com/zalando/postgres-operator/blob/master/docs/developer.md#code-generation) when introducing new fields to the `acid.zalan.do` api package.
  - N/A: no API changes
- [x] New [configuration options](https://github.com/zalando/postgres-operator/blob/master/docs/developer.md#introduce-additional-configuration-parameters) are reflected in CRD validation, helm charts and sample manifests.
  - N/A: env vars are optional with defaults, passed through existing `logical_backup_cronjob_environment_secret`
- [x] New functionality is covered by [unit](https://github.com/zalando/postgres-operator/blob/master/docs/developer.md#unit-tests) and/or [e2e](https://github.com/zalando/postgres-operator/blob/master/docs/developer.md#end-to-end-tests) tests.
  - Tested locally with Docker PostgreSQL: immediate return when PG reachable, correct failure after retries, correct retry on delayed PG start, correct handling of custom env vars
- [x] You have checked existing open PRs for possible overlay and referenced them.
  - No overlapping PRs found