### PR TITLE
Add pg_ident.conf passthrough field to Patroni spec

### DIFF
--- a/docs/reference/cluster_manifest.md
+++ b/docs/reference/cluster_manifest.md
@@ -371,6 +371,12 @@ explanation of `ttl` and `loop_wait` parameters.
   custom `pg_hba` should include the pam line to avoid breaking pam
   authentication. Optional.
 
+* **pg_ident**
+  list of custom `pg_ident` lines defining user name maps for external
+  authentication methods (e.g. cert, gss, peer). Each line is of the form
+  `mapname system-username pg-username`. Patroni manages `pg_ident.conf`
+  and reloads PostgreSQL when this list changes. Optional.
+
 * **ttl**
   Patroni `ttl` parameter value, optional. The default is set by the Spilo
   Docker image. Optional.

--- a/manifests/complete-postgres-manifest.yaml
+++ b/manifests/complete-postgres-manifest.yaml
@@ -137,6 +137,9 @@ spec:
 #    pg_hba:
 #      - hostssl all all 0.0.0.0/0 md5
 #      - host    all all 0.0.0.0/0 md5
+#    pg_ident:
+#      - mymap /^(.*)@example\.com$ \1
+#      - mymap admin@example.com postgres
 #    slots:
 #      permanent_physical_1:
 #        type: physical

--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -2418,6 +2418,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  pg_ident:
+                    items:
+                      type: string
+                    type: array
                   retry_timeout:
                     format: int32
                     type: integer

--- a/pkg/apis/acid.zalan.do/v1/postgresql.crd.yaml
+++ b/pkg/apis/acid.zalan.do/v1/postgresql.crd.yaml
@@ -2418,6 +2418,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  pg_ident:
+                    items:
+                      type: string
+                    type: array
                   retry_timeout:
                     format: int32
                     type: integer

--- a/pkg/apis/acid.zalan.do/v1/postgresql_type.go
+++ b/pkg/apis/acid.zalan.do/v1/postgresql_type.go
@@ -241,6 +241,7 @@ type Resources struct {
 type Patroni struct {
 	InitDB                map[string]string            `json:"initdb,omitempty"`
 	PgHba                 []string                     `json:"pg_hba,omitempty"`
+	PgIdent               []string                     `json:"pg_ident,omitempty"`
 	TTL                   uint32                       `json:"ttl,omitempty"`
 	LoopWait              uint32                       `json:"loop_wait,omitempty"`
 	RetryTimeout          uint32                       `json:"retry_timeout,omitempty"`

--- a/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/acid.zalan.do/v1/zz_generated.deepcopy.go
@@ -675,6 +675,11 @@ func (in *Patroni) DeepCopyInto(out *Patroni) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.PgIdent != nil {
+		in, out := &in.PgIdent, &out.PgIdent
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Slots != nil {
 		in, out := &in.Slots, &out.Slots
 		*out = make(map[string]map[string]string, len(*in))

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -35,15 +35,16 @@ import (
 )
 
 const (
-	pgBinariesLocationTemplate     = "/usr/lib/postgresql/%v/bin"
-	patroniPGBinariesParameterName = "bin_dir"
-	patroniPGHBAConfParameterName  = "pg_hba"
-	localHost                      = "127.0.0.1/32"
-	scalyrSidecarName              = "scalyr-sidecar"
-	logicalBackupContainerName     = "logical-backup"
-	connectionPoolerContainer      = "connection-pooler"
-	pgPort                         = 5432
-	operatorPort                   = 8080
+	pgBinariesLocationTemplate      = "/usr/lib/postgresql/%v/bin"
+	patroniPGBinariesParameterName  = "bin_dir"
+	patroniPGHBAConfParameterName   = "pg_hba"
+	patroniPGIdentConfParameterName = "pg_ident"
+	localHost                       = "127.0.0.1/32"
+	scalyrSidecarName               = "scalyr-sidecar"
+	logicalBackupContainerName      = "logical-backup"
+	connectionPoolerContainer       = "connection-pooler"
+	pgPort                          = 5432
+	operatorPort                    = 8080
 )
 
 type patroniDCS struct {
@@ -469,11 +470,15 @@ PatroniInitDBParams:
 			config.Bootstrap.DCS.PGBootstrapConfiguration[constants.PatroniPGParametersParameterName] = bootstrap
 		}
 	}
-	// Patroni gives us a choice of writing pg_hba.conf to either the bootstrap section or to the local postgresql one.
-	// We choose the local one, because we need Patroni to change pg_hba.conf in PostgreSQL after the user changes the
+
+	// Patroni gives us a choice of writing pg_hba.conf and pg_ident.conf to either the bootstrap section or to the local postgresql one.
+	// We choose the local one, because we need Patroni to change them in PostgreSQL after the user changes the
 	// relevant section in the manifest.
 	if len(patroni.PgHba) > 0 {
 		config.PgLocalConfiguration[patroniPGHBAConfParameterName] = patroni.PgHba
+	}
+	if len(patroni.PgIdent) > 0 {
+		config.PgLocalConfiguration[patroniPGIdentConfParameterName] = patroni.PgIdent
 	}
 
 	res, err := json.Marshal(config)

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -90,6 +90,7 @@ func TestGenerateSpiloJSONConfiguration(t *testing.T) {
 					"data-checksums": "true",
 				},
 				PgHba:                 []string{"hostssl all all 0.0.0.0/0 scram-sha-256", "host    all all 0.0.0.0/0 scram-sha-256"},
+				PgIdent:               []string{"mymap user1 dbuser1", "mymap user2 dbuser2"},
 				TTL:                   30,
 				LoopWait:              10,
 				RetryTimeout:          10,
@@ -101,7 +102,7 @@ func TestGenerateSpiloJSONConfiguration(t *testing.T) {
 				FailsafeMode:          util.True(),
 			},
 			opConfig: &config.Config{},
-			result:   `{"postgresql":{"bin_dir":"/usr/lib/postgresql/18/bin","pg_hba":["hostssl all all 0.0.0.0/0 scram-sha-256","host    all all 0.0.0.0/0 scram-sha-256"]},"bootstrap":{"initdb":[{"auth-host":"scram-sha-256"},{"auth-local":"trust"},"data-checksums",{"encoding":"UTF8"},{"locale":"en_US.UTF-8"}],"dcs":{"ttl":30,"loop_wait":10,"retry_timeout":10,"maximum_lag_on_failover":33554432,"synchronous_mode":true,"synchronous_mode_strict":true,"synchronous_node_count":1,"slots":{"permanent_logical_1":{"database":"foo","plugin":"pgoutput","type":"logical"}},"failsafe_mode":true}}}`,
+			result:   `{"postgresql":{"bin_dir":"/usr/lib/postgresql/18/bin","pg_hba":["hostssl all all 0.0.0.0/0 scram-sha-256","host    all all 0.0.0.0/0 scram-sha-256"],"pg_ident":["mymap user1 dbuser1","mymap user2 dbuser2"]},"bootstrap":{"initdb":[{"auth-host":"scram-sha-256"},{"auth-local":"trust"},"data-checksums",{"encoding":"UTF8"},{"locale":"en_US.UTF-8"}],"dcs":{"ttl":30,"loop_wait":10,"retry_timeout":10,"maximum_lag_on_failover":33554432,"synchronous_mode":true,"synchronous_mode_strict":true,"synchronous_node_count":1,"slots":{"permanent_logical_1":{"database":"foo","plugin":"pgoutput","type":"logical"}},"failsafe_mode":true}}}`,
 		},
 		{
 			subtest: "Patroni failsafe_mode configured globally",

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -921,6 +921,9 @@ func (c *Cluster) checkAndSetGlobalPostgreSQLConfiguration(pod *v1.Pod, effectiv
 	if desiredPatroniConfig.PgHba != nil && !reflect.DeepEqual(desiredPatroniConfig.PgHba, effectivePatroniConfig.PgHba) {
 		configToSet["pg_hba"] = desiredPatroniConfig.PgHba
 	}
+	if desiredPatroniConfig.PgIdent != nil && !reflect.DeepEqual(desiredPatroniConfig.PgIdent, effectivePatroniConfig.PgIdent) {
+		configToSet["pg_ident"] = desiredPatroniConfig.PgIdent
+	}
 	if desiredPatroniConfig.RetryTimeout > 0 && desiredPatroniConfig.RetryTimeout != effectivePatroniConfig.RetryTimeout {
 		configToSet["retry_timeout"] = desiredPatroniConfig.RetryTimeout
 	}


### PR DESCRIPTION
Patroni already supports pg_ident.conf natively under `postgresql.pg_ident` (a list of lines, same shape as `pg_hba`). This PR exposes it through the Postgresql CRD so users can configure ident maps from the manifest, mirroring the existing `pg_hba` passthrough (#361).

Use cases: cert auth with `map=...` (mapping client cert SAN/CN to PG roles), GSS principal stripping, PAM username rewrites, peer auth maps. Anywhere a `pg_hba` line uses `map=mapname`, you currently can't supply the mapping rules without forking.

Implementation mirrors `pg_hba`:
- `PgIdent []string` on the `Patroni` struct
- written into the local Patroni postgresql config (so changes propagate via the Patroni REST API on manifest update, not only at bootstrap)
- diff-and-set in `checkAndSetGlobalPostgreSQLConfiguration`

Validation is delegated to Patroni/Postgres on reload, same as `pg_hba`. The operator doesn't parse the lines.

## Checklist

- [x] Code formatted (gofmt)
- [x] Generated code updated via `make codegen` (deepcopy + both CRD yamls)
- [x] CRD validation, sample manifest, and reference docs updated
- [x] Unit tests extended (`k8sres_test.go`, `util_test.go`)
- [x] No overlapping open PRs