### PR TITLE
Add support for loadBalancerClass in LoadBalancer services

### DIFF
--- a/docs/reference/operator_parameters.md
+++ b/docs/reference/operator_parameters.md
@@ -719,6 +719,13 @@ In the CRD-based configuration they are grouped under the `load_balancer` key.
   defines external traffic policy for load
   balancers. Allowed values are `Cluster` (default) and `Local`.
 
+* **load_balancer_class**
+  specifies the load balancer class to use for LoadBalancer services. This is
+  useful when running multiple load balancer providers in the same cluster,
+  allowing you to select which provider should handle the service. For example,
+  `service.k8s.aws/nlb` for AWS Network Load Balancer. When not set, the
+  cluster's default load balancer class is used.
+
 * **master_dns_name_format**
   defines the DNS name string template for the master load balancer cluster.
   The default is `{cluster}.{namespace}.{hostedzone}`, where `{cluster}` is

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -473,6 +473,9 @@ spec:
                   replica_legacy_dns_name_format:
                     type: string
                     default: "{cluster}-repl.{team}.{hostedzone}"
+                  load_balancer_class:
+                    type: string
+                    description: "LoadBalancerClass to use for LoadBalancer services"
               aws_or_gcp:
                 type: object
                 properties:

--- a/manifests/postgresql-operator-default-configuration.yaml
+++ b/manifests/postgresql-operator-default-configuration.yaml
@@ -149,6 +149,7 @@ configuration:
     enable_replica_load_balancer: false
     enable_replica_pooler_load_balancer: false
     external_traffic_policy: "Cluster"
+    # load_balancer_class: "service.k8s.aws/nlb"
     master_dns_name_format: "{cluster}.{namespace}.{hostedzone}"
     # master_legacy_dns_name_format: "{cluster}.{team}.{hostedzone}"
     replica_dns_name_format: "{cluster}-repl.{namespace}.{hostedzone}"

--- a/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
+++ b/pkg/apis/acid.zalan.do/v1/operator_configuration_type.go
@@ -147,6 +147,7 @@ type LoadBalancerConfiguration struct {
 	ReplicaDNSNameFormat            config.StringTemplate `json:"replica_dns_name_format,omitempty"`
 	ReplicaLegacyDNSNameFormat      config.StringTemplate `json:"replica_legacy_dns_name_format,omitempty"`
 	ExternalTrafficPolicy           string                `json:"external_traffic_policy" default:"Cluster"`
+	LoadBalancerClass               string                `json:"load_balancer_class,omitempty"`
 }
 
 // AWSGCPConfiguration defines the configuration for AWS

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2020,6 +2020,9 @@ func (c *Cluster) configureLoadBalanceService(serviceSpec *v1.ServiceSpec, sourc
 
 	c.logger.Debugf("final load balancer source ranges as seen in a service spec (not necessarily applied): %q", serviceSpec.LoadBalancerSourceRanges)
 	serviceSpec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyType(c.OpConfig.ExternalTrafficPolicy)
+	if c.OpConfig.LoadBalancerClass != "" {
+		serviceSpec.LoadBalancerClass = &c.OpConfig.LoadBalancerClass
+	}
 	serviceSpec.Type = v1.ServiceTypeLoadBalancer
 }
 

--- a/pkg/controller/operator_config.go
+++ b/pkg/controller/operator_config.go
@@ -176,6 +176,7 @@ func (c *Controller) importConfigurationFromCRD(fromCRD *acidv1.OperatorConfigur
 	result.ReplicaDNSNameFormat = fromCRD.LoadBalancer.ReplicaDNSNameFormat
 	result.ReplicaLegacyDNSNameFormat = fromCRD.LoadBalancer.ReplicaLegacyDNSNameFormat
 	result.ExternalTrafficPolicy = util.Coalesce(fromCRD.LoadBalancer.ExternalTrafficPolicy, "Cluster")
+	result.LoadBalancerClass = fromCRD.LoadBalancer.LoadBalancerClass
 
 	// AWS or GCP config
 	result.WALES3Bucket = fromCRD.AWSGCP.WALES3Bucket

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -220,6 +220,7 @@ type Config struct {
 	StorageResizeMode                        string            `name:"storage_resize_mode" default:"pvc"`
 	EnableLoadBalancer                       *bool             `name:"enable_load_balancer"` // deprecated and kept for backward compatibility
 	ExternalTrafficPolicy                    string            `name:"external_traffic_policy" default:"Cluster"`
+	LoadBalancerClass                        string            `name:"load_balancer_class"`
 	MasterDNSNameFormat                      StringTemplate    `name:"master_dns_name_format" default:"{cluster}.{namespace}.{hostedzone}"`
 	MasterLegacyDNSNameFormat                StringTemplate    `name:"master_legacy_dns_name_format" default:"{cluster}.{team}.{hostedzone}"`
 	ReplicaDNSNameFormat                     StringTemplate    `name:"replica_dns_name_format" default:"{cluster}-repl.{namespace}.{hostedzone}"`


### PR DESCRIPTION
## What this PR does

This adds a new configuration option `load_balancer_class` that allows users to specify which load balancer provider should handle the service when running multiple providers in the same cluster.

Fixes #2600

## Changes

- Added `load_balancer_class` field to `LoadBalancerConfiguration` struct
- Added config mapping in `importConfigurationFromCRD()`
- Modified `configureLoadBalanceService()` to set `spec.loadBalancerClass` when configured
- Updated CRD schema with new field
- Updated default configuration manifest
- Added documentation

## Example usage

```yaml
apiVersion: acid.zalan.do/v1
kind: OperatorConfiguration
metadata:
  name: postgres-operator
configuration:
  load_balancer:
    enable_master_load_balancer: true
    load_balancer_class: "service.k8s.aws/nlb"
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

Note: parts of this implementation were developed with AI assistance.