### PR TITLE
feat(helm): Add extraObjects value

### DIFF
--- a/charts/postgres-operator/templates/_helpers.tpl
+++ b/charts/postgres-operator/templates/_helpers.tpl
@@ -60,6 +60,18 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Render an extra object, given as a map or as a string, with Helm templating support.
+Expects a dict with "value" (the object) and "context" (the root context).
+*/}}
+{{- define "postgres-operator.renderObject" -}}
+{{- if typeIs "string" .value -}}
+{{- tpl .value .context -}}
+{{- else -}}
+{{- tpl (toYaml .value) .context -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Flatten nested config options when ConfigMap is used as ConfigTarget
 */}}
 {{- define "flattenValuesForConfigMap" }}

--- a/charts/postgres-operator/templates/extra-objects.yaml
+++ b/charts/postgres-operator/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ include "postgres-operator.renderObject" (dict "value" . "context" $) }}
+{{ end }}

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -570,3 +570,8 @@ controllerID:
   # The name of the controller ID to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+
+# Extra Kubernetes manifests to deploy alongside the operator.
+# Each entry is a full manifest, either as a map or as a string (templated with tpl,
+# so Helm templating like {{ .Release.Namespace }} can be used).
+extraObjects: []


### PR DESCRIPTION
# Add extraObjects to the Helm chart

Adds an extraObjects value that lets users deploy arbitrary manifests as part of the postgres-operator release. Defaults to [], so rendered output is unchanged for existing users.

## Why ?

We deploy the operator with ArgoCD, where the chart is the unit of deployment: ArgoCD applies what the chart renders and nothing else. But several operator settings only point at a resource the chart cannot create — pod_environment_configmap, pod_environment_secret, infrastructure_roles_secret_name, oauth_token_secret_name.

Our blocker is pod_environment_configmap: to let Patroni reach an external etcd v3, every database pod needs the etcd cert paths in its environment, which requires a ConfigMap the chart has no way to create. The alternatives — a second ArgoCD Application for one ConfigMap, a Kustomize wrapper, or an out-of-band kubectl apply — all put a resource the operator depends on outside the sync loop.

extraObjects keeps the operator and the resources it references in one self-contained release. Traefik, kube-prometheus-stack and Grafana expose the same escape hatch.

## Usage

```
extraObjects:
  - apiVersion: v1
    kind: ConfigMap
    metadata:
      name: pod-environment
      namespace: '{{ .Release.Namespace }}'
    data:
      ETCD3_CACERT: /certs/ca.crt
      ETCD3_CERT: /certs/tls.crt
      ETCD3_KEY: /certs/tls.key

configKubernetes:
  pod_environment_configmap: '{{ .Release.Namespace }}/pod-environment'
```

Entries may be maps or strings, and are rendered with tpl so Helm templating works in values.

## Testing

helm template verified for both forms, with templating expanded, and confirmed identical output to master with default values.

Thomas