### PR TITLE
fix: correct 'occured' typo in error messages

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1293,7 +1293,7 @@ func (c *Cluster) Delete() error {
 	// If we are done deleting our various resources we remove the finalizer to let K8S finally delete the Postgres CR
 	if anyErrors {
 		c.eventRecorder.Event(c.GetReference(), v1.EventTypeWarning, "Delete", "some resources could be successfully deleted yet")
-		return fmt.Errorf("some error(s) occured when deleting resources, NOT removing finalizer yet")
+		return fmt.Errorf("some error(s) occurred when deleting resources, NOT removing finalizer yet")
 	}
 	if err := c.removeFinalizer(); err != nil {
 		return fmt.Errorf("done cleaning up, but error when removing finalizer: %v", err)

--- a/pkg/cluster/volumes.go
+++ b/pkg/cluster/volumes.go
@@ -39,7 +39,7 @@ func (c *Cluster) syncVolumes() error {
 		} else {
 			err = c.syncUnderlyingEBSVolume()
 			if err != nil {
-				c.logger.Errorf("errors occured during EBS volume adjustments: %v", err)
+				c.logger.Errorf("errors occurred during EBS volume adjustments: %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes two instances of 'occured' to 'occurred' in user-visible error logs in pkg/cluster/cluster.go and pkg/cluster/volumes.go.