### PR TITLE
Remove references to registry.opensource.zalan.do

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -4,6 +4,7 @@ allow_concurrent_steps: true
 build_env: &BUILD_ENV
   PYTHON_BASE_IMAGE: container-registry.zalando.net/library/python-3.11-slim
   ALPINE_BASE_IMAGE: container-registry.zalando.net/library/alpine-3
+  UBUNTU_BASE_IMAGE: container-registry.zalando.net/library/ubuntu-22.04
   MULTI_ARCH_REGISTRY: container-registry-test.zalando.net/acid
 
 pipeline:
@@ -126,6 +127,7 @@ pipeline:
 
           docker buildx create --config /etc/cdp-buildkitd.toml --driver-opt network=host --bootstrap --use
           docker buildx build --platform linux/amd64,linux/arm64 \
+                              --build-arg BASE_IMAGE="${UBUNTU_BASE_IMAGE}" \
                               -t ${IMAGE}:${CDP_BUILD_VERSION} \
                               --push .
 

--- a/logical-backup/Dockerfile
+++ b/logical-backup/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=registry.opensource.zalan.do/library/ubuntu-22.04:latest
+ARG BASE_IMAGE=ubuntu:22.04
 FROM ${BASE_IMAGE}
 LABEL maintainer="Team ACID @ Zalando <team-acid@zalando.de>"
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1581,8 +1581,8 @@ func newCronJob(image, schedule string, vars []v1.EnvVar, mounts []v1.VolumeMoun
 
 func TestCompareLogicalBackupJob(t *testing.T) {
 
-	img1 := "registry.opensource.zalan.do/acid/logical-backup:v1.0"
-	img2 := "registry.opensource.zalan.do/acid/logical-backup:v2.0"
+	img1 := "ghcr.io/zalando/postgres-operator/logical-backup:v1.14.0"
+	img2 := "ghcr.io/zalando/postgres-operator/logical-backup:v1.15.1"
 
 	clientSet := fake.NewSimpleClientset()
 	acidClientSet := fakeacidv1.NewSimpleClientset()


### PR DESCRIPTION
Zalando wants to decommission the docker registry hosting images on `registry.opensource.zalan.do`

This removes any reference to `registry.opensource.zalan.do` and replaces with open source images where applicable.

I believe this also fixes an issue where logical-backup image was built with a non-multi-arch image before.