### PR TITLE
make pooler labels configurable and change defaults

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -670,6 +670,12 @@ spec:
                   connection_pooler_image:
                     type: string
                     default: "registry.opensource.zalan.do/acid/pgbouncer:master-32"
+                  connection_pooler_labels:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    default:
+                      component: db-connection-pooler
                   connection_pooler_max_db_connections:
                     type: integer
                     default: 60
@@ -683,6 +689,9 @@ spec:
                     type: integer
                     minimum: 1
                     default: 2
+                  connection_pooler_role_label:
+                    type: string
+                    default: "pooler-role"
                   connection_pooler_default_cpu_limit:
                     type: string
                     pattern: '^(\d+m|\d+(\.\d{1,3})?)$'

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -442,12 +442,17 @@ configConnectionPooler:
   connection_pooler_user: "pooler"
   # docker image
   connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-32"
+  # labels to add to the connection pooler deployment and pods
+  connection_pooler_labels:
+    component: db-connection-pooler
   # max db connections the pooler should hold
   connection_pooler_max_db_connections: 60
   # default pooling mode
   connection_pooler_mode: "transaction"
   # number of pooler instances
   connection_pooler_number_of_instances: 2
+  # role label to add to the connection pooler resources to filter them easier
+  connection_pooler_role_label: pooler-role
   # default resources
   connection_pooler_default_cpu_request: 500m
   connection_pooler_default_memory_request: 100Mi

--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -452,8 +452,8 @@ configuration they are grouped under the `kubernetes` key.
   pooler deployment. The default is empty.
 
 * **pod_role_label**
-  name of the label assigned to the Postgres pods (and services/endpoints) by
-  the operator. The default is `spilo-role`.
+  name of the label assigned to most cluster resources to distinguish objects
+  with relation to the primary instance from the replica(s). The default is `spilo-role`.
 
 * **cluster_labels**
   list of `name:value` pairs for additional labels assigned to the cluster
@@ -1068,6 +1068,14 @@ operator being able to provide some reasonable defaults.
 
 * **connection_pooler_mode**
   Default pooler mode, `session` or `transaction`. Default is `transaction`.
+
+* **connection_pooler_labels**
+  List of `name:value` pairs for additional labels assigned to the pooler
+  objects. The default is `component:db-connection-pooler`.
+
+* **connection_pooler_role_label**
+  name of the label assigned to most pooler resources to distinguish objects
+  with relation to the primary instance from the replica(s). The default is `pooler-role`.
 
 * **connection_pooler_default_cpu_request**
   **connection_pooler_default_memory_reques**

--- a/e2e/scripts/cleanup.sh
+++ b/e2e/scripts/cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 kubectl delete postgresql acid-minimal-cluster
-kubectl delete deployments -l application=db-connection-pooler,cluster-name=acid-minimal-cluster
+kubectl delete deployments -l application=spilo,cluster-name=acid-minimal-cluster,component=db-connection-pooler
 kubectl delete statefulsets -l application=spilo,cluster-name=acid-minimal-cluster
 kubectl delete services -l application=spilo,cluster-name=acid-minimal-cluster
 kubectl delete configmap postgres-operator

--- a/e2e/scripts/watch_objects.sh
+++ b/e2e/scripts/watch_objects.sh
@@ -10,13 +10,13 @@ echo
 echo 'Pods'
 kubectl get pods -l application=spilo -o wide --all-namespaces
 echo
-kubectl get pods -l application=db-connection-pooler -o wide --all-namespaces
+kubectl get pods -l application=spilo,component=db-connection-pooler -o wide --all-namespaces
 echo
 echo 'Statefulsets'
 kubectl get statefulsets --all-namespaces
 echo
 echo 'Deployments'
-kubectl get deployments --all-namespaces -l application=db-connection-pooler
+kubectl get deployments --all-namespaces -l application=spilo,component=db-connection-pooler
 kubectl get deployments --all-namespaces -l application=postgres-operator
 echo
 echo

--- a/e2e/tests/test_e2e.py
+++ b/e2e/tests/test_e2e.py
@@ -678,7 +678,7 @@ class EndToEndTestCase(unittest.TestCase):
         the end turn connection pooler off to not interfere with other tests.
         '''
         k8s = self.k8s
-        pooler_label = 'application=db-connection-pooler,cluster-name=acid-minimal-cluster'
+        pooler_label = 'application=spilo,component=db-connection-pooler,cluster-name=acid-minimal-cluster'
         master_pooler_label = 'connection-pooler=acid-minimal-cluster-pooler'
         replica_pooler_label = master_pooler_label + '-repl'
         self.eventuallyEqual(lambda: k8s.get_operator_state(), {"0": "idle"}, "Operator does not get in sync")

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -18,9 +18,11 @@ data:
   connection_pooler_default_memory_limit: 100Mi
   connection_pooler_default_memory_request: 100Mi
   connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-32"
+  connection_pooler_labels: "component:db-connection-pooler"
   connection_pooler_max_db_connections: "60"
   connection_pooler_mode: "transaction"
   connection_pooler_number_of_instances: "2"
+  connection_pooler_role_label: pooler-role
   connection_pooler_schema: "pooler"
   connection_pooler_user: "pooler"
   crd_categories: "all"

--- a/manifests/minimal-fake-pooler-deployment.yaml
+++ b/manifests/minimal-fake-pooler-deployment.yaml
@@ -4,19 +4,22 @@ kind: Deployment
 metadata:
   name: acid-minimal-cluster-pooler
   labels:
-    application: db-connection-pooler
+    application: spilo
+    component: db-connection-pooler
     connection-pooler: acid-minimal-cluster-pooler
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: db-connection-pooler
+      application: spilo
+      component: db-connection-pooler
       connection-pooler: acid-minimal-cluster-pooler
       cluster-name: acid-minimal-cluster
   template:
     metadata:
       labels:
-        application: db-connection-pooler
+        application: spilo
+        component: db-connection-pooler
         connection-pooler: acid-minimal-cluster-pooler
         cluster-name: acid-minimal-cluster
     spec:

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -668,6 +668,12 @@ spec:
                   connection_pooler_image:
                     type: string
                     default: "registry.opensource.zalan.do/acid/pgbouncer:master-32"
+                  connection_pooler_labels:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    default:
+                      component: db-connection-pooler
                   connection_pooler_max_db_connections:
                     type: integer
                     default: 60
@@ -681,6 +687,9 @@ spec:
                     type: integer
                     minimum: 1
                     default: 2
+                  connection_pooler_role_label:
+                    type: string
+                    default: "pooler-role"
                   connection_pooler_default_cpu_limit:
                     type: string
                     pattern: '^(\d+m|\d+(\.\d{1,3})?)$'

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -218,9 +218,12 @@ configuration:
     connection_pooler_default_memory_limit: 100Mi
     connection_pooler_default_memory_request: 100Mi
     connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-32"
+    connection_pooler_labels:
+      component: db-connection-pooler
     # connection_pooler_max_db_connections: 60
     connection_pooler_mode: "transaction"
     connection_pooler_number_of_instances: 2
+    connection_pooler_role_label: pooler-role
     # connection_pooler_schema: "pooler"
     # connection_pooler_user: "pooler"
   patroni:

--- a/pkg/apis/acid.zalan.do/v1/crds.go
+++ b/pkg/apis/acid.zalan.do/v1/crds.go
@@ -898,6 +898,17 @@ var OperatorConfigCRDResourceValidation = apiextv1.CustomResourceValidation{
 							"connection_pooler_image": {
 								Type: "string",
 							},
+							"connection_pooler_labels": {
+								Type: "object",
+								AdditionalProperties: &apiextv1.JSONSchemaPropsOrBool{
+									Schema: &apiextv1.JSONSchemaProps{
+										Type: "string",
+									},
+								},
+							},
+							"connection_pooler_role_label": {
+								Type: "string",
+							},
 							"connection_pooler_max_db_connections": {
 								Type: "integer",
 							},

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -209,16 +209,18 @@ type ScalyrConfiguration struct {
 
 // ConnectionPoolerConfiguration defines default configuration for connection pooler
 type ConnectionPoolerConfiguration struct {
-	NumberOfInstances    *int32 `json:"connection_pooler_number_of_instances,omitempty"`
-	Schema               string `json:"connection_pooler_schema,omitempty"`
-	User                 string `json:"connection_pooler_user,omitempty"`
-	Image                string `json:"connection_pooler_image,omitempty"`
-	Mode                 string `json:"connection_pooler_mode,omitempty"`
-	MaxDBConnections     *int32 `json:"connection_pooler_max_db_connections,omitempty"`
-	DefaultCPURequest    string `json:"connection_pooler_default_cpu_request,omitempty"`
-	DefaultMemoryRequest string `json:"connection_pooler_default_memory_request,omitempty"`
-	DefaultCPULimit      string `json:"connection_pooler_default_cpu_limit,omitempty"`
-	DefaultMemoryLimit   string `json:"connection_pooler_default_memory_limit,omitempty"`
+	NumberOfInstances    *int32            `json:"connection_pooler_number_of_instances,omitempty"`
+	Schema               string            `json:"connection_pooler_schema,omitempty"`
+	User                 string            `json:"connection_pooler_user,omitempty"`
+	Image                string            `json:"connection_pooler_image,omitempty"`
+	Mode                 string            `json:"connection_pooler_mode,omitempty"`
+	MaxDBConnections     *int32            `json:"connection_pooler_max_db_connections,omitempty"`
+	Labels               map[string]string `json:"connection_pooler_labels,omitempty"`
+	RoleLabel            string            `json:"connection_pooler_role_label,omitempty"`
+	DefaultCPURequest    string            `json:"connection_pooler_default_cpu_request,omitempty"`
+	DefaultMemoryRequest string            `json:"connection_pooler_default_memory_request,omitempty"`
+	DefaultCPULimit      string            `json:"connection_pooler_default_cpu_limit,omitempty"`
+	DefaultMemoryLimit   string            `json:"connection_pooler_default_memory_limit,omitempty"`
 }
 
 // OperatorLogicalBackupConfiguration defines configuration for logical backup

--- a/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
@@ -142,6 +142,13 @@ func (in *ConnectionPoolerConfiguration) DeepCopyInto(out *ConnectionPoolerConfi
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1782,6 +1782,8 @@ func TestCrossNamespacedSecrets(t *testing.T) {
 		Config{
 			OpConfig: config.Config{
 				ConnectionPooler: config.ConnectionPooler{
+					Labels:                               map[string]string{"component": "db-connection-pooler"},
+					RoleLabel:                            "pooler-role",
 					ConnectionPoolerDefaultCPURequest:    "100m",
 					ConnectionPoolerDefaultCPULimit:      "100m",
 					ConnectionPoolerDefaultMemoryRequest: "100Mi",

--- a/pkg/cluster/connection_pooler.go
+++ b/pkg/cluster/connection_pooler.go
@@ -115,8 +115,9 @@ func (c *Cluster) poolerUser(spec *acidv1.PostgresSpec) string {
 func (c *Cluster) poolerLabelsSet(addExtraLabels bool) labels.Set {
 	poolerLabels := c.labelsSet(addExtraLabels)
 
-	// TODO should be config values
-	poolerLabels["application"] = "db-connection-pooler"
+	for k, v := range c.OpConfig.ConnectionPooler.Labels {
+		poolerLabels[k] = v
+	}
 
 	return poolerLabels
 }
@@ -134,7 +135,7 @@ func (c *Cluster) connectionPoolerLabels(role PostgresRole, addExtraLabels bool)
 
 	if addExtraLabels {
 		extraLabels := map[string]string{}
-		extraLabels[c.OpConfig.PodRoleLabel] = string(role)
+		extraLabels[c.OpConfig.ConnectionPooler.RoleLabel] = string(role)
 
 		poolerLabelsSet = labels.Merge(poolerLabelsSet, extraLabels)
 	}

--- a/pkg/cluster/connection_pooler_test.go
+++ b/pkg/cluster/connection_pooler_test.go
@@ -45,7 +45,7 @@ func deploymentUpdated(cluster *Cluster, err error, reason SyncReason) error {
 	for _, role := range [2]PostgresRole{Master, Replica} {
 
 		poolerLabels := cluster.labelsSet(false)
-		poolerLabels["application"] = "db-connection-pooler"
+		poolerLabels["component"] = "db-connection-pooler"
 		poolerLabels["connection-pooler"] = cluster.connectionPoolerName(role)
 
 		if cluster.ConnectionPooler[role] != nil && cluster.ConnectionPooler[role].Deployment != nil &&
@@ -65,7 +65,7 @@ func objectsAreSaved(cluster *Cluster, err error, reason SyncReason) error {
 
 	for _, role := range []PostgresRole{Master, Replica} {
 		poolerLabels := cluster.labelsSet(false)
-		poolerLabels["application"] = "db-connection-pooler"
+		poolerLabels["component"] = "db-connection-pooler"
 		poolerLabels["connection-pooler"] = cluster.connectionPoolerName(role)
 
 		if cluster.ConnectionPooler[role].Deployment == nil || !util.MapContains(cluster.ConnectionPooler[role].Deployment.Labels, poolerLabels) {
@@ -86,7 +86,7 @@ func MasterObjectsAreSaved(cluster *Cluster, err error, reason SyncReason) error
 	}
 
 	poolerLabels := cluster.labelsSet(false)
-	poolerLabels["application"] = "db-connection-pooler"
+	poolerLabels["component"] = "db-connection-pooler"
 	poolerLabels["connection-pooler"] = cluster.connectionPoolerName(Master)
 
 	if cluster.ConnectionPooler[Master].Deployment == nil || !util.MapContains(cluster.ConnectionPooler[Master].Deployment.Labels, poolerLabels) {
@@ -106,7 +106,7 @@ func ReplicaObjectsAreSaved(cluster *Cluster, err error, reason SyncReason) erro
 	}
 
 	poolerLabels := cluster.labelsSet(false)
-	poolerLabels["application"] = "db-connection-pooler"
+	poolerLabels["component"] = "db-connection-pooler"
 	poolerLabels["connection-pooler"] = cluster.connectionPoolerName(Replica)
 
 	if cluster.ConnectionPooler[Replica].Deployment == nil || !util.MapContains(cluster.ConnectionPooler[Replica].Deployment.Labels, poolerLabels) {
@@ -170,6 +170,8 @@ func TestNeedConnectionPooler(t *testing.T) {
 					ReplicationUsername: replicationUserName,
 				},
 				ConnectionPooler: config.ConnectionPooler{
+					Labels:                               map[string]string{"component": "db-connection-pooler"},
+					RoleLabel:                            "pooler-role",
 					ConnectionPoolerDefaultCPURequest:    "100m",
 					ConnectionPoolerDefaultCPULimit:      "100m",
 					ConnectionPoolerDefaultMemoryRequest: "100Mi",
@@ -301,6 +303,8 @@ func TestConnectionPoolerCreateDeletion(t *testing.T) {
 		Config{
 			OpConfig: config.Config{
 				ConnectionPooler: config.ConnectionPooler{
+					Labels:                               map[string]string{"component": "db-connection-pooler"},
+					RoleLabel:                            "pooler-role",
 					ConnectionPoolerDefaultCPURequest:    "100m",
 					ConnectionPoolerDefaultCPULimit:      "100m",
 					ConnectionPoolerDefaultMemoryRequest: "100Mi",
@@ -336,7 +340,7 @@ func TestConnectionPoolerCreateDeletion(t *testing.T) {
 	}
 	for _, role := range [2]PostgresRole{Master, Replica} {
 		poolerLabels := cluster.labelsSet(false)
-		poolerLabels["application"] = "db-connection-pooler"
+		poolerLabels["component"] = "db-connection-pooler"
 		poolerLabels["connection-pooler"] = cluster.connectionPoolerName(role)
 
 		if cluster.ConnectionPooler[role] != nil {
@@ -409,6 +413,8 @@ func TestConnectionPoolerSync(t *testing.T) {
 		Config{
 			OpConfig: config.Config{
 				ConnectionPooler: config.ConnectionPooler{
+					Labels:                               map[string]string{"component": "db-connection-pooler"},
+					RoleLabel:                            "pooler-role",
 					ConnectionPoolerDefaultCPURequest:    "100m",
 					ConnectionPoolerDefaultCPULimit:      "100m",
 					ConnectionPoolerDefaultMemoryRequest: "100Mi",
@@ -678,6 +684,8 @@ func TestConnectionPoolerPodSpec(t *testing.T) {
 				PodServiceAccountName: "postgres-pod",
 				ConnectionPooler: config.ConnectionPooler{
 					MaxDBConnections:                     k8sutil.Int32ToPointer(60),
+					Labels:                               map[string]string{"component": "db-connection-pooler"},
+					RoleLabel:                            "pooler-role",
 					ConnectionPoolerDefaultCPURequest:    "100m",
 					ConnectionPoolerDefaultCPULimit:      "100m",
 					ConnectionPoolerDefaultMemoryRequest: "100Mi",
@@ -789,6 +797,8 @@ func TestConnectionPoolerDeploymentSpec(t *testing.T) {
 					ReplicationUsername: replicationUserName,
 				},
 				ConnectionPooler: config.ConnectionPooler{
+					Labels:                               map[string]string{"component": "db-connection-pooler"},
+					RoleLabel:                            "pooler-role",
 					ConnectionPoolerDefaultCPURequest:    "100m",
 					ConnectionPoolerDefaultCPULimit:      "100m",
 					ConnectionPoolerDefaultMemoryRequest: "100Mi",
@@ -1003,6 +1013,8 @@ func TestPoolerTLS(t *testing.T) {
 					SpiloFSGroup:         &spiloFSGroup,
 				},
 				ConnectionPooler: config.ConnectionPooler{
+					Labels:                               map[string]string{"component": "db-connection-pooler"},
+					RoleLabel:                            "pooler-role",
 					ConnectionPoolerDefaultCPURequest:    "100m",
 					ConnectionPoolerDefaultCPULimit:      "100m",
 					ConnectionPoolerDefaultMemoryRequest: "100Mi",
@@ -1072,6 +1084,8 @@ func TestConnectionPoolerServiceSpec(t *testing.T) {
 					ReplicationUsername: replicationUserName,
 				},
 				ConnectionPooler: config.ConnectionPooler{
+					Labels:                               map[string]string{"component": "db-connection-pooler"},
+					RoleLabel:                            "pooler-role",
 					ConnectionPoolerDefaultCPURequest:    "100m",
 					ConnectionPoolerDefaultCPULimit:      "100m",
 					ConnectionPoolerDefaultMemoryRequest: "100Mi",

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -3022,6 +3022,8 @@ func TestEnableLoadBalancers(t *testing.T) {
 			subTest: "LBs enabled in config, disabled in manifest",
 			config: config.Config{
 				ConnectionPooler: config.ConnectionPooler{
+					Labels:                               map[string]string{"component": "db-connection-pooler"},
+					RoleLabel:                            "pooler-role",
 					ConnectionPoolerDefaultCPURequest:    "100m",
 					ConnectionPoolerDefaultCPULimit:      "100m",
 					ConnectionPoolerDefaultMemoryRequest: "100Mi",
@@ -3069,6 +3071,8 @@ func TestEnableLoadBalancers(t *testing.T) {
 			subTest: "LBs enabled in manifest, disabled in config",
 			config: config.Config{
 				ConnectionPooler: config.ConnectionPooler{
+					Labels:                               map[string]string{"component": "db-connection-pooler"},
+					RoleLabel:                            "pooler-role",
 					ConnectionPoolerDefaultCPURequest:    "100m",
 					ConnectionPoolerDefaultCPULimit:      "100m",
 					ConnectionPoolerDefaultMemoryRequest: "100Mi",

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -192,6 +192,8 @@ func TestPodAnnotationsSync(t *testing.T) {
 				PodManagementPolicy:     "ordered_ready",
 				CustomPodAnnotations:    customPodAnnotations,
 				ConnectionPooler: config.ConnectionPooler{
+					Labels:                               map[string]string{"component": "db-connection-pooler"},
+					RoleLabel:                            "pooler-role",
 					ConnectionPoolerDefaultCPURequest:    "100m",
 					ConnectionPoolerDefaultCPULimit:      "100m",
 					ConnectionPoolerDefaultMemoryRequest: "100Mi",

--- a/pkg/cluster/util_test.go
+++ b/pkg/cluster/util_test.go
@@ -301,6 +301,8 @@ func newInheritedAnnotationsCluster(client k8sutil.KubernetesClient) (*Cluster, 
 				PatroniAPICheckTimeout:  time.Duration(5),
 				KubernetesUseConfigMaps: true,
 				ConnectionPooler: config.ConnectionPooler{
+					Labels:                               map[string]string{"component": "db-connection-pooler"},
+					RoleLabel:                            "pooler-role",
 					ConnectionPoolerDefaultCPURequest:    "100m",
 					ConnectionPoolerDefaultCPULimit:      "100m",
 					ConnectionPoolerDefaultMemoryRequest: "100Mi",

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -280,6 +280,8 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 		fromCRD.ConnectionPooler.Mode,
 		constants.ConnectionPoolerDefaultMode)
 
+	result.ConnectionPooler.Labels = util.CoalesceStrMap(fromCRD.ConnectionPooler.Labels, map[string]string{"application": "spilo"})
+	result.ConnectionPooler.RoleLabel = util.Coalesce(fromCRD.ConnectionPooler.RoleLabel, "pooler-role")
 	result.ConnectionPooler.ConnectionPoolerDefaultCPURequest = fromCRD.ConnectionPooler.DefaultCPURequest
 	result.ConnectionPooler.ConnectionPoolerDefaultMemoryRequest = fromCRD.ConnectionPooler.DefaultMemoryRequest
 	result.ConnectionPooler.ConnectionPoolerDefaultCPULimit = fromCRD.ConnectionPooler.DefaultCPULimit

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -152,16 +152,18 @@ type LogicalBackup struct {
 
 // Operator options for connection pooler
 type ConnectionPooler struct {
-	NumberOfInstances                    *int32 `name:"connection_pooler_number_of_instances" default:"2"`
-	Schema                               string `name:"connection_pooler_schema" default:"pooler"`
-	User                                 string `name:"connection_pooler_user" default:"pooler"`
-	Image                                string `name:"connection_pooler_image" default:"registry.opensource.zalan.do/acid/pgbouncer"`
-	Mode                                 string `name:"connection_pooler_mode" default:"transaction"`
-	MaxDBConnections                     *int32 `name:"connection_pooler_max_db_connections" default:"60"`
-	ConnectionPoolerDefaultCPURequest    string `name:"connection_pooler_default_cpu_request"`
-	ConnectionPoolerDefaultMemoryRequest string `name:"connection_pooler_default_memory_request"`
-	ConnectionPoolerDefaultCPULimit      string `name:"connection_pooler_default_cpu_limit"`
-	ConnectionPoolerDefaultMemoryLimit   string `name:"connection_pooler_default_memory_limit"`
+	NumberOfInstances                    *int32            `name:"connection_pooler_number_of_instances" default:"2"`
+	Schema                               string            `name:"connection_pooler_schema" default:"pooler"`
+	User                                 string            `name:"connection_pooler_user" default:"pooler"`
+	Image                                string            `name:"connection_pooler_image" default:"registry.opensource.zalan.do/acid/pgbouncer"`
+	Mode                                 string            `name:"connection_pooler_mode" default:"transaction"`
+	MaxDBConnections                     *int32            `name:"connection_pooler_max_db_connections" default:"60"`
+	Labels                               map[string]string `name:"connection_pooler_labels,omitempty" default:"component:db-connection-pooler"`
+	RoleLabel                            string            `name:"connection_pooler_role_label" default:"pooler-role"`
+	ConnectionPoolerDefaultCPURequest    string            `name:"connection_pooler_default_cpu_request"`
+	ConnectionPoolerDefaultMemoryRequest string            `name:"connection_pooler_default_memory_request"`
+	ConnectionPoolerDefaultCPULimit      string            `name:"connection_pooler_default_cpu_limit"`
+	ConnectionPoolerDefaultMemoryLimit   string            `name:"connection_pooler_default_memory_limit"`
 }
 
 // Config describes operator config
@@ -302,6 +304,11 @@ func Copy(c *Config) Config {
 	cfg.ClusterLabels = make(map[string]string, len(c.ClusterLabels))
 	for k, v := range c.ClusterLabels {
 		cfg.ClusterLabels[k] = v
+	}
+
+	cfg.ConnectionPooler.Labels = make(map[string]string, len(c.ConnectionPooler.Labels))
+	for k, v := range c.ConnectionPooler.Labels {
+		cfg.ConnectionPooler.Labels[k] = v
 	}
 
 	return cfg

--- a/ui/operator_ui/spiloutils.py
+++ b/ui/operator_ui/spiloutils.py
@@ -17,7 +17,7 @@ AWS_ENDPOINT = getenv('AWS_ENDPOINT')
 OPERATOR_CLUSTER_NAME_LABEL = getenv('OPERATOR_CLUSTER_NAME_LABEL', 'cluster-name')
 
 COMMON_CLUSTER_LABEL = getenv('COMMON_CLUSTER_LABEL', '{"application":"spilo"}')
-COMMON_POOLER_LABEL = getenv('COMMON_POOLER_LABEL', '{"application":"db-connection-pooler"}')
+COMMON_POOLER_LABEL = getenv('COMMON_POOLER_LABEL', '{"application":"spilo","component":"db-connection-pooler"}')
 
 logger.info("Common Cluster Label: {}".format(COMMON_CLUSTER_LABEL))
 logger.info("Common Pooler Label: {}".format(COMMON_POOLER_LABEL))


### PR DESCRIPTION
All resources of one cluster should belong to one application label, not an extra application. On the other hand, there should not be two pods queryable with `application: spilo, spilo-role: master`. Therefore, the role identifier for pooler pods must be changed, too.

As this is a breaking change, we introduce new config options to be able to continue using the old way of labelling, meaning:
- `connection_pooler_labels: application:db-connection-pooler`
- `connection_pooler_role_label: spilo-role`

The new defaults used for these two config options are:
- `connection_pooler_labels: component:db-connection-pooler`
- `connection_pooler_role_label: pooler-role`