### PR TITLE
add env var for spilo with irsa

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2214,6 +2214,11 @@ func (c *Cluster) generateCloneEnvironment(description *acidv1.CloneDescription)
 		}
 	}
 
+	if c.OpConfig.IRSARoleARN != "" {
+		result = append(result, v1.EnvVar{Name: "CLONE_AWS_ROLE_ARN", Value: c.OpConfig.IRSARoleARN})
+		result = append(result, v1.EnvVar{Name: "CLONE_AWS_WEB_IDENTITY_TOKEN_FILE", Value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"})
+	}
+
 	return result
 }
 
@@ -2257,6 +2262,11 @@ func (c *Cluster) generateStandbyEnvironment(description *acidv1.StandbyDescript
 		})
 		result = append(result, v1.EnvVar{Name: "STANDBY_METHOD", Value: "STANDBY_WITH_WALE"})
 		result = append(result, v1.EnvVar{Name: "STANDBY_WAL_BUCKET_SCOPE_PREFIX", Value: ""})
+	}
+
+	if c.OpConfig.IRSARoleARN != "" {
+		result = append(result, v1.EnvVar{Name: "STANDBY_AWS_ROLE_ARN", Value: c.OpConfig.IRSARoleARN})
+		result = append(result, v1.EnvVar{Name: "STANDBY_AWS_WEB_IDENTITY_TOKEN_FILE", Value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"})
 	}
 
 	return result


### PR DESCRIPTION
### Problem detected on smoke tests

Standby and clone clusters fail to bootstrap when the operator is configured with IRSA (irsa_role_arn). Patroni exits with PatroniFatalException: Failed to bootstrap cluster after wal-g repeatedly fails with NoCredentialProviders.

Root cause: The EKS admission webhook injects AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE into the pod environment (bare, unprefixed). Spilo's configure_spilo.py writes these into the main envdir (/run/etc/wal-e.d/env/) correctly, but for standby and clone it looks for the prefixed versions (STANDBY_AWS_ROLE_ARN, CLONE_AWS_ROLE_ARN) which are never set. wal-g runs under envdir which replaces the entire environment with only the files in the target directory — so without the prefixed vars being written there, wal-g has no credentials.

### Proposed Fix

In generateCloneEnvironment() and generateStandbyEnvironment() in pkg/cluster/k8sres.go, when IRSARoleARN is configured, add the prefixed IRSA env vars to the pod spec:

- CLONE_AWS_ROLE_ARN / CLONE_AWS_WEB_IDENTITY_TOKEN_FILE
- STANDBY_AWS_ROLE_ARN / STANDBY_AWS_WEB_IDENTITY_TOKEN_FILE

Spilo then finds these in the pod environment and writes them into the respective envdirs, giving wal-g valid IRSA credentials for S3 access.

This is the PR created for spilo: https://github.com/zalando/spilo/pull/1206