### PR TITLE
clean the kube2iam annotations when the role is empty

### DIFF
--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -1783,31 +1783,22 @@ func (c *Cluster) syncLogicalBackupJob() error {
 				return fmt.Errorf("could not patch labels of the logical backup job %q: %v", jobName, err)
 			}
 		}
-		_, kubeIamInCurrent := job.Annotations[constants.KubeIAmAnnotation]
-		_, kubeIamInDesired := desiredJob.Annotations[constants.KubeIAmAnnotation]
-		kubeIamNeedsRemoval := kubeIamInCurrent && !kubeIamInDesired
-		if changed, _ := c.compareAnnotations(job.Annotations, desiredJob.Annotations, nil); changed || kubeIamNeedsRemoval {
-			patchAnnotations := make(map[string]interface{})
-			for k, v := range desiredJob.Annotations {
-				patchAnnotations[k] = v
-			}
-			if kubeIamNeedsRemoval {
-				patchAnnotations[constants.KubeIAmAnnotation] = nil
-			}
-			patchData, err := json.Marshal(map[string]interface{}{
-				"metadata": map[string]interface{}{"annotations": patchAnnotations},
-			})
+		if changed, _ := c.compareAnnotations(job.Annotations, desiredJob.Annotations, nil); changed {
+			patchData, err := metaAnnotationsPatch(desiredJob.Annotations)
 			if err != nil {
-				return fmt.Errorf("could not form patch for the logical backup job %q annotations: %v", jobName, err)
+				return fmt.Errorf("could not form patch for the logical backup job %q: %v", jobName, err)
 			}
-			_, err = c.KubeClient.CronJobs(c.Namespace).Patch(context.TODO(), jobName, types.MergePatchType, patchData, metav1.PatchOptions{})
+			_, err = c.KubeClient.CronJobs(c.Namespace).Patch(context.TODO(), jobName, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
 			if err != nil {
 				return fmt.Errorf("could not patch annotations of the logical backup job %q: %v", jobName, err)
 			}
 		}
-		if _, ok := job.Spec.JobTemplate.Annotations[constants.KubeIAmAnnotation]; ok {
-			if _, exists := desiredJob.Spec.JobTemplate.Annotations[constants.KubeIAmAnnotation]; !exists {
+		if _, ok := job.Annotations[constants.KubeIAmAnnotation]; ok {
+			if _, exists := desiredJob.Annotations[constants.KubeIAmAnnotation]; !exists {
 				patchData, err := json.Marshal(map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]*string{constants.KubeIAmAnnotation: nil},
+					},
 					"spec": map[string]interface{}{
 						"jobTemplate": map[string]interface{}{
 							"metadata": map[string]interface{}{
@@ -1817,11 +1808,11 @@ func (c *Cluster) syncLogicalBackupJob() error {
 					},
 				})
 				if err != nil {
-					return fmt.Errorf("could not form patch for the logical backup job %q job template annotations: %v", jobName, err)
+					return fmt.Errorf("could not form patch to remove kube2iam annotation from logical backup job %q: %v", jobName, err)
 				}
 				_, err = c.KubeClient.CronJobs(c.Namespace).Patch(context.TODO(), jobName, types.MergePatchType, patchData, metav1.PatchOptions{})
 				if err != nil {
-					return fmt.Errorf("could not remove kube2iam annotation from logical backup job %q job template: %v", jobName, err)
+					return fmt.Errorf("could not remove kube2iam annotation from logical backup job %q: %v", jobName, err)
 				}
 			}
 		}

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -1783,36 +1783,46 @@ func (c *Cluster) syncLogicalBackupJob() error {
 				return fmt.Errorf("could not patch labels of the logical backup job %q: %v", jobName, err)
 			}
 		}
-		if changed, _ := c.compareAnnotations(job.Annotations, desiredJob.Annotations, nil); changed {
-			patchData, err := metaAnnotationsPatch(desiredJob.Annotations)
-			if err != nil {
-				return fmt.Errorf("could not form patch for the logical backup job %q: %v", jobName, err)
+		_, kubeIamInCurrent := job.Annotations[constants.KubeIAmAnnotation]
+		_, kubeIamInDesired := desiredJob.Annotations[constants.KubeIAmAnnotation]
+		kubeIamNeedsRemoval := kubeIamInCurrent && !kubeIamInDesired
+		if changed, _ := c.compareAnnotations(job.Annotations, desiredJob.Annotations, nil); changed || kubeIamNeedsRemoval {
+			patchAnnotations := make(map[string]interface{})
+			for k, v := range desiredJob.Annotations {
+				patchAnnotations[k] = v
 			}
-			_, err = c.KubeClient.CronJobs(c.Namespace).Patch(context.TODO(), jobName, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
+			if kubeIamNeedsRemoval {
+				patchAnnotations[constants.KubeIAmAnnotation] = nil
+			}
+			patchData, err := json.Marshal(map[string]interface{}{
+				"metadata": map[string]interface{}{"annotations": patchAnnotations},
+			})
+			if err != nil {
+				return fmt.Errorf("could not form patch for the logical backup job %q annotations: %v", jobName, err)
+			}
+			_, err = c.KubeClient.CronJobs(c.Namespace).Patch(context.TODO(), jobName, types.MergePatchType, patchData, metav1.PatchOptions{})
 			if err != nil {
 				return fmt.Errorf("could not patch annotations of the logical backup job %q: %v", jobName, err)
 			}
 		}
-
-		if c.OpConfig.KubeIAMRole == "" {
-			patch, err := json.Marshal(map[string]interface{}{
-				"metadata": map[string]interface{}{
-					"annotations": map[string]*string{constants.KubeIAmAnnotation: nil},
-				},
-				"spec": map[string]interface{}{
-					"jobTemplate": map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"annotations": map[string]*string{constants.KubeIAmAnnotation: nil},
+		if _, ok := job.Spec.JobTemplate.Annotations[constants.KubeIAmAnnotation]; ok {
+			if _, exists := desiredJob.Spec.JobTemplate.Annotations[constants.KubeIAmAnnotation]; !exists {
+				patchData, err := json.Marshal(map[string]interface{}{
+					"spec": map[string]interface{}{
+						"jobTemplate": map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"annotations": map[string]*string{constants.KubeIAmAnnotation: nil},
+							},
 						},
 					},
-				},
-			})
-			if err != nil {
-				return fmt.Errorf("could not marshal kube2iam annotation removal patch for logical backup job %q: %v", jobName, err)
-			}
-			_, err = c.KubeClient.CronJobs(c.Namespace).Patch(context.TODO(), jobName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
-			if err != nil {
-				return fmt.Errorf("could not remove kube2iam annotation from logical backup job %q: %v", jobName, err)
+				})
+				if err != nil {
+					return fmt.Errorf("could not form patch for the logical backup job %q job template annotations: %v", jobName, err)
+				}
+				_, err = c.KubeClient.CronJobs(c.Namespace).Patch(context.TODO(), jobName, types.MergePatchType, patchData, metav1.PatchOptions{})
+				if err != nil {
+					return fmt.Errorf("could not remove kube2iam annotation from logical backup job %q job template: %v", jobName, err)
+				}
 			}
 		}
 		c.LogicalBackupJob = desiredJob

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -1793,7 +1793,9 @@ func (c *Cluster) syncLogicalBackupJob() error {
 				return fmt.Errorf("could not patch annotations of the logical backup job %q: %v", jobName, err)
 			}
 		}
-		if _, ok := job.Annotations[constants.KubeIAmAnnotation]; ok {
+		_, kubeIamInCronJob := job.Annotations[constants.KubeIAmAnnotation]
+		_, kubeIamInTemplate := job.Spec.JobTemplate.Annotations[constants.KubeIAmAnnotation]
+		if kubeIamInCronJob || kubeIamInTemplate {
 			if _, exists := desiredJob.Annotations[constants.KubeIAmAnnotation]; !exists {
 				patchData, err := json.Marshal(map[string]interface{}{
 					"metadata": map[string]interface{}{

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -1793,6 +1793,28 @@ func (c *Cluster) syncLogicalBackupJob() error {
 				return fmt.Errorf("could not patch annotations of the logical backup job %q: %v", jobName, err)
 			}
 		}
+
+		if c.OpConfig.KubeIAMRole == "" {
+			patch, err := json.Marshal(map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]*string{constants.KubeIAmAnnotation: nil},
+				},
+				"spec": map[string]interface{}{
+					"jobTemplate": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"annotations": map[string]*string{constants.KubeIAmAnnotation: nil},
+						},
+					},
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("could not marshal kube2iam annotation removal patch for logical backup job %q: %v", jobName, err)
+			}
+			_, err = c.KubeClient.CronJobs(c.Namespace).Patch(context.TODO(), jobName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+			if err != nil {
+				return fmt.Errorf("could not remove kube2iam annotation from logical backup job %q: %v", jobName, err)
+			}
+		}
 		c.LogicalBackupJob = desiredJob
 		return nil
 	}


### PR DESCRIPTION
clean the kube2iam annotations when the role is empty from the cronjob and job template.

This is a follow up on https://github.com/zalando/postgres-operator/pull/3128 to clean up the annotations for kube2iam when not role is passed (or empty).
During the migration we noticed the `spilo-logical-backup` cronjob and the job template were still with the annotation, this creates confusion.

This PR only deletes the `KubeIAmAnnotation` to reduce the risk of deleting any other annotation created in another place/time. If preferred I can delete all annotations not present when generating the cronjob