### PR TITLE
add CLONE/STANDBY_AWS_STS_REGIONAL_ENDPOINTS when IRSA is configured

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2224,9 +2224,11 @@ func (c *Cluster) generateCloneEnvironment(description *acidv1.CloneDescription)
 	}
 
 	if c.OpConfig.IRSARoleARN != "" {
+		result = append(result, v1.EnvVar{Name: "CLONE_AWS_STS_REGIONAL_ENDPOINTS", Value: "regional"})
 		result = append(result, v1.EnvVar{Name: "CLONE_AWS_ROLE_ARN", Value: c.OpConfig.IRSARoleARN})
 		result = append(result, v1.EnvVar{Name: "CLONE_AWS_WEB_IDENTITY_TOKEN_FILE", Value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"})
 		result = append(result, v1.EnvVar{Name: "CLONE_AWS_REGION", Value: c.OpConfig.AWSRegion})
+		result = append(result, v1.EnvVar{Name: "STANDBY_AWS_STS_REGIONAL_ENDPOINTS", Value: "regional"})
 	}
 
 	return result


### PR DESCRIPTION
## Description

Follows up on #3180.

When `irsa_role_arn` is set, the operator injects IRSA-related env vars for clone and standby clusters. However, `AWS_STS_REGIONAL_ENDPOINTS` was missing. Without it, WAL-G may fall back to a global STS endpoint or construct a broken one, causing credential retrieval to fail.

This change adds `CLONE_AWS_STS_REGIONAL_ENDPOINTS` and `STANDBY_AWS_STS_REGIONAL_ENDPOINTS` with value `regional`, consistent with how the other IRSA vars are hardcoded.

NOTE: PR created with the help of AI agents