### PR TITLE
Fix no space left error during e2e test setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/postgres-operator-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/postgres-operator-issue-template.md
@@ -9,7 +9,7 @@ assignees: ''
 
 Please, answer some short questions which should help us to understand your problem / question better?
 
-- **Which image of the operator are you using?** e.g. ghcr.io/zalando/postgres-operator:v1.15.1
+- **Which image of the operator are you using?** e.g. ghcr.io/zalando/postgres-operator:v2.0.0
 - **Where do you run it - cloud or metal? Kubernetes or OpenShift?** [AWS K8s | GCP ... | Bare Metal K8s]
 - **Are you running Postgres Operator in production?** [yes | no]
 - **Type of issue?** [Bug report, question, feature request, etc.]

--- a/.github/ISSUE_TEMPLATE/postgres-operator-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/postgres-operator-issue-template.md
@@ -9,7 +9,7 @@ assignees: ''
 
 Please, answer some short questions which should help us to understand your problem / question better?
 
-- **Which image of the operator are you using?** e.g. ghcr.io/zalando/postgres-operator:v2.0.0
+- **Which image of the operator are you using?** e.g. ghcr.io/zalando/postgres-operator:v1.15.1
 - **Where do you run it - cloud or metal? Kubernetes or OpenShift?** [AWS K8s | GCP ... | Bare Metal K8s]
 - **Are you running Postgres Operator in production?** [yes | no]
 - **Type of issue?** [Bug report, question, feature request, etc.]

--- a/.github/workflows/run_e2e.yaml
+++ b/.github/workflows/run_e2e.yaml
@@ -21,5 +21,12 @@ jobs:
       run: make codegen
     - name: Run unit tests
       run: make test
+    - name: Pre-pull heavy images directly on Kind nodes
+      run: |
+        FOR_NODE=$(kind get nodes --name postgres-operator-e2e-tests 2>/dev/null || true)
+        for node in $FOR_NODE; do
+          echo "Pulling Spilo image on node $node..."
+          docker exec "$node" crictl pull ghcr.io/zalando/spilo-18:4.1-p2
+        done
     - name: Run end-2-end tests
       run: make e2e

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Convert coverage to lcov
       uses: jandelgado/gcov2lcov-action@v1.2.0
     - name: Coveralls
-      uses: coverallsapp/github-action@v2
+      uses: coverallsapp/github-action@v2.3.4
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         file: coverage.lcov

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -22,9 +22,9 @@ jobs:
     - name: Run unit tests
       run: go test -race -covermode atomic -coverprofile=coverage.out ./...
     - name: Convert coverage to lcov
-      uses: jandelgado/gcov2lcov-action@v1.1.1
+      uses: jandelgado/gcov2lcov-action@v1.2.0
     - name: Coveralls
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: coverage.lcov
+        file: coverage.lcov

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -24,6 +24,15 @@ esac
 echo "Clustername: ${cluster_name}"
 echo "Kubeconfig path: ${kubeconfig_path}"
 
+# Helper function to pull images directly into kind nodes via crictl (bypasses host disk duplication)
+function pull_on_kind_nodes() {
+  local img="$1"
+  echo "Pulling ${img} directly on kind nodes..."
+  for node in $(kind get nodes --name "${cluster_name}"); do
+    docker exec "$node" crictl pull "${img}"
+  done
+}
+
 function pull_images(){
   operator_tag=$(git describe --tags --always --dirty)
   components=("postgres-operator" "pooler")
@@ -66,14 +75,14 @@ function start_kind(){
   export KUBECONFIG="${kubeconfig_path}"
   kind create cluster --name ${cluster_name} --config kind-cluster-postgres-operator-e2e-tests.yaml  
   
-  echo "Pulling Spilo image for platform ${PLATFORM}"
-  docker pull --platform ${PLATFORM} "${spilo_image}"
-  kind load docker-image "${spilo_image}" --name ${cluster_name}
+  echo "Pulling Spilo image on kind nodes directly..."
+  pull_on_kind_nodes "${spilo_image}"
 }
 
 function load_operator_images() {
   echo "Loading operator images"
   export KUBECONFIG="${kubeconfig_path}"
+  # For locally built operator images, kind load is still fine since they're light
   kind load docker-image "${operator_image}" --name ${cluster_name}
   kind load docker-image "${pooler_image}" --name ${cluster_name}
 }


### PR DESCRIPTION
Current e2e test runs report the following issue:

```
ERROR: failed to load image: command "docker exec --privileged -i postgres-operator-e2e-tests-worker ctr --namespace=k8s.io images import --all-platforms --digests --snapshotter=overlayfs -" failed with error: exit status 1
```

Using kind load image is a potential space waster and switching to ctr to directly load Spilo into the kind nodes could fix it.