### PR TITLE
Fix JSON value of OPERATOR_UI_CONFIG

### DIFF
--- a/ui/manifests/deployment.yaml
+++ b/ui/manifests/deployment.yaml
@@ -77,7 +77,7 @@ spec:
                     "17",
                     "16",
                     "15",
-                    "14",
+                    "14"
                   ]
                 }
             # Exemple of settings to make snapshot view working in the ui when using AWS


### PR DESCRIPTION
Remove excess comma from OPERATOR_UI_CONFIG.
This produces an error from python failing to parse the JSON when starting up the container