### PR TITLE
Fix operatorconfigurations CRD: render NamespacedName fields as type string

### DIFF
--- a/charts/postgres-operator/crds/operatorconfigurations.yaml
+++ b/charts/postgres-operator/crds/operatorconfigurations.yaml
@@ -226,24 +226,7 @@ spec:
                       type: string
                     type: array
                   infrastructure_roles_secret_name:
-                    description: |-
-                      NamespacedName comprises a resource name, with a mandatory namespace,
-                      rendered as "<namespace>/<name>".  Being a type captures intent and
-                      helps make sure that UIDs, namespaced names and non-namespaced names
-                      do not get conflated in code.  For most use cases, namespace and name
-                      will already have been format validated at the API entry point, so we
-                      don't do that here.  Where that's not the case (e.g. in testing),
-                      consider using NamespacedNameOrDie() in testing.go in this package.
-
-                      from: https://github.com/kubernetes/apimachinery/blob/master/pkg/types/namespacedname.go
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - name
-                    type: object
+                    type: string
                   infrastructure_roles_secrets:
                     description: namespaced name of the secret containing infrastructure
                       roles names and passwords
@@ -265,14 +248,7 @@ spec:
                           description: |-
                             Name of a secret which describes the role, and optionally name of a
                             configmap with an extra information
-                          properties:
-                            name:
-                              type: string
-                            namespace:
-                              type: string
-                          required:
-                          - name
-                          type: object
+                          type: string
                         template:
                           type: boolean
                         userkey:
@@ -458,14 +434,7 @@ spec:
                     default: postgres-operator
                     description: namespaced name of the secret containing the OAuth2
                       token to pass to the teams API
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - name
-                    type: object
+                    type: string
                   pdb_master_label_selector:
                     default: true
                     type: boolean
@@ -485,14 +454,7 @@ spec:
                   pod_environment_configmap:
                     description: namespaced name of the ConfigMap with environment
                       variables to populate on every pod
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - name
-                    type: object
+                    type: string
                   pod_environment_secret:
                     type: string
                   pod_management_policy:

--- a/manifests/operatorconfiguration.crd.yaml
+++ b/manifests/operatorconfiguration.crd.yaml
@@ -226,24 +226,7 @@ spec:
                       type: string
                     type: array
                   infrastructure_roles_secret_name:
-                    description: |-
-                      NamespacedName comprises a resource name, with a mandatory namespace,
-                      rendered as "<namespace>/<name>".  Being a type captures intent and
-                      helps make sure that UIDs, namespaced names and non-namespaced names
-                      do not get conflated in code.  For most use cases, namespace and name
-                      will already have been format validated at the API entry point, so we
-                      don't do that here.  Where that's not the case (e.g. in testing),
-                      consider using NamespacedNameOrDie() in testing.go in this package.
-
-                      from: https://github.com/kubernetes/apimachinery/blob/master/pkg/types/namespacedname.go
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - name
-                    type: object
+                    type: string
                   infrastructure_roles_secrets:
                     description: namespaced name of the secret containing infrastructure
                       roles names and passwords
@@ -265,14 +248,7 @@ spec:
                           description: |-
                             Name of a secret which describes the role, and optionally name of a
                             configmap with an extra information
-                          properties:
-                            name:
-                              type: string
-                            namespace:
-                              type: string
-                          required:
-                          - name
-                          type: object
+                          type: string
                         template:
                           type: boolean
                         userkey:
@@ -458,14 +434,7 @@ spec:
                     default: postgres-operator
                     description: namespaced name of the secret containing the OAuth2
                       token to pass to the teams API
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - name
-                    type: object
+                    type: string
                   pdb_master_label_selector:
                     default: true
                     type: boolean
@@ -485,14 +454,7 @@ spec:
                   pod_environment_configmap:
                     description: namespaced name of the ConfigMap with environment
                       variables to populate on every pod
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - name
-                    type: object
+                    type: string
                   pod_environment_secret:
                     type: string
                   pod_management_policy:

--- a/pkg/apis/acid.zalan.do/v1/operatorconfiguration.crd.yaml
+++ b/pkg/apis/acid.zalan.do/v1/operatorconfiguration.crd.yaml
@@ -226,24 +226,7 @@ spec:
                       type: string
                     type: array
                   infrastructure_roles_secret_name:
-                    description: |-
-                      NamespacedName comprises a resource name, with a mandatory namespace,
-                      rendered as "<namespace>/<name>".  Being a type captures intent and
-                      helps make sure that UIDs, namespaced names and non-namespaced names
-                      do not get conflated in code.  For most use cases, namespace and name
-                      will already have been format validated at the API entry point, so we
-                      don't do that here.  Where that's not the case (e.g. in testing),
-                      consider using NamespacedNameOrDie() in testing.go in this package.
-
-                      from: https://github.com/kubernetes/apimachinery/blob/master/pkg/types/namespacedname.go
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - name
-                    type: object
+                    type: string
                   infrastructure_roles_secrets:
                     description: namespaced name of the secret containing infrastructure
                       roles names and passwords
@@ -265,14 +248,7 @@ spec:
                           description: |-
                             Name of a secret which describes the role, and optionally name of a
                             configmap with an extra information
-                          properties:
-                            name:
-                              type: string
-                            namespace:
-                              type: string
-                          required:
-                          - name
-                          type: object
+                          type: string
                         template:
                           type: boolean
                         userkey:
@@ -458,14 +434,7 @@ spec:
                     default: postgres-operator
                     description: namespaced name of the secret containing the OAuth2
                       token to pass to the teams API
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - name
-                    type: object
+                    type: string
                   pdb_master_label_selector:
                     default: true
                     type: boolean
@@ -485,14 +454,7 @@ spec:
                   pod_environment_configmap:
                     description: namespaced name of the ConfigMap with environment
                       variables to populate on every pod
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - name
-                    type: object
+                    type: string
                   pod_environment_secret:
                     type: string
                   pod_management_policy:

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -23,6 +23,11 @@ import (
 // consider using NamespacedNameOrDie() in testing.go in this package.
 //
 // from: https://github.com/kubernetes/apimachinery/blob/master/pkg/types/namespacedname.go
+//
+// NamespacedName marshals to and unmarshals from a plain JSON string
+// ("<namespace>/<name>") via its custom MarshalJSON/UnmarshalJSON, so its CRD
+// schema must be a string rather than the struct controller-gen would infer.
+// +kubebuilder:validation:Type=string
 type NamespacedName struct {
 	Namespace string `json:"namespace,omitempty"`
 	Name      string `json:"name"`


### PR DESCRIPTION
### Problem

Installing/upgrading to v2.0.0 fails at the CRD apply step. The apiserver rejects the OperatorConfiguration CRD:

```
The CustomResourceDefinition "operatorconfigurations.acid.zalan.do" is invalid:
...properties[oauth_token_secret_name].default: Invalid value: "string":
in body must be of type object
```

This blocks the whole 1.15.x → 2.0.0 upgrade before the operator Deployment is ever touched.

### Root cause

These CRDs are generated by `controller-gen` from the Go types (see the `manifests` target in the `Makefile`). `spec.NamespacedName` is a struct `{Namespace, Name}`, so controller-gen emits an **object** schema for every `NamespacedName` field. But `NamespacedName` has custom `MarshalJSON`/`UnmarshalJSON` that (de)serialize it as a plain JSON **string** `"namespace/name"`:

```go
func (n NamespacedName) MarshalJSON() ([]byte, error) {
    return []byte("\"" + n.String() + "\""), nil
}
func (n *NamespacedName) UnmarshalJSON(data []byte) error {
    var tmp string
    if err := json.Unmarshal(data, &tmp); err != nil { return err }
    // ... Decode(tmp) splits on "/"
}
```

So the generated object schema never matched how the operator actually reads and writes these fields (in 1.15.x they were `type: string`). For `oauth_token_secret_name` it becomes a hard failure, because that field also carries `// +kubebuilder:default=postgres-operator`, and a scalar string default on an object-typed property is rejected by the apiserver.

### Fix

Annotate the `NamespacedName` type itself with `// +kubebuilder:validation:Type=string` and regenerate the CRDs. controller-gen then emits `type: string` for **all** `NamespacedName` fields — `oauth_token_secret_name`, `infrastructure_roles_secret_name`, `pod_environment_configmap`, and the nested infrastructure-role `secretname` — matching their runtime serialization and restoring 1.15.x behaviour.

A field-level `+kubebuilder:validation:Type=string` override does **not** work here: it conflicts with the struct-derived schema (`conflicting types in allOf branches: object vs string`) and fails generation. The override has to be on the type.

Changes:
- `pkg/spec/types.go` — the marker (source of the fix)
- regenerated `manifests/operatorconfiguration.crd.yaml` and its two synced copies (`pkg/apis/acid.zalan.do/v1/operatorconfiguration.crd.yaml`, `charts/postgres-operator/crds/operatorconfigurations.yaml`)

The CRDs were regenerated with the pinned `controller-tools` (`go tool controller-gen ...`), so the only diff is the intended object→string change on the `NamespacedName` fields — no unrelated churn.

### Verification

Server-side dry-run apply against a real cluster:

- unpatched master CRD → rejected with the error above
- regenerated CRD → `customresourcedefinition.apiextensions.k8s.io/operatorconfigurations.acid.zalan.do configured (server dry run)`

Fixes #3143