### PR TITLE
Pass CLONE_AWS_REGION and STANDBY_AWS_REGION when IRSA is configured

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2226,6 +2226,7 @@ func (c *Cluster) generateCloneEnvironment(description *acidv1.CloneDescription)
 	if c.OpConfig.IRSARoleARN != "" {
 		result = append(result, v1.EnvVar{Name: "CLONE_AWS_ROLE_ARN", Value: c.OpConfig.IRSARoleARN})
 		result = append(result, v1.EnvVar{Name: "CLONE_AWS_WEB_IDENTITY_TOKEN_FILE", Value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"})
+		result = append(result, v1.EnvVar{Name: "CLONE_AWS_REGION", Value: c.OpConfig.AWSRegion})
 	}
 
 	return result
@@ -2276,6 +2277,7 @@ func (c *Cluster) generateStandbyEnvironment(description *acidv1.StandbyDescript
 	if c.OpConfig.IRSARoleARN != "" {
 		result = append(result, v1.EnvVar{Name: "STANDBY_AWS_ROLE_ARN", Value: c.OpConfig.IRSARoleARN})
 		result = append(result, v1.EnvVar{Name: "STANDBY_AWS_WEB_IDENTITY_TOKEN_FILE", Value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"})
+		result = append(result, v1.EnvVar{Name: "STANDBY_AWS_REGION", Value: c.OpConfig.AWSRegion})
 	}
 
 	return result


### PR DESCRIPTION
Description:
When irsa_role_arn is set, the operator already injects CLONE_AWS_ROLE_ARN and CLONE_AWS_WEB_IDENTITY_TOKEN_FILE for clone clusters, and the equivalent vars for standby. However, CLONE_AWS_REGION and STANDBY_AWS_REGION were missing.

Without the region, spilo's configure_spilo.py falls back to reading it from IMDS (169.254.169.254). On clusters where IRSA is used and the IMDS hop limit is set to 1 (pods cannot reach IMDS), this fallback returns an empty or malformed value, causing wal-g to construct a broken STS endpoint (e.g. sts.loca.amazonaws.com) and fail to authenticate.

This change adds CLONE_AWS_REGION and STANDBY_AWS_REGION alongside the other IRSA env vars, using c.OpConfig.AWSRegion which defaults to eu-central-1 and can be overridden via the operator configmap.

NOTE: This PR was done with the help of AI agents