### PR TITLE
Use maxUnavailable for the critical-op PDB to stop idle alert noise

### DIFF
--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -653,8 +653,14 @@ The PDB is only relaxed in two scenarios:
 * If a cluster is scaled down to `0` instances (e.g. for draining nodes)
 * If the PDB is disabled in the configuration (`enable_pod_disruption_budget`)
 
-The PDBs are still in place: the primary PDB with `MinAvailable` set to `0` and the
-critical operations PDB with `MaxUnavailable` set to `100%`. Disabling PDBs
+The PDBs are still in place but fully relaxed: the primary PDB with `MinAvailable`
+set to `0` and the critical operations PDB with `MaxUnavailable` set to `100%`.
+The two PDBs intentionally use different budget fields matching their purposes:
+the primary PDB guarantees a minimum count of always-present pods
+(`MinAvailable`), while the critical operations PDB freezes disruptions for
+whatever pods currently carry the `critical-operation=true` label - a
+usually-empty set, which `MaxUnavailable: 0` expresses without producing an
+unsatisfiable budget while idle. Disabling PDBs
 helps avoiding blocking Kubernetes upgrades in managed K8s environments at the
 cost of prolonged DB downtime. See PR [#384](https://github.com/zalando/postgres-operator/pull/384)
 for the use case.

--- a/docs/administrator.md
+++ b/docs/administrator.md
@@ -639,9 +639,11 @@ masters in single-node clusters and/or the last remaining running instance in a 
 cluster.
 
 ## PDB for critical operations
-The `MinAvailable` parameter of this PDB is equal to the `numberOfInstances` set in the
-cluster manifest, while label selector includes `critical-operation=true` condition. This
-allows to protect all pods of a cluster, given they are labeled accordingly.
+The `MaxUnavailable` parameter of this PDB is set to `0`, while label selector includes
+`critical-operation=true` condition. This blocks voluntary disruptions for all pods of a
+cluster that are labeled accordingly, without leaving an unsatisfiable budget behind when
+no pods carry the label (which previously kept monitoring alerts like
+`KubePdbNotEnoughHealthyPods` firing permanently).
 For example, Operator labels all Spilo pods with `critical-operation=true` during the major
 version upgrade run. You may want to protect cluster pods during other critical operations
 by assigning the label to pods yourself or using other means of automation.
@@ -651,7 +653,8 @@ The PDB is only relaxed in two scenarios:
 * If a cluster is scaled down to `0` instances (e.g. for draining nodes)
 * If the PDB is disabled in the configuration (`enable_pod_disruption_budget`)
 
-The PDBs are still in place having `MinAvailable` set to `0`. Disabling PDBs
+The PDBs are still in place: the primary PDB with `MinAvailable` set to `0` and the
+critical operations PDB with `MaxUnavailable` set to `100%`. Disabling PDBs
 helps avoiding blocking Kubernetes upgrades in managed K8s environments at the
 cost of prolonged DB downtime. See PR [#384](https://github.com/zalando/postgres-operator/pull/384)
 for the use case.

--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2315,12 +2315,18 @@ func (c *Cluster) generatePrimaryPodDisruptionBudget() *policyv1.PodDisruptionBu
 }
 
 func (c *Cluster) generateCriticalOpPodDisruptionBudget() *policyv1.PodDisruptionBudget {
-	minAvailable := intstr.FromInt32(c.Spec.NumberOfInstances)
+	// MaxUnavailable: 0 blocks voluntary disruption of any pod carrying the
+	// critical-operation label, while keeping the budget satisfied when no
+	// pod matches (status.desiredHealthy stays 0 outside critical
+	// operations). The previous MinAvailable: N spec left desiredHealthy at
+	// N with zero matching pods during normal operation, permanently firing
+	// alerts like kube-prometheus-stack's KubePdbNotEnoughHealthyPods (#3020).
+	maxUnavailable := intstr.FromInt32(0)
 	pdbEnabled := c.OpConfig.EnablePodDisruptionBudget
 
-	// if PodDisruptionBudget is disabled or if there are no DB pods, set the budget to 0.
+	// if PodDisruptionBudget is disabled or if there are no DB pods, allow all disruptions.
 	if (pdbEnabled != nil && !(*pdbEnabled)) || c.Spec.NumberOfInstances <= 0 {
-		minAvailable = intstr.FromInt(0)
+		maxUnavailable = intstr.FromString("100%")
 	}
 
 	labels := c.labelsSet(false)
@@ -2335,7 +2341,7 @@ func (c *Cluster) generateCriticalOpPodDisruptionBudget() *policyv1.PodDisruptio
 			OwnerReferences: c.ownerReferences(),
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
-			MinAvailable: &minAvailable,
+			MaxUnavailable: &maxUnavailable,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -2556,6 +2556,17 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 		}
 	}
 
+	hasMaxUnavailable := func(expected string) func(cluster *Cluster, podDisruptionBudget *policyv1.PodDisruptionBudget) error {
+		return func(cluster *Cluster, podDisruptionBudget *policyv1.PodDisruptionBudget) error {
+			actual := podDisruptionBudget.Spec.MaxUnavailable.String()
+			if actual != expected {
+				return fmt.Errorf("PodDisruptionBudget MaxUnavailable is incorrect, got %s, expected %s",
+					actual, expected)
+			}
+			return nil
+		}
+	}
+
 	hasMinAvailable := func(expectedMinAvailable int) func(cluster *Cluster, podDisruptionBudget *policyv1.PodDisruptionBudget) error {
 		return func(cluster *Cluster, podDisruptionBudget *policyv1.PodDisruptionBudget) error {
 			actual := podDisruptionBudget.Spec.MinAvailable.IntVal
@@ -2749,7 +2760,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 			check: []func(cluster *Cluster, podDisruptionBudget *policyv1.PodDisruptionBudget) error{
 				testPodDisruptionBudgetOwnerReference,
 				hasName("postgres-myapp-database-critical-op-pdb"),
-				hasMinAvailable(3),
+				hasMaxUnavailable("0"),
 				testLabelsAndSelectors(false),
 			},
 		},
@@ -2766,7 +2777,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 			check: []func(cluster *Cluster, podDisruptionBudget *policyv1.PodDisruptionBudget) error{
 				testPodDisruptionBudgetOwnerReference,
 				hasName("postgres-myapp-database-critical-op-pdb"),
-				hasMinAvailable(0),
+				hasMaxUnavailable("100%"),
 				testLabelsAndSelectors(false),
 			},
 		},
@@ -2783,7 +2794,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 			check: []func(cluster *Cluster, podDisruptionBudget *policyv1.PodDisruptionBudget) error{
 				testPodDisruptionBudgetOwnerReference,
 				hasName("postgres-myapp-database-critical-op-pdb"),
-				hasMinAvailable(0),
+				hasMaxUnavailable("100%"),
 				testLabelsAndSelectors(false),
 			},
 		},
@@ -2800,7 +2811,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 			check: []func(cluster *Cluster, podDisruptionBudget *policyv1.PodDisruptionBudget) error{
 				testPodDisruptionBudgetOwnerReference,
 				hasName("postgres-myapp-database-critical-op-pdb"),
-				hasMinAvailable(3),
+				hasMaxUnavailable("0"),
 				testLabelsAndSelectors(false),
 			},
 		},


### PR DESCRIPTION
## Problem description

Since v1.15.0 the operator creates `postgres-<cluster>-critical-op-pdb` with `minAvailable: <numberOfInstances>` and a selector matching pods labeled `critical-operation=true`. During normal operation no pods carry that label, so the PDB's status is permanently `currentHealthy: 0, desiredHealthy: N` - an unsatisfiable budget. Kubernetes behavior is unaffected (no matched pods, nothing to block), but monitoring stacks alert on exactly this condition: kube-prometheus-stack's `KubePdbNotEnoughHealthyPods` fires forever on every idle cluster.

This PR expresses the same protection as `maxUnavailable: 0` instead:

- During critical operations, behavior is identical - zero voluntary evictions permitted among labeled pods.
- While idle, the budget is satisfied (`desiredHealthy` = matched - 0 = 0) - no alert.
- When PDBs are disabled (`enable_pod_disruption_budget: false`) or instances are scaled to zero, the budget relaxes to `maxUnavailable: "100%"`, replacing the previous `minAvailable: 0`.

Compared to #3024 (on-demand create/delete around operations, later abandoned), this keeps the PDB persistent - no lifecycle choreography and no leaked unsatisfiable PDB if the operator restarts mid-operation - and only changes the budget field.

**Behavioral note:** no user-facing configuration changes; what changes is the field used inside the operator-generated (and operator-owned, reconciled) PDB resource. Blocking semantics are equivalent for every labeling state; any external tooling reading `spec.minAvailable` off this specific PDB would observe the new shape after upgrading.

## Testing

Beyond the updated unit tests, the patched image was deployed to a real 7-node k3s v1.36.2 cluster running an operator-managed postgres: with PDBs enabled, the critical-op PDB is created with `maxUnavailable: 0` and reports a satisfied status while idle (`desiredHealthy: 0` - the #3020 alert can no longer fire); labeling a pod `critical-operation=true` engages the budget (`allowedDisruptions: 0`) and eviction of the labeled pod is denied; the budget remains satisfied during the operation, so no false alert fires mid-operation either.

*Disclosure: this patch was authored with AI assistance (Claude, via Claude Code), reviewed and submitted by a human.*

## Linked issues

Fixes #3020. Alternative to the abandoned #3024.

## Checklist

Thanks for submitting a pull request to the Postgres Operator project.
Please, ensure your contribution matches the following items:

- [x] Your go code is formatted
- [x] You have updated generated code when introducing new fields to the `acid.zalan.do` api package (n/a - no API changes)
- [x] New configuration options are reflected in CRD validation, helm charts and sample manifests (n/a - no new options)
- [x] New functionality is covered by unit and/or e2e tests (critical-op PDB unit test scenarios updated; `go test ./pkg/cluster/` passes)
- [x] You have checked existing open PRs for possible overlay and referenced them (#3024)