### PR TITLE
Fix resync/repair ticker period

### DIFF
--- a/pkg/controller/postgresql.go
+++ b/pkg/controller/postgresql.go
@@ -27,7 +27,8 @@ import (
 
 func (c *Controller) clusterResync(stopCh <-chan struct{}, wg *sync.WaitGroup) {
 	defer wg.Done()
-	ticker := time.NewTicker(c.opConfig.ResyncPeriod.Duration)
+	period := min(c.opConfig.ResyncPeriod.Duration, c.opConfig.RepairPeriod.Duration)
+	ticker := time.NewTicker(period)
 
 	for {
 		select {


### PR DESCRIPTION
Hello,

This is a fix for #2321.

#304 introduced a `repair_period` (5 minutes) that is smaller than `resync_period` (30 minutes) to fix failing clusters.

However, the resync/repair ticker's period is currently set to the `resync_period`, so having a shorter `repair_period` has no effect.

This PR sets the ticker's period to the smallest value.