### PR TITLE
update docker build commands in Makefiles to use buildx

### DIFF
--- a/.github/ISSUE_TEMPLATE/postgres-operator-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/postgres-operator-issue-template.md
@@ -9,7 +9,7 @@ assignees: ''
 
 Please, answer some short questions which should help us to understand your problem / question better?
 
-- **Which image of the operator are you using?** e.g. ghcr.io/zalando/postgres-operator:v1.15.1
+- **Which image of the operator are you using?** e.g. ghcr.io/zalando/postgres-operator:v2.0.0
 - **Where do you run it - cloud or metal? Kubernetes or OpenShift?** [AWS K8s | GCP ... | Bare Metal K8s]
 - **Are you running Postgres Operator in production?** [yes | no]
 - **Type of issue?** [Bug report, question, feature request, etc.]

--- a/.github/ISSUE_TEMPLATE/postgres-operator-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/postgres-operator-issue-template.md
@@ -9,7 +9,7 @@ assignees: ''
 
 Please, answer some short questions which should help us to understand your problem / question better?
 
-- **Which image of the operator are you using?** e.g. ghcr.io/zalando/postgres-operator:v2.0.0
+- **Which image of the operator are you using?** e.g. ghcr.io/zalando/postgres-operator:v1.15.1
 - **Where do you run it - cloud or metal? Kubernetes or OpenShift?** [AWS K8s | GCP ... | Bare Metal K8s]
 - **Are you running Postgres Operator in production?** [yes | no]
 - **Type of issue?** [Bug report, question, feature request, etc.]

--- a/Makefile
+++ b/Makefile
@@ -101,10 +101,10 @@ docker: $(GENERATED_CRDS) ${DOCKERDIR}/${DOCKERFILE}
 	echo "Version ${VERSION}"
 	echo "CDP tag ${CDP_TAG}"
 	echo "git describe $(shell git describe --tags --always --dirty)"
-	docker build --rm -t "$(IMAGE_TAG)" -f "${DOCKERDIR}/${DOCKERFILE}" --build-arg VERSION="${VERSION}" --build-arg BASE_IMAGE="${BASE_IMAGE}" .
+	docker buildx build --load --rm -t "$(IMAGE_TAG)" -f "${DOCKERDIR}/${DOCKERFILE}" --build-arg VERSION="${VERSION}" --build-arg BASE_IMAGE="${BASE_IMAGE}" .
 
 pooler:
-	cd pooler; docker build --rm -t "$(POOLER_TAG)" --build-arg VERSION="${VERSION}" --build-arg BASE_IMAGE="${BASE_IMAGE}" .
+	cd pooler; docker buildx build --load --rm -t "$(POOLER_TAG)" --build-arg VERSION="${VERSION}" --build-arg BASE_IMAGE="${BASE_IMAGE}" .
 
 indocker-race:
 	docker run --rm -v "${GOPATH}":"${GOPATH}" -e GOPATH="${GOPATH}" -e RACE=1 -w ${PWD} golang:1.26.4 bash -c "make linux"

--- a/charts/postgres-operator/crds/postgresqls.yaml
+++ b/charts/postgres-operator/crds/postgresqls.yaml
@@ -457,6 +457,7 @@ spec:
               envFrom:
                 items:
                   description: EnvFromSource represents the source of a set of ConfigMaps
+                    or Secrets
                   properties:
                     configMapRef:
                       description: The ConfigMap to select from
@@ -476,8 +477,9 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     prefix:
-                      description: An optional identifier to prepend to each key in
-                        the ConfigMap. Must be a C_IDENTIFIER.
+                      description: |-
+                        Optional text to prepend to the name of each environment variable.
+                        May consist of any printable ASCII characters except '='.
                       type: string
                     secretRef:
                       description: The Secret to select from
@@ -498,7 +500,6 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
               initContainers:
                 items:
                   description: A single application container that you want to run

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,12 +8,11 @@ ARG TARGETARCH
 COPY  . /go/src/github.com/zalando/postgres-operator
 WORKDIR /go/src/github.com/zalando/postgres-operator
 
-RUN go clean -cache -modcache
 RUN go mod vendor \
     && CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o build/postgres-operator -v -ldflags "-X=main.version=${VERSION}" cmd/main.go
 
 ARG BASE_IMAGE
-FROM --platform=$TARGETPLATFORM ${BASE_IMAGE}
+FROM ${BASE_IMAGE}
 LABEL maintainer="Team ACID @ Zalando <team-acid@zalando.de>"
 LABEL org.opencontainers.image.source="https://github.com/zalando/postgres-operator"
 

--- a/docker/build_operator.sh
+++ b/docker/build_operator.sh
@@ -26,6 +26,5 @@ export PATH="$PATH:$HOME/go/bin"
 export GOPATH="$HOME/go"
 mkdir -p build
 
-go clean -cache -modcache
 go mod vendor
 CGO_ENABLED=0 go build -o build/postgres-operator -v -ldflags "$OPERATOR_LDFLAGS" cmd/main.go

--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -1565,7 +1565,7 @@ make docker
 
 # build in image in minikube docker env
 eval $(minikube docker-env)
-docker build -t ghcr.io/zalando/postgres-operator-ui:v1.15.1 .
+docker buildx build --load -t ghcr.io/zalando/postgres-operator-ui:v1.15.1 .
 
 # apply UI manifests next to a running Postgres Operator
 kubectl apply -f manifests/

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -30,8 +30,7 @@ git clone https://github.com/zalando/postgres-operator.git
 We use [Go Modules](https://github.com/golang/go/wiki/Modules) for handling dependencies.
 Run `go mod vendor && go mod tidy` to install them.
 
-Build the operator with the `make docker` command. You may define the TAG variable to assign an explicit tag to your Docker image and the IMAGE to set the image name. By default, the tag is computed with
-`git describe --tags --always --dirty` and the image is `ghcr.io/zalando/postgres-operator`. On macos search and replace `sed -i` commands with `sed -i ''` for the make commands to work.
+Build the operator with the `make docker` command. You may define the TAG variable to assign an explicit tag to your Docker image and the IMAGE to set the image name. By default, the tag is computed with `git describe --tags --always --dirty` and the image is `ghcr.io/zalando/postgres-operator`.
 
 ```bash
 export TAG=$(git describe --tags --always --dirty)

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -3,7 +3,7 @@
 FROM python:3.11-slim
 LABEL maintainer="Team ACID @ Zalando <team-acid@zalando.de>"
 
-ENV TERM xterm-256color
+ENV TERM=xterm-256color
 
 RUN apt-get -qq -y update \
  # https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -37,7 +37,7 @@ copy: clean
 	mkdir tls
 
 docker:
-	docker build -t "$(IMAGE):$(TAG)" .
+	docker buildx build --load --rm -t "$(IMAGE):$(TAG)" .
 
 push: docker
 	docker push "$(IMAGE):$(TAG)"


### PR DESCRIPTION
docker build is already deprecated so we switch to docker buildx like in the GitHub actions. This needs to be reflected in the docs, too.

I ran into some memory issues locally and got the recommendation to remove go clean -cache -modcache commands again, as it would try to allocate more memory.

This PR also does a small update to the postgresql CRD in the charts directory to make unit tests work. Was an oversight of a previous merge.