### PR TITLE
Set SPILO_PROVIDER=aws when using IRSA

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -1101,6 +1101,10 @@ func (c *Cluster) generateSpiloPodEnvVars(
 		opConfigEnvVars = append(opConfigEnvVars, v1.EnvVar{Name: "LOG_BUCKET_SCOPE_PREFIX", Value: ""})
 	}
 
+	if c.OpConfig.IRSARoleARN != "" {
+		opConfigEnvVars = append(opConfigEnvVars, v1.EnvVar{Name: "SPILO_PROVIDER", Value: "aws"})
+	}
+
 	envVars = appendEnvVars(envVars, opConfigEnvVars...)
 
 	return envVars, nil


### PR DESCRIPTION
When IRSA is configured, spilo attempts to detect the provider by probing the EC2 metadata API (169.254.169.254). When access to that endpoint is restricted, this results in a misleading "assuming local Docker setup" log line, even though the cluster is operating correctly.

Since IRSA is AWS-only, explicitly setting SPILO_PROVIDER=aws skips the probe and makes the provider explicit.