### PR TITLE
feat: allow overriding external-dns hostname annotation

### DIFF
--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -896,8 +896,9 @@ its services:
 
 - `external-dns.alpha.kubernetes.io/hostname` with the value defined by the
   operator configs `master_dns_name_format` and `replica_dns_name_format`.
-  This value can't be overwritten. If any changing in its value is needed, it
-  MUST be done changing the DNS format operator config parameters; and
+  This value can be overwritten by specifying the annotation in
+  `serviceAnnotations`, `masterServiceAnnotations`, or `replicaServiceAnnotations`
+  in the cluster manifest; and
 
 There are multiple options to specify service annotations that will be merged
 with each other and override in the following order (where latter take

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -767,16 +767,16 @@ func TestServiceAnnotations(t *testing.T) {
 			},
 		},
 		{
-			about:                      "Master with cluster annotations do not override external-dns annotations",
+			about:                      "Master with user-defined external-dns annotation is preserved",
 			role:                       "master",
 			enableMasterLoadBalancerOC: true,
 			enableTeamIdClusterPrefix:  false,
 			operatorAnnotations:        make(map[string]string),
 			serviceAnnotations: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname": "wrong.external-dns-name.example.com",
+				"external-dns.alpha.kubernetes.io/hostname": "custom.user-defined.example.com",
 			},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname": "acid-test-stg.test.db.example.com,test-stg.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname": "custom.user-defined.example.com",
 			},
 		},
 		{
@@ -916,16 +916,16 @@ func TestServiceAnnotations(t *testing.T) {
 			},
 		},
 		{
-			about:                       "Replica with cluster annotations do not override external-dns annotations",
+			about:                       "Replica with user-defined external-dns annotation is preserved",
 			role:                        "replica",
 			enableReplicaLoadBalancerOC: true,
 			enableTeamIdClusterPrefix:   false,
 			operatorAnnotations:         make(map[string]string),
 			serviceAnnotations: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname": "wrong.external-dns-name.example.com",
+				"external-dns.alpha.kubernetes.io/hostname": "custom.user-defined-repl.example.com",
 			},
 			expect: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname": "acid-test-stg-repl.test.db.example.com,test-stg-repl.acid.db.example.com",
+				"external-dns.alpha.kubernetes.io/hostname": "custom.user-defined-repl.example.com",
 			},
 		},
 		{

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2027,10 +2027,11 @@ func (c *Cluster) generateServiceAnnotations(role PostgresRole, spec *acidv1.Pos
 	annotations := c.getCustomServiceAnnotations(role, spec)
 
 	if c.shouldCreateLoadBalancerForService(role, spec) {
-		dnsName := c.dnsName(role)
-
-		// External DNS name annotation is not customizable
-		annotations[constants.ZalandoDNSNameAnnotation] = dnsName
+		// Only set the DNS annotation if not already defined by user in service annotations
+		if _, exists := annotations[constants.ZalandoDNSNameAnnotation]; !exists {
+			dnsName := c.dnsName(role)
+			annotations[constants.ZalandoDNSNameAnnotation] = dnsName
+		}
 	}
 
 	if len(annotations) == 0 {


### PR DESCRIPTION
## Summary
Allows users to override the `external-dns.alpha.kubernetes.io/hostname` annotation by specifying it in `serviceAnnotations`, `masterServiceAnnotations`, or `replicaServiceAnnotations` in the cluster manifest.

Fixes #2591

## Changes
- **pkg/cluster/k8sres.go**: Modified `generateServiceAnnotations()` to check if the DNS annotation already exists before setting it
- **pkg/cluster/cluster_test.go**: Updated tests to verify user-defined annotations are preserved (changed test case names and expectations)
- **docs/administrator.md**: Updated documentation to reflect that the annotation can now be overwritten

## Before
The operator always overwrote the `external-dns.alpha.kubernetes.io/hostname` annotation with the value from `master_dns_name_format` or `replica_dns_name_format`, ignoring any user-defined value.

## After
If the user has already defined the `external-dns.alpha.kubernetes.io/hostname` annotation in their service annotations, the operator will preserve that value instead of overwriting it.

## Test plan
- [x] Updated existing tests to verify new behavior
- [x] All unit tests pass (`go test ./...`)

---

**Disclosure**: I used AI assistance (Claude) to help implement this change under my review and testing.