### PR TITLE
fix type deference when calling ebs modify volume endpoint

### DIFF
--- a/pkg/util/volumes/ebs.go
+++ b/pkg/util/volumes/ebs.go
@@ -171,7 +171,15 @@ func (r *EBSVolumeResizer) ModifyVolume(volumeID string, newType *string, newSiz
 		t := int32(*throughput)
 		throughputInt32 = &t
 	}
-	input := ec2.ModifyVolumeInput{Size: sizeInt32, VolumeId: &volumeID, VolumeType: types.VolumeType(*newType), Iops: iopsInt32, Throughput: throughputInt32}
+	input := ec2.ModifyVolumeInput{
+		Size:       sizeInt32,
+		VolumeId:   &volumeID,
+		Iops:       iopsInt32,
+		Throughput: throughputInt32,
+	}
+	if newType != nil {
+		input.VolumeType = types.VolumeType(*newType)
+	}
 	output, err := r.connection.ModifyVolume(context.TODO(), &input)
 	if err != nil {
 		return fmt.Errorf("could not modify persistent volume: %v", err)

--- a/pkg/util/volumes/ebs.go
+++ b/pkg/util/volumes/ebs.go
@@ -155,31 +155,32 @@ func (r *EBSVolumeResizer) ResizeVolume(volumeID string, newSize int64) error {
 
 // ModifyVolume Modify EBS volume
 func (r *EBSVolumeResizer) ModifyVolume(volumeID string, newType *string, newSize *int64, iops *int64, throughput *int64) error {
-	/* first check if the volume is already of a requested size */
 	var sizeInt32 *int32
 	var iopsInt32 *int32
 	var throughputInt32 *int32
+
+	input := ec2.ModifyVolumeInput{
+		VolumeId: &volumeID,
+	}
 	if newSize != nil {
 		s := int32(*newSize)
 		sizeInt32 = &s
+		input.Size = sizeInt32
 	}
 	if iops != nil {
 		i := int32(*iops)
 		iopsInt32 = &i
+		input.Iops = iopsInt32
 	}
 	if throughput != nil {
 		t := int32(*throughput)
 		throughputInt32 = &t
-	}
-	input := ec2.ModifyVolumeInput{
-		Size:       sizeInt32,
-		VolumeId:   &volumeID,
-		Iops:       iopsInt32,
-		Throughput: throughputInt32,
+		input.Throughput = throughputInt32
 	}
 	if newType != nil {
 		input.VolumeType = types.VolumeType(*newType)
 	}
+
 	output, err := r.connection.ModifyVolume(context.TODO(), &input)
 	if err != nil {
 		return fmt.Errorf("could not modify persistent volume: %v", err)


### PR DESCRIPTION
Updating AWS SDK dependency in https://github.com/zalando/postgres-operator/pull/3108 introduced a bug with syncing EBS volumes. Previously calling modify volume endpoint allowed for leaving the volume type to nil. But since it was changed to an enum in v2 our operator crashes when trying to dereference the VolumeType. The solution is to not pass the type information to the endpoint when it's set.

trying to fix the following problem:
```
time="2026-07-24T14:31:50Z" level=debug msg="starting to sync EBS volumes: type, iops, throughput, and size" cluster-name=default/test-volume-resize pkg=cluster
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2298108]

goroutine 82 [running]:
github.com/zalando/postgres-operator/pkg/util/volumes.(*EBSVolumeResizer).ModifyVolume(0x32aebfc26858, {0x32aec252e888, 0x15}, 0x0, 0x32aec26dbda8, 0x0, 0x0)
        /go/src/github.com/zalando/postgres-operator/pkg/util/volumes/ebs.go:174 +0x148
github.com/zalando/postgres-operator/pkg/cluster.(*Cluster).syncUnderlyingEBSVolume(0x32aebf9af908)
        /go/src/github.com/zalando/postgres-operator/pkg/cluster/volumes.go:123 +0x3ac
github.com/zalando/postgres-operator/pkg/cluster.(*Cluster).syncVolumes(0x32aebf9af908)
        /go/src/github.com/zalando/postgres-operator/pkg/cluster/volumes.go:40 +0x164
github.com/zalando/postgres-operator/pkg/cluster.(*Cluster).Sync(0x32aebf9af908, 0x32aebf9d7408)
        /go/src/github.com/zalando/postgres-operator/pkg/cluster/sync.go:99 +0x45c
github.com/zalando/postgres-operator/pkg/controller.(*Controller).processEvent(0x32aebfc22008, {{0xc290fbaadc465a1f, 0x4fdd334, 0x4897f80}, {0x32aebfc5d110, 0x24}, {0x2c0af57, 0x4}, 0x0, 0x32aebf9d7408, ...}, ...)
        /go/src/github.com/zalando/postgres-operator/pkg/controller/postgresql.go:345 +0xc3c
github.com/zalando/postgres-operator/pkg/controller.(*Controller).processClusterEventsQueue.func2({0x2a70460, 0x32aebfb58be0}, 0x50?)
        /go/src/github.com/zalando/postgres-operator/pkg/controller/postgresql.go:372 +0xcc
k8s.io/client-go/tools/cache.(*FIFO).Pop(0x32aebfd06b40, 0x32aebfd47778)
        /go/src/github.com/zalando/postgres-operator/vendor/k8s.io/client-go/tools/cache/fifo.go:274 +0x1d0
github.com/zalando/postgres-operator/pkg/controller.(*Controller).processClusterEventsQueue(0x32aebfc22008, 0xa, 0x32aebf8ac7e0, 0x0?)
        /go/src/github.com/zalando/postgres-operator/pkg/controller/postgresql.go:366 +0xd4
created by github.com/zalando/postgres-operator/pkg/controller.(*Controller).Run in goroutine 1
        /go/src/github.com/zalando/postgres-operator/pkg/controller/controller.go:442 +0x4c
```