### PR TITLE
ui: honor AWS_ENDPOINT in read_basebackups S3 list/get

### DIFF
--- a/ui/operator_ui/spiloutils.py
+++ b/ui/operator_ui/spiloutils.py
@@ -321,11 +321,18 @@ def read_basebackups(
     suffix = '' if uid == 'base' else '/' + uid
     backups = []
 
+    # Reuse a single S3 client configured with AWS_ENDPOINT so MinIO /
+    # other S3-compatible backends are hit for list+get calls too. The
+    # previous plain client('s3') fell back to the default AWS endpoint
+    # and returned empty data against a custom endpoint; read_stored_clusters
+    # and read_versions already pass endpoint_url=AWS_ENDPOINT (#3078).
+    s3_client = client('s3', endpoint_url=AWS_ENDPOINT)
+
     for vp in postgresql_versions:
         backup_prefix = f'{prefix}{pg_cluster}{suffix}/wal/{vp}/basebackups_005/'
         logger.info(f"{bucket}/{backup_prefix}")
 
-        paginator = client('s3').get_paginator('list_objects_v2')
+        paginator = s3_client.get_paginator('list_objects_v2')
         pages = paginator.paginate(Bucket=bucket, Prefix=backup_prefix)
 
         for page in pages:
@@ -334,7 +341,7 @@ def read_basebackups(
                 if not key.endswith("backup_stop_sentinel.json"):
                     continue
 
-                response = client('s3').get_object(Bucket=bucket, Key=key)
+                response = s3_client.get_object(Bucket=bucket, Key=key)
                 backup_info = loads(response["Body"].read().decode("utf-8"))
                 last_modified = response["LastModified"].astimezone(timezone.utc).isoformat()
 


### PR DESCRIPTION
## Summary

Fixes #3078.

`read_stored_clusters` and `read_versions` in `ui/operator_ui/spiloutils.py` build their S3 clients with `endpoint_url=AWS_ENDPOINT`, but `read_basebackups` used a bare `client('s3')` for both the `list_objects_v2` paginator and the per-key `get_object`. On MinIO / S3-compatible backends the list+get requests hit the default AWS endpoint, so the UI's Backups tab renders cluster/version prefixes (from the correctly-configured `read_stored_clusters`) then returns empty base backup details.

## Fix

Build `s3_client = client('s3', endpoint_url=AWS_ENDPOINT)` once per call and reuse it for both the paginator and `get_object`. No behaviour change when `AWS_ENDPOINT` is unset — boto3 already defaults to the AWS endpoint in that case.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('spiloutils.py').read())"` syntax check.
- [ ] Manual: set `AWS_ENDPOINT=http://minio.example.com`, push a base backup via Spilo, open the UI's Backups tab — base backup details now populate instead of showing an empty list.
