### PR TITLE
fix: makefile and scripts to also run on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,15 +29,18 @@ PKG := `go list ./... | grep -v /vendor/`
 
 ifeq ($(DEBUG),1)
 	DOCKERFILE = DebugDockerfile
-	DEBUG_POSTFIX := -debug-$(shell date hhmmss)
+	DEBUG_POSTFIX := -debug-$(shell date +"%H%M%S")
 	BUILD_FLAGS += -gcflags "-N -l"
 else
 	DOCKERFILE = Dockerfile
 endif
 
+
 ifeq ($(FRESH),1)
   DEBUG_FRESH=$(shell date +"%H-%M-%S")
 endif
+
+SED := $(shell command -v gsed 2>/dev/null || command -v sed)
 
 ifdef CDP_PULL_REQUEST_NUMBER
 	CDP_TAG := -${CDP_BUILD_VERSION}
@@ -69,8 +72,8 @@ $(GENERATED_CRDS): $(GENERATED)
 	go tool controller-gen crd:crdVersions=v1,allowDangerousTypes=true paths=./pkg/apis/acid.zalan.do/... output:crd:dir=manifests
 	@mv manifests/acid.zalan.do_postgresqls.yaml manifests/postgresql.crd.yaml
 	@# hack to use lowercase kind and listKind
-	@sed -i -e 's/kind: Postgresql/kind: postgresql/' manifests/postgresql.crd.yaml
-	@sed -i -e 's/listKind: PostgresqlList/listKind: postgresqlList/' manifests/postgresql.crd.yaml
+	@$(SED) -i -e 's/kind: Postgresql/kind: postgresql/' manifests/postgresql.crd.yaml
+	@$(SED) -i -e 's/listKind: PostgresqlList/listKind: postgresqlList/' manifests/postgresql.crd.yaml
 	@hack/adjust_postgresql_crd.sh
 	@mv manifests/acid.zalan.do_operatorconfigurations.yaml manifests/operatorconfiguration.crd.yaml
 	@mv manifests/acid.zalan.do_postgresteams.yaml manifests/postgresteam.crd.yaml

--- a/hack/adjust_postgresql_crd.sh
+++ b/hack/adjust_postgresql_crd.sh
@@ -13,12 +13,14 @@
 
 file="${1:-"manifests/postgresql.crd.yaml"}"
 
-sed -i '/^[[:space:]]*standby:$/{
+SED=$(command -v gsed 2>/dev/null || command -v sed)
+
+$SED -i '/^[[:space:]]*standby:$/{
     # Capture the indentation
     s/^\([[:space:]]*\)standby:$/\1standby:\n\1  anyOf:\n\1  - required:\n\1    - s3_wal_path\n\1  - required:\n\1    - gs_wal_path\n\1  - required:\n\1    - standby_host\n\1  not:\n\1    required:\n\1    - s3_wal_path\n\1    - gs_wal_path/
 }' "$file"
 
-sed -i '/^[[:space:]]*maintenanceWindows:$/{
+$SED -i '/^[[:space:]]*maintenanceWindows:$/{
     # Capture the indentation
     s/^\([[:space:]]*\)maintenanceWindows:$/\1maintenanceWindows:\n\1  items:\n\1    pattern: '\''^\\ *((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\\d):([0-5]?\\d)|(2[0-3]|[01]?\\d):([0-5]?\\d))-((2[0-3]|[01]?\\d):([0-5]?\\d)|(2[0-3]|[01]?\\d):([0-5]?\\d))\\ *$'\''\n\1    type: string/
 }' "$file"


### PR DESCRIPTION
adjust makefile and scripts to also run on macos:

- use POSIX date format command to also work on macos
- using SED that try to use gsed (gnu-seed) for macos