### PR TITLE
Add retry logic to role synchronization

### DIFF
--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -17,6 +17,7 @@ import (
 	"github.com/zalando/postgres-operator/pkg/util"
 	"github.com/zalando/postgres-operator/pkg/util/constants"
 	"github.com/zalando/postgres-operator/pkg/util/k8sutil"
+	"github.com/zalando/postgres-operator/pkg/util/retryutil"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -1510,7 +1511,18 @@ DBUSERS:
 	}
 
 	pgSyncRequests := c.userSyncStrategy.ProduceSyncRequests(dbUsers, newUsers)
-	if err = c.userSyncStrategy.ExecuteSyncRequests(pgSyncRequests, c.pgDb); err != nil {
+
+	err = retryutil.Retry(
+		constants.PostgresConnectTimeout,
+		constants.PostgresConnectRetryTimeout,
+		func() (bool, error) {
+			err2 := c.userSyncStrategy.ExecuteSyncRequests(pgSyncRequests, c.pgDb)
+			if err2 != nil {
+				return false, err2
+			}
+			return true, nil
+		})
+	if err != nil {
 		return fmt.Errorf("error executing sync statements: %v", err)
 	}
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -17,6 +17,7 @@ import (
 	"github.com/zalando/postgres-operator/v2/pkg/util"
 	"github.com/zalando/postgres-operator/v2/pkg/util/constants"
 	"github.com/zalando/postgres-operator/v2/pkg/util/k8sutil"
+	"github.com/zalando/postgres-operator/v2/pkg/util/retryutil"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -1510,7 +1511,18 @@ DBUSERS:
 	}
 
 	pgSyncRequests := c.userSyncStrategy.ProduceSyncRequests(dbUsers, newUsers)
-	if err = c.userSyncStrategy.ExecuteSyncRequests(pgSyncRequests, c.pgDb); err != nil {
+
+	err = retryutil.Retry(
+		constants.PostgresConnectTimeout,
+		constants.PostgresConnectRetryTimeout,
+		func() (bool, error) {
+			err2 := c.userSyncStrategy.ExecuteSyncRequests(pgSyncRequests, c.pgDb)
+			if err2 != nil {
+				return false, err2
+			}
+			return true, nil
+		})
+	if err != nil {
 		return fmt.Errorf("error executing sync statements: %v", err)
 	}
 


### PR DESCRIPTION
Prevents `syncRoles()` from failing during cluster startup, crash recovery, or primary failover windows.

When a PostgreSQL instance is starting up or processing WAL logs, it will accept connections but reject write operations with a `26006` read-only transaction error. Since role syncing occurs within a reconciliation loop, failing flat during this phase creates unnecessary error noise.

This adds a retry logic around `c.userSyncStrategy.ExecuteSyncRequests`  to not fail immediately.

Closes #3099